### PR TITLE
Fix time zone problem from tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,4 @@ EXPOSE 80
 # https://nextjs.org/telemetry
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD ["npm", "start", "--port", "80"]
+CMD ["npm", "start", "--", "--port", "80"]

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --dir src",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:ci": "jest --ci --runInBand --coverage"
+    "test": "TZ=UTZ jest",
+    "test:watch": "TZ=UTZ jest --watch",
+    "test:ci": "TZ=UTZ jest --ci --runInBand --coverage"
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --dir src",
-    "test": "TZ=UTZ jest",
-    "test:watch": "TZ=UTZ jest --watch",
-    "test:ci": "TZ=UTZ jest --ci --runInBand --coverage"
+    "test": "TZ=UTC jest",
+    "test:watch": "TZ=UTC jest --watch",
+    "test:ci": "TZ=UTC jest --ci --runInBand --coverage"
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",

--- a/src/common/components/formatted-date/format.test.ts
+++ b/src/common/components/formatted-date/format.test.ts
@@ -2,18 +2,18 @@ import format from './format';
 
 describe('format', () => {
   it('should format date correctly in Finnish', async () => {
-    expect(format('2022-01-02T03:04:00.000Z', 'fi')).toEqual('2.1.2022, 5.04');
+    expect(format('2022-01-02T03:04:00.000Z', 'fi')).toEqual('2.1.2022, 3.04');
   });
 
   it('should format date correctly in Swedish', async () => {
-    expect(format('2022-01-02T03:04:00.000Z', 'sv')).toEqual('2.1.2022 kl. 5.04');
+    expect(format('2022-01-02T03:04:00.000Z', 'sv')).toEqual('2.1.2022 kl. 3.04');
   });
 
   it('should format date correctly in English', async () => {
-    expect(format('2022-01-02T03:04:00.000Z', 'en')).toEqual('01/02/2022, 5.04');
+    expect(format('2022-01-02T03:04:00.000Z', 'en')).toEqual('01/02/2022, 3.04');
   });
 
   it('should use 24 hour clock in English', async () => {
-    expect(format('2022-01-02T12:04:00.000Z', 'en')).toEqual('01/02/2022, 14.04');
+    expect(format('2022-01-02T12:04:00.000Z', 'en')).toEqual('01/02/2022, 12.04');
   });
 });

--- a/src/common/components/formatted-date/formatted-date.test.tsx
+++ b/src/common/components/formatted-date/formatted-date.test.tsx
@@ -8,6 +8,6 @@ describe('FormattedDate', () => {
       <FormattedDate date="2022-01-02T03:04:00.000Z" />
     );
 
-    expect(screen.queryByText('2.1.2022, 5.04')).toBeTruthy();
+    expect(screen.queryByText('2.1.2022, 3.04')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Day.js uses system time zone automatically so it causes problems
when developers' machines are running in different time zone than CI.