### PR TITLE
Switched from Fetch to Axios

### DIFF
--- a/src/common/components/axios-base-query/index.tsx
+++ b/src/common/components/axios-base-query/index.tsx
@@ -1,0 +1,31 @@
+import axios, { AxiosRequestConfig, AxiosError } from 'axios';
+import { BaseQueryFn } from '@reduxjs/toolkit/query';
+
+const axiosBaseQuery = ({ baseUrl }: { baseUrl: string } = { baseUrl: '' }):
+  BaseQueryFn<
+    {
+      url: string;
+      method: AxiosRequestConfig['method'];
+      data?: AxiosRequestConfig['data'];
+    },
+    unknown,
+    unknown
+  > =>
+  async ({ url, method, data }) => {
+    try {
+      const result = await axios({
+        url: baseUrl + url,
+        headers: { 'content-type': 'application/json' },
+        method,
+        data
+      });
+      return { data: result.data };
+    } catch (axiosError) {
+      let error = axiosError as AxiosError;
+      return {
+        error: { status: error.response?.status, data: error.response?.data }
+      };
+    }
+  };
+
+export default axiosBaseQuery;

--- a/src/common/components/collection/collection-slice.tsx
+++ b/src/common/components/collection/collection-slice.tsx
@@ -1,27 +1,22 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { Collection } from '../../interfaces/collection.interface';
+import axiosBaseQuery from '../axios-base-query';
 
 export const collectionApi = createApi({
   reducerPath: 'collectionAPI',
-  baseQuery: fetchBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
+  baseQuery: axiosBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
   tagTypes: ['Collection'],
   endpoints: builder => ({
     getCollection: builder.query<Collection, { terminologyId: string, collectionId: string }>({
       query: ({ terminologyId, collectionId }) => ({
         url: `/collection?graphId=${terminologyId}&collectionId=${collectionId}`,
-        method: 'GET',
-        headers: {
-          'content-type': 'application/json',
-        },
+        method: 'GET'
       })
     }),
     getCollections: builder.query<Collection[], string>({
       query: (terminologyId) => ({
         url: `/collections?graphId=${terminologyId}`,
-        method: 'GET',
-        headers: {
-          'content-type': 'application/json',
-        },
+        method: 'GET'
       })
     }),
   }),

--- a/src/common/components/concept/concept-slice.tsx
+++ b/src/common/components/concept/concept-slice.tsx
@@ -1,18 +1,16 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { Concept } from '../../interfaces/concept.interface';
+import axiosBaseQuery from '../axios-base-query';
 
 export const conceptApi = createApi({
   reducerPath: 'conceptAPI',
-  baseQuery: fetchBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
+  baseQuery: axiosBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
   tagTypes: ['Concept'],
   endpoints: builder => ({
     getConcept: builder.query<Concept, { terminologyId: string, conceptId: string }>({
       query: ({ terminologyId, conceptId }) => ({
         url: `/concept?graphId=${terminologyId}&conceptId=${conceptId}`,
-        method: 'GET',
-        headers: {
-          'content-type': 'application/json',
-        },
+        method: 'GET'
       })
     })
   }),

--- a/src/common/components/terminology-search/terminology-search-slice.tsx
+++ b/src/common/components/terminology-search/terminology-search-slice.tsx
@@ -1,7 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import type { AppState, AppThunk } from '../../../store';
 import { GroupSearchResult, OrganizationSearchResult, TerminologySearchResult } from '../../interfaces/terminology.interface';
+import axiosBaseQuery from '../axios-base-query';
 
 export interface SearchState {
   filter: {
@@ -48,17 +49,14 @@ export const terminologySearchSlice = createSlice({
 
 export const terminologySearchApi = createApi({
   reducerPath: 'terminologySearchApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
+  baseQuery: axiosBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
   tagTypes: ['TerminologySearch'],
   endpoints: builder => ({
     getSearchResult: builder.query<TerminologySearchResult, {filter: SearchState['filter'], resultStart: number}>({
       query: (value) => ({
         url: '/searchTerminology',
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-        },
-        body: {
+        data: {
           query: value.filter.keyword,
           statuses: Array.from(Object.keys(value.filter.status).filter(s => value.filter.status[s])),
           groups: value.filter.infoDomains.map(infoD => infoD.id),
@@ -73,18 +71,12 @@ export const terminologySearchApi = createApi({
       query: () => ({
         url: '/groups',
         method: 'GET',
-        headers: {
-          'content-type': 'application/json',
-        },
       }),
     }),
     getOrganizations: builder.query<OrganizationSearchResult[], null>({
       query: () => ({
         url: '/organizations',
         method: 'GET',
-        headers: {
-          'content-type': 'application/json',
-        },
       }),
     })
   }),

--- a/src/common/components/vocabulary/vocabulary-slice.tsx
+++ b/src/common/components/vocabulary/vocabulary-slice.tsx
@@ -1,7 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { AppState, AppThunk } from '../../../store';
 import { VocabularyConcepts, VocabularyInfoDTO } from '../../interfaces/vocabulary.interface';
+import axiosBaseQuery from '../axios-base-query';
 
 export interface VocabularyState {
   filter: {
@@ -53,17 +54,14 @@ export const vocabularySlice = createSlice({
 
 export const vocabularyApi = createApi({
   reducerPath: 'vocabularyAPI',
-  baseQuery: fetchBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
+  baseQuery: axiosBaseQuery({ baseUrl: '/terminology-api/api/v1/frontend' }),
   tagTypes: ['Vocabulary'],
   endpoints: builder => ({
     getConceptResult: builder.query<VocabularyConcepts, string>({
       query: (value) => ({
         url: '/searchConcept',
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-        },
-        body: {
+        data: {
           highlight: true,
           pageFrom: 0,
           pageSize: 100,


### PR DESCRIPTION
Warnings about using fetch with SSR pages have previously emerged when running unit tests. Therefore Redux toolkit's baseQueryFn has been replaced with an Axios component.

Changes in this PR:
- Added new component to replace baseQueryFn that uses Axios
- Replaces all createApi() to use the new component instead of baseQueryFn