### PR TITLE
Yti 1615 filter mobile version

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -79,5 +79,6 @@
   "pagination-page": "Page",
   "impersonate-user": "Impersonate user",
   "navigation-open": "Open navigation",
-  "navigation-close": "Close navigation"
+  "navigation-close": "Close navigation",
+  "filter-with-current": "(en) kpl seuraavilla rajauksilla"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -62,7 +62,7 @@
   "vocabulary-info-vocabulary-export": "(en) Lataa sanasto",
   "vocabulary-info-vocabulary-export-description": "(en) Voit tarkastella sanaston, käsitevalikoiman ja käsitteen, sekä termien tietoja Excel-tiedostomuodoissa.",
   "vocabulary-info-concept": "Concept",
-  "vocabulary-filter-filter-list": "(en) RAJAA LISTAA",
+  "vocabulary-filter-filter-list": "(en) Rajaa listaa",
   "vocabulary-filter-remove-all": "(en) Poista kaikki rajaukset",
   "vocabulary-filter-show-only": "(en) Näytä vain",
   "vocabulary-filter-show-concept-states": "(en) Näytä käsitteiden tilat",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -80,5 +80,6 @@
   "pagination-page": "Sivu",
   "impersonate-user": "Esiinny käyttäjänä",
   "navigation-open": "Avaa navigaatio",
-  "navigation-close": "Sulje navigaatio"
+  "navigation-close": "Sulje navigaatio",
+  "filter-with-current": "kpl seuraavilla rajauksilla"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -63,7 +63,7 @@
   "vocabulary-info-vocabulary-export": "Lataa sanasto",
   "vocabulary-info-vocabulary-export-description": "Voit tarkastella sanaston, käsitevalikoiman ja käsitteen, sekä termien tietoja Excel-tiedostomuodoissa.",
   "vocabulary-info-concept": "Käsite",
-  "vocabulary-filter-filter-list": "RAJAA LISTAA",
+  "vocabulary-filter-filter-list": "Rajaa listaa",
   "vocabulary-filter-remove-all": "Poista kaikki rajaukset",
   "vocabulary-filter-show-only": "Näytä vain",
   "vocabulary-filter-show-concept-states": "Näytä käsitteiden tilat",

--- a/src/common/components/filter/checkbox-area.tsx
+++ b/src/common/components/filter/checkbox-area.tsx
@@ -22,6 +22,7 @@ interface CheckboxProps {
 export default function CheckboxArea({ data, filter, setFilter, title, type, isModal }: CheckboxProps) {
   const { t } = useTranslation('common');
   const dispatch = useStoreDispatch();
+  const variant = isModal ? 'large' : 'small';
 
   const handleCheckbox = (s: string | InfoDProp) => {
     let retVal: CheckboxProps['filter'] | null = null;
@@ -61,28 +62,28 @@ export default function CheckboxArea({ data, filter, setFilter, title, type, isM
         <FilterCheckbox
           onClick={() => handleCheckbox('VALID')}
           checked={filter.status?.['VALID'] as boolean}
-          variant={isModal ? 'large' : 'small'}
+          variant={variant}
         >
           {t('VALID')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('DRAFT')}
           checked={filter.status?.['DRAFT'] as boolean}
-          variant={isModal ? 'large' : 'small'}
+          variant={variant}
         >
           {t('DRAFT')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('RETIRED')}
           checked={filter.status?.['RETIRED'] as boolean}
-          variant={isModal ? 'large' : 'small'}
+          variant={variant}
         >
           {t('RETIRED')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('SUPERSEDED')}
           checked={filter.status?.['SUPERSEDED'] as boolean}
-          variant={isModal ? 'large' : 'small'}
+          variant={variant}
         >
           {t('SUPERSEDED')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
@@ -111,7 +112,7 @@ export default function CheckboxArea({ data, filter, setFilter, title, type, isM
               checked={
                 filter.infoDomains?.filter((infoD: InfoDProp) => infoD.id === d.id).length > 0
               }
-              variant={isModal ? 'large' : 'small'}
+              variant={variant}
             >
               {d.value} (n {t('vocabulary-filter-items')})
             </FilterCheckbox>

--- a/src/common/components/filter/checkbox-area.tsx
+++ b/src/common/components/filter/checkbox-area.tsx
@@ -16,9 +16,10 @@ interface CheckboxProps {
   setFilter: (x: any) => AppThunk;
   title: string;
   type?: string;
+  isModal?: boolean;
 }
 
-export default function CheckboxArea({ data, filter, setFilter, title, type }: CheckboxProps) {
+export default function CheckboxArea({ data, filter, setFilter, title, type, isModal }: CheckboxProps) {
   const { t } = useTranslation('common');
   const dispatch = useStoreDispatch();
 
@@ -60,24 +61,28 @@ export default function CheckboxArea({ data, filter, setFilter, title, type }: C
         <FilterCheckbox
           onClick={() => handleCheckbox('VALID')}
           checked={filter.status?.['VALID'] as boolean}
+          variant={isModal ? 'large' : 'small'}
         >
           {t('VALID')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('DRAFT')}
           checked={filter.status?.['DRAFT'] as boolean}
+          variant={isModal ? 'large' : 'small'}
         >
           {t('DRAFT')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('RETIRED')}
           checked={filter.status?.['RETIRED'] as boolean}
+          variant={isModal ? 'large' : 'small'}
         >
           {t('RETIRED')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
         <FilterCheckbox
           onClick={() => handleCheckbox('SUPERSEDED')}
           checked={filter.status?.['SUPERSEDED'] as boolean}
+          variant={isModal ? 'large' : 'small'}
         >
           {t('SUPERSEDED')} (n {t('vocabulary-filter-items')})
         </FilterCheckbox>
@@ -106,6 +111,7 @@ export default function CheckboxArea({ data, filter, setFilter, title, type }: C
               checked={
                 filter.infoDomains?.filter((infoD: InfoDProp) => infoD.id === d.id).length > 0
               }
+              variant={isModal ? 'large' : 'small'}
             >
               {d.value} (n {t('vocabulary-filter-items')})
             </FilterCheckbox>

--- a/src/common/components/filter/dropdown-area.tsx
+++ b/src/common/components/filter/dropdown-area.tsx
@@ -1,4 +1,4 @@
-import { DropdownItem } from 'suomifi-ui-components';
+import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 import { AppThunk, useStoreDispatch } from '../../../store';
 import { SearchState } from '../terminology-search/terminology-search-slice';
 import { DropdownPlaceholder, DropdownWrapper } from './filter.styles';
@@ -32,8 +32,8 @@ export default function DropdownArea({
 
   // Returns dropdown with given data values.
   return (
-    <div>
-      <DropdownWrapper
+    <DropdownWrapper>
+      <Dropdown
         labelText={title}
         visualPlaceholder={
           <DropdownPlaceholder>
@@ -42,7 +42,6 @@ export default function DropdownArea({
         }
         value={filter.showByOrg}
         onChange={(value) => handleChange(value)}
-        isModal={isModal}
       >
         {data.map((value: string, idx: number) => {
           return (
@@ -54,8 +53,8 @@ export default function DropdownArea({
             </DropdownItem>
           );
         })}
-      </DropdownWrapper>
-    </div>
+      </Dropdown>
+    </DropdownWrapper>
   );
 
 }

--- a/src/common/components/filter/dropdown-area.tsx
+++ b/src/common/components/filter/dropdown-area.tsx
@@ -1,7 +1,7 @@
-import { Dropdown, DropdownItem } from 'suomifi-ui-components';
+import { DropdownItem } from 'suomifi-ui-components';
 import { AppThunk, useStoreDispatch } from '../../../store';
 import { SearchState } from '../terminology-search/terminology-search-slice';
-import { DropdownPlaceholder } from './filter.styles';
+import { DropdownPlaceholder, DropdownWrapper } from './filter.styles';
 
 interface DropdownProps {
   data?: string[];
@@ -9,9 +9,17 @@ interface DropdownProps {
   setFilter: (x: any) => AppThunk;
   title: string;
   visualPlaceholder?: string;
+  isModal?: boolean;
 }
 
-export default function DropdownArea({ data, filter, setFilter, title, visualPlaceholder }: DropdownProps) {
+export default function DropdownArea({
+  data,
+  filter,
+  isModal = false,
+  setFilter,
+  title,
+  visualPlaceholder
+}: DropdownProps) {
   const dispatch = useStoreDispatch();
 
   const handleChange = (value: string) => {
@@ -25,7 +33,7 @@ export default function DropdownArea({ data, filter, setFilter, title, visualPla
   // Returns dropdown with given data values.
   return (
     <div>
-      <Dropdown
+      <DropdownWrapper
         labelText={title}
         visualPlaceholder={
           <DropdownPlaceholder>
@@ -34,6 +42,7 @@ export default function DropdownArea({ data, filter, setFilter, title, visualPla
         }
         value={filter.showByOrg}
         onChange={(value) => handleChange(value)}
+        isModal={isModal}
       >
         {data.map((value: string, idx: number) => {
           return (
@@ -45,7 +54,7 @@ export default function DropdownArea({ data, filter, setFilter, title, visualPla
             </DropdownItem>
           );
         })}
-      </Dropdown>
+      </DropdownWrapper>
     </div>
   );
 

--- a/src/common/components/filter/dropdown-area.tsx
+++ b/src/common/components/filter/dropdown-area.tsx
@@ -9,13 +9,11 @@ interface DropdownProps {
   setFilter: (x: any) => AppThunk;
   title: string;
   visualPlaceholder?: string;
-  isModal?: boolean;
 }
 
 export default function DropdownArea({
   data,
   filter,
-  isModal = false,
   setFilter,
   title,
   visualPlaceholder

--- a/src/common/components/filter/dropdown-area.tsx
+++ b/src/common/components/filter/dropdown-area.tsx
@@ -32,7 +32,7 @@ export default function DropdownArea({ data, filter, setFilter, title, visualPla
             {visualPlaceholder}
           </DropdownPlaceholder>
         }
-        value={filter.showByOrg || ''}
+        value={filter.showByOrg}
         onChange={(value) => handleChange(value)}
       >
         {data.map((value: string, idx: number) => {

--- a/src/common/components/filter/filter-props.tsx
+++ b/src/common/components/filter/filter-props.tsx
@@ -1,0 +1,3 @@
+export interface FilterWrapperProps {
+  isModal?: boolean;
+}

--- a/src/common/components/filter/filter-props.tsx
+++ b/src/common/components/filter/filter-props.tsx
@@ -1,3 +1,3 @@
 export interface FilterWrapperProps {
-  isModal?: boolean;
+  isModal: boolean;
 }

--- a/src/common/components/filter/filter-props.tsx
+++ b/src/common/components/filter/filter-props.tsx
@@ -1,3 +1,3 @@
-export interface FilterWrapperProps {
+export interface FilterStyledProps {
   isModal: boolean;
 }

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -56,6 +56,7 @@ export const HeaderButton = styled(Button)`
   font-size: 16px;
   font-weight: 400;
   padding: 0px 5px 0px;
+
   :hover {
     background: none;
   }

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -1,13 +1,21 @@
 import styled from 'styled-components';
-import { Button, Checkbox, Dropdown, Icon, RadioButton, SearchInput } from 'suomifi-ui-components';
+import { Button, Checkbox, Icon, RadioButton, SearchInput } from 'suomifi-ui-components';
 import { FilterStyledProps } from './filter-props';
 
 export const DropdownPlaceholder = styled.i`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
 `;
 
-export const DropdownWrapper = styled(Dropdown)<FilterStyledProps>`
-  min-width: ${(props) => props.isModal ? '100%' : 'inherit'}
+export const DropdownWrapper = styled.div`
+  min-width: inherit;
+
+  > span {
+    min-width: 100%;
+
+    > div > div > * {
+      width: calc(100% - 47px);
+    }
+  }
 `;
 
 export const FilterCheckbox = styled(Checkbox)`

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -1,9 +1,13 @@
 import styled from 'styled-components';
-import { Button, Checkbox, Icon, RadioButton } from 'suomifi-ui-components';
-import { FilterWrapperProps } from './filter-props';
+import { Button, Checkbox, Dropdown, Icon, RadioButton, SearchInput } from 'suomifi-ui-components';
+import { FilterStyledProps } from './filter-props';
 
 export const DropdownPlaceholder = styled.i`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
+`;
+
+export const DropdownWrapper = styled(Dropdown)<FilterStyledProps>`
+  min-width: ${(props) => props.isModal ? '100%' : 'inherit'}
 `;
 
 export const FilterCheckbox = styled(Checkbox)`
@@ -15,7 +19,7 @@ export const FilterRadioButton = styled(RadioButton)`
   font-size: 16px;
 `;
 
-export const FilterWrapper = styled.div<FilterWrapperProps>`
+export const FilterWrapper = styled.div<FilterStyledProps>`
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   border: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   height: max-content;
@@ -71,4 +75,8 @@ export const RemoveWrapper = styled.div`
     text-decoration: underline;
     text-decoration-color: ${(props) => props.theme.suomifi.colors.highlightBase};
   }
+`;
+
+export const SearchInputWrapper = styled(SearchInput)<FilterStyledProps>`
+  min-width: ${(props) => props.isModal ? '100%' : 'inherit' }
 `;

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Checkbox, Icon, RadioButton } from 'suomifi-ui-components';
+import { Button, Checkbox, Icon, RadioButton } from 'suomifi-ui-components';
 import { FilterWrapperProps } from './filter-props';
 
 export const DropdownPlaceholder = styled.i`
@@ -36,13 +36,16 @@ export const Header = styled.div`
   font-size: 18px;
   font-weight: 600;
   justify-content: space-between;
-  padding: 25px 20px 30px;
+  padding: 25px 20px 25px;
+`;
 
-  span {
-    font-weight: 400;
-    display: flex;
-    align-items: center;
-    gap: 6px;
+export const HeaderButton = styled(Button)`
+  background: none;
+  font-size: 16px;
+  font-weight: 400;
+  padding: 0px 5px 0px;
+  :hover {
+    background: none;
   }
 `;
 

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Checkbox, Icon, RadioButton } from 'suomifi-ui-components';
+import { FilterWrapperProps } from './filter-props';
 
 export const DropdownPlaceholder = styled.i`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
@@ -14,11 +15,11 @@ export const FilterRadioButton = styled(RadioButton)`
   font-size: 16px;
 `;
 
-export const FilterWrapper = styled.div`
+export const FilterWrapper = styled.div<FilterWrapperProps>`
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   border: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   height: max-content;
-  width: 350px;
+  width: ${(props) => props.isModal ? '100%' : '350px'};
 
   > div, hr {
     padding-left: 20px;
@@ -34,7 +35,15 @@ export const Header = styled.div`
   display: flex;
   font-size: 18px;
   font-weight: 600;
+  justify-content: space-between;
   padding: 25px 20px 30px;
+
+  span {
+    font-weight: 400;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
 `;
 
 export const Hr = styled.hr`

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -50,6 +50,11 @@ export const Header = styled.div`
   font-weight: 600;
   justify-content: space-between;
   padding: 25px 20px 25px;
+  text-transform: uppercase;
+
+  > * {
+    text-transform: uppercase;
+  }
 `;
 
 export const HeaderButton = styled(Button)`

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -109,26 +109,26 @@ export default function Filter({
   }
 
   function renderCloseButton() {
-    if (isModal) {
-      return (
-        <>
-          <Hr />
-          <div>
-            {resultCount} {t('filter-with-current')}
-          </div>
-          <div>
-            <Button
-              fullWidth
-              onClick={() => setShowModal && setShowModal(false)}
-            >
-              {t('close')}
-            </Button>
-          </div>
-        </>
-      );
-    } else {
+    if (!isModal) {
       return null;
     }
+
+    return (
+      <>
+        <Hr />
+        <div>
+          {resultCount} {t('filter-with-current')}
+        </div>
+        <div>
+          <Button
+            fullWidth
+            onClick={() => setShowModal && setShowModal(false)}
+          >
+            {t('close')}
+          </Button>
+        </div>
+      </>
+    );
   }
 
   function renderDropdownArea() {
@@ -148,7 +148,6 @@ export default function Filter({
           setFilter={setSomeFilter}
           title={t('terminology-search-filter-by-organization')}
           visualPlaceholder={t('terminology-search-filter-pick-organization')}
-          isModal={isModal}
         />
       );
     }

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import CheckboxArea from './checkbox-area';
 import RadioButtonArea from './radio-button-area';
@@ -14,6 +15,7 @@ import { initialState, SearchState } from '../terminology-search/terminology-sea
 import { AppThunk } from '../../../store';
 import { CommonInfoDTO, GroupSearchResult, OrganizationSearchResult } from '../../interfaces/terminology.interface';
 import { isEqual } from 'lodash';
+import { Button, Icon } from 'suomifi-ui-components';
 
 export interface FilterProps {
   filter: VocabularyState['filter'] | SearchState['filter'];
@@ -22,6 +24,8 @@ export interface FilterProps {
   resetSomeFilter: () => AppThunk;
   setSomeFilter: (x: any) => AppThunk;
   type: string;
+  isModal?: boolean;
+  setShowModal?: Dispatch<SetStateAction<boolean>>;
 }
 
 export default function Filter({
@@ -30,17 +34,17 @@ export default function Filter({
   organizations,
   resetSomeFilter,
   setSomeFilter,
-  type
+  type,
+  isModal,
+  setShowModal
 }: FilterProps) {
   const { t, i18n } = useTranslation('common');
 
   // Returns filter according to templates found below.
   if (type === 'vocabulary' && 'showBy' in filter) {
     return (
-      <FilterWrapper>
-        <Header>
-          {t('vocabulary-filter-filter-list')}
-        </Header>
+      <FilterWrapper isModal={isModal}>SULJE
+        {renderTitle()}
         {/* If filter has any value 'checked' Remove-component is displayed. */}
         {renderRemove()}
         {renderRadioButtonArea()}
@@ -48,14 +52,22 @@ export default function Filter({
         {renderCheckboxArea(true)}
         <Hr />
         {renderSearchInputArea()}
+        {isModal
+          ?
+          <>
+            <Hr />
+            <div>
+              <Button fullWidth>{t('close')}</Button>
+            </div>
+          </>
+          : null
+        }
       </FilterWrapper>
     );
   } else if (type === 'terminology-search' && 'showByOrg' in filter && groups) {
     return (
-      <FilterWrapper>
-        <Header>
-          {t('vocabulary-filter-filter-list')}
-        </Header>
+      <FilterWrapper isModal={isModal}>
+        {renderTitle()}
         {/* If filter has any value 'checked' Remove-component is displayed. */}
         {renderRemove()}
         {renderDropdownArea()}
@@ -65,6 +77,7 @@ export default function Filter({
         {renderCheckboxArea(true)}
         <Hr />
         {renderCheckboxArea()}
+        {renderCloseButton()}
       </FilterWrapper>
     );
   }
@@ -96,6 +109,26 @@ export default function Filter({
           type='infoDomains'
         />
       );
+    }
+  }
+
+  function renderCloseButton() {
+    if (isModal) {
+      return (
+        <>
+          <Hr />
+          <div>
+            <Button
+              fullWidth
+              onClick={() => setShowModal && setShowModal(false)}
+            >
+              {t('close')}
+            </Button>
+          </div>
+        </>
+      );
+    } else {
+      return null;
     }
   }
 
@@ -175,6 +208,25 @@ export default function Filter({
         visualPlaceholder={t('vocabulary-filter-visual-placeholder')}
       />
     );
+  }
+
+  function renderTitle() {
+    if (isModal) {
+      return (
+        <Header>
+          {t('vocabulary-filter-filter-list').toUpperCase()}
+          <span onClick={() => setShowModal && setShowModal(false)}>
+            {t('close').toUpperCase()} <Icon icon='close' />
+          </span>
+        </Header>
+      );
+    } else {
+      return (
+        <Header>
+          {t('vocabulary-filter-filter-list').toUpperCase()}
+        </Header>
+      );
+    }
   }
 
   return <></>;

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -83,6 +83,7 @@ export default function Filter({
           title={t('vocabulary-filter-show-concept-states')}
           filter={filter}
           setFilter={setSomeFilter}
+          isModal={isModal}
         />
       );
     } else if (groups) {
@@ -101,6 +102,7 @@ export default function Filter({
             })
           }
           type='infoDomains'
+          isModal={isModal}
         />
       );
     }
@@ -159,6 +161,7 @@ export default function Filter({
           data={['concepts', 'collections']}
           filter={filter}
           setFilter={setSomeFilter}
+          isModal={isModal}
         />
       );
     }

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -122,7 +122,7 @@ export default function Filter({
         <div>
           <Button
             fullWidth
-            onClick={() => setShowModal && setShowModal(false)}
+            onClick={() => setShowModal?.(false)}
           >
             {t('close')}
           </Button>
@@ -215,19 +215,19 @@ export default function Filter({
     if (isModal) {
       return (
         <Header>
-          {t('vocabulary-filter-filter-list').toUpperCase()}
+          {t('vocabulary-filter-filter-list')}
           <HeaderButton
             iconRight='close'
-            onClick={() => setShowModal && setShowModal(false)}
+            onClick={() => setShowModal?.(false)}
           >
-            {t('close').toUpperCase()}
+            {t('close')}
           </HeaderButton>
         </Header>
       );
     } else {
       return (
         <Header>
-          {t('vocabulary-filter-filter-list').toUpperCase()}
+          {t('vocabulary-filter-filter-list')}
         </Header>
       );
     }

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -8,6 +8,7 @@ import DropdownArea from './dropdown-area';
 import {
   FilterWrapper,
   Header,
+  HeaderButton,
   Hr
 } from './filter.styles';
 import { vocabularyEmptyState, VocabularyState } from '../vocabulary/vocabulary-slice';
@@ -15,7 +16,7 @@ import { initialState, SearchState } from '../terminology-search/terminology-sea
 import { AppThunk } from '../../../store';
 import { CommonInfoDTO, GroupSearchResult, OrganizationSearchResult } from '../../interfaces/terminology.interface';
 import { isEqual } from 'lodash';
-import { Button, Icon } from 'suomifi-ui-components';
+import { Button } from 'suomifi-ui-components';
 
 export interface FilterProps {
   filter: VocabularyState['filter'] | SearchState['filter'];
@@ -211,9 +212,12 @@ export default function Filter({
       return (
         <Header>
           {t('vocabulary-filter-filter-list').toUpperCase()}
-          <span onClick={() => setShowModal && setShowModal(false)}>
-            {t('close').toUpperCase()} <Icon icon='close' />
-          </span>
+          <HeaderButton
+            iconRight='close'
+            onClick={() => setShowModal && setShowModal(false)}
+          >
+            {t('close').toUpperCase()}
+          </HeaderButton>
         </Header>
       );
     } else {

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -26,6 +26,7 @@ export interface FilterProps {
   type: string;
   isModal?: boolean;
   setShowModal?: Dispatch<SetStateAction<boolean>>;
+  resultCount?: number;
 }
 
 export default function Filter({
@@ -35,15 +36,16 @@ export default function Filter({
   resetSomeFilter,
   setSomeFilter,
   type,
-  isModal,
-  setShowModal
+  isModal = false,
+  setShowModal,
+  resultCount
 }: FilterProps) {
   const { t, i18n } = useTranslation('common');
 
   // Returns filter according to templates found below.
   if (type === 'vocabulary' && 'showBy' in filter) {
     return (
-      <FilterWrapper isModal={isModal}>SULJE
+      <FilterWrapper isModal={isModal}>
         {renderTitle()}
         {/* If filter has any value 'checked' Remove-component is displayed. */}
         {renderRemove()}
@@ -117,6 +119,9 @@ export default function Filter({
       return (
         <>
           <Hr />
+          <div>
+            {resultCount} {t('filter-with-current')}
+          </div>
           <div>
             <Button
               fullWidth

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -54,16 +54,7 @@ export default function Filter({
         {renderCheckboxArea(true)}
         <Hr />
         {renderSearchInputArea()}
-        {isModal
-          ?
-          <>
-            <Hr />
-            <div>
-              <Button fullWidth>{t('close')}</Button>
-            </div>
-          </>
-          : null
-        }
+        {renderCloseButton()}
       </FilterWrapper>
     );
   } else if (type === 'terminology-search' && 'showByOrg' in filter && groups) {

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -148,6 +148,7 @@ export default function Filter({
           setFilter={setSomeFilter}
           title={t('terminology-search-filter-by-organization')}
           visualPlaceholder={t('terminology-search-filter-pick-organization')}
+          isModal={isModal}
         />
       );
     }
@@ -206,6 +207,7 @@ export default function Filter({
         filter={filter}
         setFilter={setSomeFilter}
         visualPlaceholder={t('vocabulary-filter-visual-placeholder')}
+        isModal={isModal}
       />
     );
   }

--- a/src/common/components/filter/radio-button-area.tsx
+++ b/src/common/components/filter/radio-button-area.tsx
@@ -9,9 +9,10 @@ interface RadioButtonProps {
   filter: VocabularyState['filter'];
   setFilter: (x: any) => AppThunk;
   title: string;
+  isModal?: boolean;
 }
 
-export default function RadioButtonArea({ filter, data, setFilter, title }: RadioButtonProps) {
+export default function RadioButtonArea({ filter, data, setFilter, title, isModal }: RadioButtonProps) {
   const { t } = useTranslation('common');
   const dispatch = useStoreDispatch();
 
@@ -50,6 +51,7 @@ export default function RadioButtonArea({ filter, data, setFilter, title }: Radi
               value={value}
               key={`radio-button-${value}-${idx}`}
               checked={value === filter.showBy}
+              variant={isModal ? 'large' : 'small'}
             >
               {t(`vocabulary-filter-${value}`)} (n {t('vocabulary-filter-items')})
             </FilterRadioButton>

--- a/src/common/components/filter/search-input-area.tsx
+++ b/src/common/components/filter/search-input-area.tsx
@@ -10,9 +10,16 @@ interface SearchInputAreaProps {
   setFilter: (x: any) => AppThunk;
   title: string;
   visualPlaceholder: string;
+  isModal?: boolean;
 }
 
-export default function SearchInputArea({ filter, setFilter, title, visualPlaceholder }: SearchInputAreaProps) {
+export default function SearchInputArea({
+  filter,
+  isModal = false,
+  setFilter,
+  title,
+  visualPlaceholder
+}: SearchInputAreaProps) {
   const { t } = useTranslation('common');
   const dispatch = useStoreDispatch();
 
@@ -44,6 +51,7 @@ export default function SearchInputArea({ filter, setFilter, title, visualPlaceh
         visualPlaceholder={visualPlaceholder}
         onChange={(value) => handleKeywordChange(value as string)}
         onSearch={(value) => handleKeyword(value as string)}
+        fullWidth={isModal}
       />
     </div>
   );

--- a/src/common/components/impersonate/mobile-impersonate-wrapper.tsx
+++ b/src/common/components/impersonate/mobile-impersonate-wrapper.tsx
@@ -8,7 +8,7 @@ export default function MobileImpersonateWrapper() {
   const users = useFakeableUsers();
   const { t } = useTranslation();
 
-  if (! users?.length) {
+  if (!users?.length) {
     return null;
   }
 

--- a/src/common/components/search-results/search-results.styles.tsx
+++ b/src/common/components/search-results/search-results.styles.tsx
@@ -39,6 +39,7 @@ export const CardSubtitle = styled(Text)`
   font-size: 12px;
   font-weight: 600;
   margin-bottom: 10px;
+  text-transform: uppercase;
   word-spacing: 1px;
 `;
 

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -76,7 +76,7 @@ export default function SearchResults({ data, filter, type, setSomeFilter }: Sea
                   </CardTitle>
 
                   <CardSubtitle>
-                    {t('terminology-search-results-terminology').toUpperCase()} &middot; <CardPill valid={terminology.status === 'VALID' ? 'true' : undefined}>{t(terminology.status ?? '')}</CardPill>
+                    {t('terminology-search-results-terminology')} &middot; <CardPill valid={terminology.status === 'VALID' ? 'true' : undefined}>{t(terminology.status ?? '')}</CardPill>
                   </CardSubtitle>
 
                   <CardDescription>
@@ -127,7 +127,7 @@ export default function SearchResults({ data, filter, type, setSomeFilter }: Sea
                   </CardTitle>
 
                   <CardSubtitle>
-                    {t('vocabulary-info-concept').toUpperCase()} &middot; {t(`${concept.status}`).toUpperCase()}
+                    {t('vocabulary-info-concept')} &middot; {t(`${concept.status}`)}
                   </CardSubtitle>
 
                   <CardDescription>

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -98,8 +98,6 @@ export default function SearchResults({ data, filter, type, setSomeFilter }: Sea
           </CardWrapper>
         </>
       );
-    } else {
-      return <></>;
     }
 
     return null;
@@ -141,8 +139,6 @@ export default function SearchResults({ data, filter, type, setSomeFilter }: Sea
           </CardWrapper>
         </>
       );
-    } else {
-      return <></>;
     }
 
     return null;

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -43,6 +43,10 @@ export default function TerminologySearch() {
 
   return (
     <>
+      <BreadcrumbNav
+        title={{url: 'search', value: t('terminology-title')}}
+      />
+      <Title info={t('terminology-title')} />
       {isSmall &&
         <FilterMobileButton
           variant='secondary'
@@ -52,10 +56,6 @@ export default function TerminologySearch() {
           {t('vocabulary-filter-filter-list')}
         </FilterMobileButton>
       }
-      <BreadcrumbNav
-        title={{url: 'search', value: t('terminology-title')}}
-      />
-      <Title info={t('terminology-title')} />
       <ResultAndFilterContainer>
         {data &&
           <ResultAndStatsWrapper>

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -19,7 +19,7 @@ import { useStoreDispatch } from '../../store';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import { useBreakpoints } from '../../common/components/media-query/media-query-context';
-import { Button, Modal, ModalContent } from 'suomifi-ui-components';
+import { Modal, ModalContent } from 'suomifi-ui-components';
 import { useState } from 'react';
 
 export default function TerminologySearch() {
@@ -91,10 +91,10 @@ export default function TerminologySearch() {
             visible={showModal}
             onEscKeyDown={() => setShowModal(false)}
             variant='smallScreen'
-            style={{border: 'none'}}
+            style={{ border: 'none' }}
           >
             <ModalContent
-              style={{padding: '0px', overflowX: 'hidden'}}
+              style={{ padding: '0' }}
             >
               <Filter
                 filter={filter as SearchState['filter']}

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -11,16 +11,20 @@ import {
   setResultStart,
 } from '../../common/components/terminology-search/terminology-search-slice';
 import Title from '../../common/components/title/title';
-import { ResultAndFilterContainer, ResultAndStatsWrapper, PaginationWrapper } from './terminology-search.styles';
+import { ResultAndFilterContainer, ResultAndStatsWrapper, PaginationWrapper, FilterMobileButton } from './terminology-search.styles';
 import SearchResults from '../../common/components/search-results/search-results';
 import Filter from '../../common/components/filter/filter';
 import Pagination from '../../common/components/pagination/pagination';
 import { useStoreDispatch } from '../../store';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
+import { useBreakpoints } from '../../common/components/media-query/media-query-context';
+import { Button, Modal, ModalContent } from 'suomifi-ui-components';
+import { useState } from 'react';
 
 export default function TerminologySearch() {
   const { t } = useTranslation();
+  const { isSmall } = useBreakpoints();
   const dispatch = useStoreDispatch();
   const query = useRouter();
   const filter = useSelector(selectFilter());
@@ -28,6 +32,7 @@ export default function TerminologySearch() {
   const { data } = useGetSearchResultQuery({ filter: filter, resultStart: resultStart });
   const { data: groups } = useGetGroupsQuery(null);
   const { data: organizations } = useGetOrganizationsQuery(null);
+  const [showModal, setShowModal] = useState(false);
 
   if (query.query.page && query.query.page !== '1') {
     dispatch(setResultStart((parseInt(query.query.page as string, 10) - 1) * 10));
@@ -38,6 +43,15 @@ export default function TerminologySearch() {
   return (
     <>
       <Title info={'test'} />
+      {isSmall &&
+        <FilterMobileButton
+          variant='secondary'
+          fullWidth
+          onClick={() => setShowModal(!showModal)}
+        >
+          {t('vocabulary-filter-filter-list')}
+        </FilterMobileButton>
+      }
       <ResultAndFilterContainer>
         {data &&
           <ResultAndStatsWrapper>
@@ -61,14 +75,40 @@ export default function TerminologySearch() {
             }
           </ResultAndStatsWrapper>
         }
-        <Filter
-          filter={filter as SearchState['filter']}
-          groups={groups}
-          organizations={organizations}
-          type={'terminology-search'}
-          setSomeFilter={setFilter}
-          resetSomeFilter={resetFilter}
-        />
+        {!isSmall
+          ?
+          <Filter
+            filter={filter as SearchState['filter']}
+            groups={groups}
+            organizations={organizations}
+            type={'terminology-search'}
+            setSomeFilter={setFilter}
+            resetSomeFilter={resetFilter}
+          />
+          :
+          <Modal
+            appElementId='__next'
+            visible={showModal}
+            onEscKeyDown={() => setShowModal(false)}
+            variant='smallScreen'
+            style={{border: 'none'}}
+          >
+            <ModalContent
+              style={{padding: '0px', overflowX: 'hidden'}}
+            >
+              <Filter
+                filter={filter as SearchState['filter']}
+                groups={groups}
+                organizations={organizations}
+                type={'terminology-search'}
+                setSomeFilter={setFilter}
+                resetSomeFilter={resetFilter}
+                isModal={true}
+                setShowModal={setShowModal}
+              />
+            </ModalContent>
+          </Modal>
+        }
       </ResultAndFilterContainer>
     </>
   );

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -105,6 +105,7 @@ export default function TerminologySearch() {
                 resetSomeFilter={resetFilter}
                 isModal={true}
                 setShowModal={setShowModal}
+                resultCount={data?.totalHitCount}
               />
             </ModalContent>
           </Modal>

--- a/src/modules/terminology-search/terminology-search.styles.tsx
+++ b/src/modules/terminology-search/terminology-search.styles.tsx
@@ -1,4 +1,9 @@
 import styled from 'styled-components';
+import { Button } from 'suomifi-ui-components';
+
+export const FilterMobileButton = styled(Button)`
+  margin-top: 20px;
+`;
 
 export const ResultAndFilterContainer = styled.div`
   display: flex;

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { initializeVocabularyFilter, resetVocabularyFilter, setVocabularyFilter, useGetConceptResultQuery, useGetVocabularyQuery, VocabularyState } from '../../common/components/vocabulary/vocabulary-slice';
 import Filter from '../../common/components/filter/filter';
 import SearchResults from '../../common/components/search-results/search-results';
@@ -7,12 +7,18 @@ import { ResultAndFilterContainer, ResultAndStatsWrapper } from './vocabulary.st
 import { selectVocabularyFilter } from '../../common/components/vocabulary/vocabulary-slice';
 import { useSelector } from 'react-redux';
 import { useStoreDispatch } from '../../store';
+import { useBreakpoints } from '../../common/components/media-query/media-query-context';
+import { FilterMobileButton } from '../terminology-search/terminology-search.styles';
+import { useTranslation } from 'next-i18next';
+import { Modal, ModalContent } from 'suomifi-ui-components';
 
 interface VocabularyProps {
   id: string;
 }
 
 export default function Vocabulary({ id }: VocabularyProps) {
+  const { t } = useTranslation('common');
+  const { isSmall } = useBreakpoints();
   const dispatch = useStoreDispatch();
   useEffect(() => {
     dispatch(initializeVocabularyFilter());
@@ -21,10 +27,20 @@ export default function Vocabulary({ id }: VocabularyProps) {
   const filter: VocabularyState['filter'] = useSelector(selectVocabularyFilter());
   const { data: concepts } = useGetConceptResultQuery(id);
   const { data: info } = useGetVocabularyQuery(id);
+  const [showModal, setShowModal] = useState(false);
 
   return (
     <>
       {info && <Title info={info} />}
+      {isSmall &&
+        <FilterMobileButton
+          variant='secondary'
+          fullWidth
+          onClick={() => setShowModal(!showModal)}
+        >
+          {t('vocabulary-filter-filter-list')}
+        </FilterMobileButton>
+      }
       <ResultAndFilterContainer>
         {concepts &&
           <ResultAndStatsWrapper>
@@ -35,12 +51,37 @@ export default function Vocabulary({ id }: VocabularyProps) {
             />
           </ResultAndStatsWrapper>
         }
-        <Filter
-          filter={filter as VocabularyState['filter']}
-          type={'vocabulary'}
-          setSomeFilter={setVocabularyFilter}
-          resetSomeFilter={resetVocabularyFilter}
-        />
+        {!isSmall
+          ?
+          <Filter
+            filter={filter as VocabularyState['filter']}
+            type={'vocabulary'}
+            setSomeFilter={setVocabularyFilter}
+            resetSomeFilter={resetVocabularyFilter}
+          />
+          :
+          <Modal
+            appElementId='__next'
+            visible={showModal}
+            onEscKeyDown={() => setShowModal(false)}
+            variant='smallScreen'
+            style={{ border: 'none' }}
+          >
+            <ModalContent
+              style={{ padding: '0' }}
+            >
+              <Filter
+                filter={filter as VocabularyState['filter']}
+                type={'vocabulary'}
+                setSomeFilter={setVocabularyFilter}
+                resetSomeFilter={resetVocabularyFilter}
+                isModal={true}
+                setShowModal={setShowModal}
+                resultCount={concepts?.totalHitCount}
+              />
+            </ModalContent>
+          </Modal>
+        }
       </ResultAndFilterContainer>
     </>
   );

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -9,7 +9,3 @@ body {
   @include fi-text-body-text;
   background-color: $fi-color-depth-light3;
 }
-
-.fi-modal_overlay {
-  z-index: 99999;
-}


### PR DESCRIPTION
Added mobile version of filter.

Changes in this PR:
- If used in mobile view, the filter can be opened from a button to a modal which takes the whole screen. The functionality of filter hasn't been altered.
- Checkboxes and radio buttons size is larger in mobile view.
- Close button appears in header when in mobile view. 


Filter is initially hidden in mobile which can be opened from a new button.
![image](https://user-images.githubusercontent.com/82932696/147536391-b2f7173f-31e2-4e58-82ad-41e312ab1ff0.png)

Filter open in search page.
![image](https://user-images.githubusercontent.com/82932696/147536451-14d2b981-4d4b-4dc8-a5db-0b2d656c6dda.png)

Filter open in a terminology page.
![image](https://user-images.githubusercontent.com/82932696/147536509-4038653f-4289-4c30-bc6f-fc3e2d4e8d0e.png)
