### PR TITLE
YTI-1067 Use MultilingualDefinitionList in terminology page

### DIFF
--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -19,6 +19,7 @@ export const FilterWrapper = styled.div`
   border: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   height: max-content;
   width: 350px;
+  margin-bottom: 80px;
 
   > div, hr {
     padding-left: 20px;

--- a/src/common/components/info-dropdown/info-basic.styles.tsx
+++ b/src/common/components/info-dropdown/info-basic.styles.tsx
@@ -7,11 +7,6 @@ export const InfoBasicWrapper = styled.div`
   max-width: 695px;
 `;
 
-export const InfoBasicLanguageWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-`;
-
 export const InfoBasicExtraWrapper = styled.div`
   margin-top: 20px;
 `;

--- a/src/common/components/info-dropdown/info-basic.tsx
+++ b/src/common/components/info-dropdown/info-basic.tsx
@@ -1,62 +1,22 @@
-import { useTranslation } from 'react-i18next';
-import { InfoBasicLanguageWrapper, InfoBasicWrapper } from './info-basic.styles';
+import { InfoBasicWrapper } from './info-basic.styles';
 import { Text } from 'suomifi-ui-components';
-import { Property } from '../../interfaces/termed-data-types.interface';
 
 interface InfoBasicProps {
-  data: Property[] | string;
+  data?: string;
   title: string;
   extra?: React.ReactNode;
 }
 
 export default function InfoBasic({ data, title, extra }: InfoBasicProps) {
-  const { t, i18n } = useTranslation('common');
-
-  if (typeof data === 'string') {
-    return (
-      <InfoBasicWrapper>
-        <Text variant='bold'>{title}</Text>
-        <Text>{data}</Text>
-        {extra}
-      </InfoBasicWrapper>
-    );
-  } else if (data.length > 0 && 'lang' in data[0]) {
-    if (data[0].lang !== '') {
-      return (
-        <InfoBasicWrapper>
-          <Text variant='bold'>{title}</Text>
-          <InfoBasicLanguageWrapper>
-            <Text key={`basic-info-${title}`}>
-              {data.find(d => d.lang === i18n.language)?.value}
-            </Text>
-          </InfoBasicLanguageWrapper>
-          {extra}
-        </InfoBasicWrapper>
-      );
-    } else {
-      return (
-        <InfoBasicWrapper>
-          <Text variant='bold'>{title}</Text>
-          <InfoBasicLanguageWrapper>
-            {data.map((d, idx: number) => {
-              return (
-                <Text key={`basic-info-${title}-${idx}`}>
-                  {
-                    idx !== 0
-                      ?
-                      <>, {t(`vocabulary-info-${d.value}`)} {d.value.toUpperCase()}</>
-                      :
-                      <>{t(`vocabulary-info-${d.value}`)} {d.value.toUpperCase()}</>
-                  }
-                </Text>
-              );
-            })}
-          </InfoBasicLanguageWrapper>
-          {extra}
-        </InfoBasicWrapper>
-      );
-    }
+  if (!data) {
+    return null;
   }
 
-  return <></>;
+  return (
+    <InfoBasicWrapper>
+      <Text variant="bold">{title}</Text>
+      <Text>{data}</Text>
+      {extra}
+    </InfoBasicWrapper>
+  );
 }

--- a/src/common/components/info-dropdown/info-block.styles.tsx
+++ b/src/common/components/info-dropdown/info-block.styles.tsx
@@ -1,34 +1,6 @@
 import styled from 'styled-components';
 import { Text } from 'suomifi-ui-components';
 
-export const InfoBlockData = styled.div`
-  border-left: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
-  border-right: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
-  border-top: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
-
-  > * {
-    border-bottom: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
-    padding-bottom: 8px;
-    padding-left: 15px;
-    padding-top: 6px;
-  }
-
-  div:nth-child(even) {
-    background-color:  ${(props) => props.theme.suomifi.colors.depthLight2};
-  }
-`;
-
-export const InfoBlockDescription = styled(Text)`
-  font-size: 16px;
-`;
-
-export const InfoBlockLanguage = styled(Text)`
-  display: inline-block;
-  font-size: 16px;
-  font-weight: 600;
-  width: 47px;
-`;
-
 export const InfoBlockTitle = styled(Text)`
   font-size: 18px;
   font-weight: 600;

--- a/src/common/components/info-dropdown/info-block.tsx
+++ b/src/common/components/info-dropdown/info-block.tsx
@@ -1,21 +1,18 @@
 import { Property } from '../../interfaces/termed-data-types.interface';
+import MultilingualDefinitionList from '../multilingual-definition-list/multilingual-definition-list';
 import {
-  InfoBlockData,
-  InfoBlockDescription,
-  InfoBlockLanguage,
   InfoBlockTitle,
   InfoBlockWrapper
 } from './info-block.styles';
 
 interface InfoBlockProps {
-  data: Property | Property[];
+  data?: Property[];
   title: string;
 }
 
 export default function InfoBlock({ data, title }: InfoBlockProps) {
-
   if (!data) {
-    return <></>;
+    return null;
   }
 
   return (
@@ -23,33 +20,9 @@ export default function InfoBlock({ data, title }: InfoBlockProps) {
       <InfoBlockTitle>
         {title}
       </InfoBlockTitle>
-      <InfoBlockData>
-        {
-          Array.isArray(data)
-            ?
-            data.map((d, idx: number) => {
-              return (
-                <div key={`info-block-${title}-${idx}`}>
-                  <InfoBlockLanguage>
-                    {d.lang.toUpperCase()}
-                  </InfoBlockLanguage>
-                  <InfoBlockDescription>
-                    {d.value}
-                  </InfoBlockDescription>
-                </div>
-              );
-            })
-            :
-            <div>
-              <InfoBlockLanguage>
-                {data.lang.toUpperCase()}
-              </InfoBlockLanguage>
-              <InfoBlockDescription>
-                {data.value}
-              </InfoBlockDescription>
-            </div>
-        }
-      </InfoBlockData>
+      <MultilingualDefinitionList
+        items={data.map(({ lang, value }) => ({ language: lang, content: value }))}
+      />
     </InfoBlockWrapper>
   );
 }

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -6,6 +6,7 @@ import InfoBlock from './info-block';
 import InfoBasic from './info-basic';
 import { VocabularyInfoDTO } from '../../interfaces/vocabulary.interface';
 import { InfoBasicExtraWrapper } from './info-basic.styles';
+import { getPropertyValue } from '../property-value/get-property-value';
 
 interface InfoExpanderProps {
   data?: VocabularyInfoDTO;
@@ -15,17 +16,8 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
   const { t } = useTranslation('common');
 
   if (!data) {
-    return <></>;
+    return null;
   }
-
-  const title = data.properties.prefLabel ?? [];
-  const description = data.properties.description?.[0] ?? [];
-  const vocabularyLanguages = data.properties.language ?? '';
-  const createdDate = FormatISODate(data.createdDate) ?? '01.01.1970, 00.00';
-  const lastModifiedDate = FormatISODate(data.lastModifiedDate) ?? '01.01.1970, 00.00';
-  const uri = data.uri ?? '';
-  const contributor = data.references.contributor?.[0].properties.prefLabel ?? '';
-  const informationDomains = data.references.inGroup?.[0].properties.prefLabel ?? '';
 
   return (
     <InfoExpanderWrapper>
@@ -33,11 +25,32 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         {t('vocabulary-info-terminology')}
       </ExpanderTitleButton>
       <ExpanderContent>
-        <InfoBlock title={t('vocabulary-info-name')} data={title} />
-        <InfoBlock title={t('vocabulary-info-description')} data={description} />
-        <InfoBasic title={t('vocabulary-info-information-domain')} data={informationDomains} />
-        <InfoBasic title={t('vocabulary-info-languages')} data={vocabularyLanguages} />
-        <InfoBasic title={t('vocabulary-info-vocabulary-type')} data={t('vocabulary-info-terminological-dictionary')} />
+        <InfoBlock
+          title={t('vocabulary-info-name')}
+          data={data.properties.prefLabel}
+        />
+        <InfoBlock
+          title={t('vocabulary-info-description')}
+          data={data.properties.description}
+        />
+        <InfoBasic
+          title={t('vocabulary-info-information-domain')}
+          data={getPropertyValue({
+            property: data.references.inGroup?.[0]?.properties.prefLabel,
+          })}
+        />
+        <InfoBasic
+          title={t('vocabulary-info-languages')}
+          data={getPropertyValue({
+            property: data.properties.language,
+            delimiter: ', ',
+            valueAccessor: ({ value }) => `${t(`vocabulary-info-${value}`)} ${value.toUpperCase()}`,
+          })}
+        />
+        <InfoBasic
+          title={t('vocabulary-info-vocabulary-type')}
+          data={t('vocabulary-info-terminological-dictionary')}
+        />
 
         <InfoExpanderDivider />
 
@@ -61,10 +74,24 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
 
         <InfoExpanderDivider />
 
-        <InfoBasic title={t('vocabulary-info-organization')} data={contributor} />
-        <InfoBasic title={t('vocabulary-info-created-at')} data={createdDate} />
-        <InfoBasic title={t('vocabulary-info-modified-at')} data={lastModifiedDate} />
-        <InfoBasic title={'URI'} data={uri} />
+        <InfoBasic
+          title={t('vocabulary-info-organization')}
+          data={getPropertyValue({
+            property: data.references.contributor?.[1]?.properties.prefLabel,
+          })}
+        />
+        <InfoBasic
+          title={t('vocabulary-info-created-at')}
+          data={FormatISODate(data.createdDate)}
+        />
+        <InfoBasic
+          title={t('vocabulary-info-modified-at')}
+          data={FormatISODate(data.lastModifiedDate)}
+        />
+        <InfoBasic
+          title={'URI'}
+          data={data.uri}
+        />
       </ExpanderContent>
     </InfoExpanderWrapper>
   );

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -77,7 +77,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         <InfoBasic
           title={t('vocabulary-info-organization')}
           data={getPropertyValue({
-            property: data.references.contributor?.[1]?.properties.prefLabel,
+            property: data.references.contributor?.[0]?.properties.prefLabel,
           })}
         />
         <InfoBasic

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -13,7 +13,7 @@ interface InfoExpanderProps {
 }
 
 export default function InfoExpander({ data }: InfoExpanderProps) {
-  const { t } = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
 
   if (!data) {
     return null;
@@ -37,6 +37,8 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           title={t('vocabulary-info-information-domain')}
           data={getPropertyValue({
             property: data.references.inGroup?.[0]?.properties.prefLabel,
+            language: i18n.language,
+            fallbackLanguage: 'fi',
           })}
         />
         <InfoBasic
@@ -78,6 +80,8 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           title={t('vocabulary-info-organization')}
           data={getPropertyValue({
             property: data.references.contributor?.[0]?.properties.prefLabel,
+            language: i18n.language,
+            fallbackLanguage: 'fi',
           })}
         />
         <InfoBasic

--- a/src/common/components/multilingual-definition-list/multilingual-definition-list.styles.tsx
+++ b/src/common/components/multilingual-definition-list/multilingual-definition-list.styles.tsx
@@ -4,7 +4,6 @@ export const MultilingualDefinitionListWrapper = styled.ul`
   list-style: none;
   padding: 0;
   margin: 0;
-  margin-top: 12px;
   border: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   font-size: 16px;
 `;

--- a/src/common/components/property-value/get-property-value.ts
+++ b/src/common/components/property-value/get-property-value.ts
@@ -1,0 +1,37 @@
+import { Property } from '../../interfaces/termed-data-types.interface';
+
+export interface GetPropertyValueParams {
+  property?: Property[];
+  valueAccessor?: (property: Property) => string;
+  language?: string;
+  fallbackLanguage?: string;
+  delimiter?: string | false;
+}
+
+export function getPropertyValue({
+  property,
+  valueAccessor = ({ value }) => value,
+  language = '',
+  fallbackLanguage = '',
+  delimiter = false
+}: GetPropertyValueParams): string | undefined {
+  const matchingProperties =
+    getMatchingProperties(property ?? [], language) ??
+    getMatchingProperties(property ?? [], fallbackLanguage) ??
+    getMatchingProperties(property ?? [], '') ??
+    [];
+
+  if (delimiter !== false) {
+    return matchingProperties.map(valueAccessor).join(delimiter);
+  } else {
+    return matchingProperties[0] ? valueAccessor(matchingProperties[0]) : '';
+  }
+}
+
+function getMatchingProperties(properties: Property[], language: string) {
+  const matchingProperties = properties?.filter(({ lang }) => lang === language);
+
+  if (matchingProperties.length) {
+    return matchingProperties;
+  }
+}

--- a/src/common/components/property-value/index.tsx
+++ b/src/common/components/property-value/index.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'next-i18next';
 import { Property } from '../../interfaces/termed-data-types.interface';
+import { getPropertyValue } from './get-property-value';
 
 export interface PropertyValueProps {
   property?: Property[];
+  valueAccessor?: (property: Property) => string;
   fallbackLanguage?: string;
-}
-
-export function getPropertyValue(
-  property: Property[] | undefined,
-  locale: string = '',
-  fallbackLanguage: string = ''
-): string | undefined {
-  return [
-    ...property?.filter(({ lang }) => lang === locale) ?? [],
-    ...property?.filter(({ lang }) => lang === fallbackLanguage) ?? [],
-    ...property?.filter(({ lang }) => !lang) ?? [],
-  ][0]?.value;
+  delimiter?: string | false;
 }
 
 /**
@@ -36,15 +27,26 @@ export function getPropertyValue(
  *
  * If current language is English, this renders as 'This is a test.'.
  * If current locale is not English, fallback language is used, and this renders as 'This is a test'.
+ *
+ * <PropertyValue property={[{ lang: '', value: 'Value 1' }, { lang: '', value: 'Value 2' }]} delimiter=", " />
+ *
+ * This renders always as 'Value 1, Value 2'.
  */
-export default function PropertyValue({ property, fallbackLanguage }: PropertyValueProps) {
+export default function PropertyValue({
+  property,
+  valueAccessor,
+  fallbackLanguage,
+  delimiter = false
+}: PropertyValueProps) {
   const { i18n } = useTranslation('common');
 
-  const value = getPropertyValue(property, i18n.language, fallbackLanguage);
-
-  if (! value) {
-    return null;
-  }
+  const value = getPropertyValue({
+    property,
+    valueAccessor,
+    language: i18n.language,
+    fallbackLanguage,
+    delimiter
+  });
 
   return (
     <>{value}</>

--- a/src/common/components/property-value/property-value.test.tsx
+++ b/src/common/components/property-value/property-value.test.tsx
@@ -54,7 +54,6 @@ describe('PropertyValue', () => {
 
     expect(screen.queryByText('Value (fi)')).toBeTruthy();
     expect(screen.queryByText('Value (sv)')).toBeFalsy();
-
   });
 
   test('should not render value in wrong language', () => {
@@ -70,5 +69,37 @@ describe('PropertyValue', () => {
     );
 
     expect(screen.queryByText('Value (sv)')).toBeFalsy();
+  });
+
+  test('should join found values when delimiter is given', () => {
+    mockedUseTranslation.mockReturnValue({ i18n: { language: 'en' }});
+
+    render(
+      <PropertyValue
+        property={[
+          { lang: 'en', value: 'Value 1', regex: '' },
+          { lang: 'en', value: 'Value 2', regex: '' },
+        ]}
+        delimiter=", "
+      />
+    );
+
+    expect(screen.queryByText('Value 1, Value 2')).toBeTruthy();
+  });
+
+  test('should join found values when delimiter is empty string', () => {
+    mockedUseTranslation.mockReturnValue({ i18n: { language: 'en' }});
+
+    render(
+      <PropertyValue
+        property={[
+          { lang: 'en', value: 'Value 1', regex: '' },
+          { lang: 'en', value: 'Value 2', regex: '' },
+        ]}
+        delimiter=""
+      />
+    );
+
+    expect(screen.queryByText('Value 1Value 2')).toBeTruthy();
   });
 });

--- a/src/common/utils/format-iso-date.ts
+++ b/src/common/utils/format-iso-date.ts
@@ -1,10 +1,8 @@
-export default function FormatISODate(ISODate: any) {
+export default function FormatISODate(ISODate: any): string | undefined {
   if (ISODate) {
     let date = ISODate.split('T')[0].split('-').reverse().join('.');
     let hour = ISODate.split('T')[1].split('.')[0].split(':').slice(0, 2).join('.');
 
     return date + ', ' + hour;
   }
-
-  return '';
 }

--- a/src/modules/concept/concept-sidebar.tsx
+++ b/src/modules/concept/concept-sidebar.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import React from 'react';
-import { getPropertyValue } from '../../common/components/property-value';
+import { getPropertyValue } from '../../common/components/property-value/get-property-value';
 import {
   Sidebar,
   SidebarDivider,
@@ -84,8 +84,8 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
         heading={t('sidebar-section-heading-related-match')}
         items={concept?.references.relatedMatch}
         href={({ properties }) => {
-          const terminologyId = getPropertyValue(properties.targetGraph);
-          const conceptId = getPropertyValue(properties.targetId);
+          const terminologyId = getPropertyValue({ property: properties.targetGraph });
+          const conceptId = getPropertyValue({ property: properties.targetId });
           return `/terminology/${terminologyId}/concept/${conceptId}`;
         }}
         propertyAccessor={({ properties }) => properties?.prefLabel}
@@ -95,8 +95,8 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
         heading={t('sidebar-section-heading-exact-match')}
         items={concept?.references.exactMatch}
         href={({ properties }) => {
-          const terminologyId = getPropertyValue(properties.targetGraph);
-          const conceptId = getPropertyValue(properties.targetId);
+          const terminologyId = getPropertyValue({ property: properties.targetGraph });
+          const conceptId = getPropertyValue({ property: properties.targetId });
           return `/terminology/${terminologyId}/concept/${conceptId}`;
         }}
         propertyAccessor={({ properties }) => properties?.prefLabel}
@@ -106,8 +106,8 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
         heading={t('sidebar-section-heading-close-match')}
         items={concept?.references.closeMatch}
         href={({ properties }) => {
-          const terminologyId = getPropertyValue(properties.targetGraph);
-          const conceptId = getPropertyValue(properties.targetId);
+          const terminologyId = getPropertyValue({ property: properties.targetGraph });
+          const conceptId = getPropertyValue({ property: properties.targetId });
           return `/terminology/${terminologyId}/concept/${conceptId}`;
         }}
         propertyAccessor={({ properties }) => properties?.prefLabel}

--- a/src/modules/concept/concept-sidebar.tsx
+++ b/src/modules/concept/concept-sidebar.tsx
@@ -96,7 +96,7 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
         items={concept?.references.exactMatch}
         href={({ properties }) => {
           const terminologyId = getPropertyValue({ property: properties.targetGraph });
-          const conceptId = getPropertyValue({ property: properties.targetId });
+          const conceptId = getPropertyValue({ property: properties.targetId });
           return `/terminology/${terminologyId}/concept/${conceptId}`;
         }}
         propertyAccessor={({ properties }) => properties?.prefLabel}

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -16,7 +16,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
   const dispatch = useStoreDispatch();
   useEffect(() => {
     dispatch(initializeVocabularyFilter());
-  }, []);
+  }, [dispatch]);
 
   const filter: VocabularyState['filter'] = useSelector(selectVocabularyFilter());
   const { data: concepts } = useGetConceptResultQuery(id);


### PR DESCRIPTION
Refactor terminology page so that it uses MultilingualDefinitionList and PropertyValue components where possible.