### PR TITLE
Skip links

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -103,5 +103,7 @@
   "filter-with-current": "{{count}} item with following filters",
   "filter-with-current_plural": "{{count}} items with following filters",
   "front-page": "Front page",
-  "breadcrumb": "Breadcrumb"
+  "breadcrumb": "Breadcrumb",
+  "skip-link-main": "Go directly to contents.",
+  "skip-link-search-results": "Go directly to search results."
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -96,5 +96,7 @@
   "navigation-close": "Sulje navigaatio",
   "filter-with-current": "{{count}} kpl seuraavilla rajauksilla",
   "front-page": "Etusivu",
-  "breadcrumb": "Murupolku"
+  "breadcrumb": "Murupolku",
+  "skip-link-main": "Siirry suoraan sisältöön.",
+  "skip-link-search-results": "Siirry suoraan hakutuloksiin."
 }

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'next-i18next';
 import { Button } from 'suomifi-ui-components';
 import Separator from '../separator';
+import SkipLink from '../skip-link/skip-link';
 import {
   CloseWrapper,
   FilterContent,
@@ -26,14 +27,20 @@ export function Filter({
   const { t } = useTranslation('common');
 
   return (
-    <FilterWrapper isModal={isModal}>
-      {renderTitle()}
-      <FilterContent>
-        <ResetAllFiltersButton />
-        {children}
-        {renderModalFooter()}
-      </FilterContent>
-    </FilterWrapper>
+    <div>
+      <SkipLink href="#search-results">
+        {t('skip-link-search-results')}
+      </SkipLink>
+
+      <FilterWrapper isModal={isModal}>
+        {renderTitle()}
+        <FilterContent>
+          <ResetAllFiltersButton />
+          {children}
+          {renderModalFooter()}
+        </FilterContent>
+      </FilterWrapper>
+    </div>
   );
 
   function renderTitle() {

--- a/src/common/components/skip-link/skip-link.styles.tsx
+++ b/src/common/components/skip-link/skip-link.styles.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const SkipLinkWrapper = styled('span')`
+  a {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+  }
+
+  a:active,
+  a:focus {
+    clip: auto;
+    height: auto;
+    margin: auto;
+    overflow: visible;
+    position: static;
+    width: auto;
+  }
+`;

--- a/src/common/components/skip-link/skip-link.test.tsx
+++ b/src/common/components/skip-link/skip-link.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { themeProvider } from '../../../tests/test-utils';
+import SkipLink from './skip-link';
+
+describe('SkipLink', () => {
+  test('should render', () => {
+    render(
+      <SkipLink href="#main">
+        Go to main content.
+      </SkipLink>,
+      { wrapper: themeProvider }
+    );
+
+    expect(screen.getByText('Go to main content.')).toBeTruthy();
+  });
+});

--- a/src/common/components/skip-link/skip-link.tsx
+++ b/src/common/components/skip-link/skip-link.tsx
@@ -1,0 +1,16 @@
+import { Link as SuomiLink } from 'suomifi-ui-components';
+import { SkipLinkWrapper } from './skip-link.styles';
+
+export interface SkipLinkProps {
+  children: React.ReactNode;
+  href: string;
+}
+
+export default function SkipLink({ children, href }: SkipLinkProps) {
+  // Note. Don't use next/link here. It moves focus back to the beginning.
+  return (
+    <SkipLinkWrapper>
+      <SuomiLink href={href}>{children}</SuomiLink>
+    </SkipLinkWrapper>
+  );
+}

--- a/src/layouts/error-layout.tsx
+++ b/src/layouts/error-layout.tsx
@@ -31,7 +31,7 @@ export default function ErrorLayout({ children }: { children: React.ReactNode })
 
         <ContentContainer >
           <MarginContainer breakpoint={breakpoint}>
-            <Block variant="main">
+            <Block variant="main" id="main">
               {children}
             </Block>
           </MarginContainer>

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'next-i18next';
 import Footer from '../common/components/footer/footer';
 import SmartHeader from '../modules/smart-header';
 import { useBreakpoints } from '../common/components/media-query/media-query-context';
+import SkipLink from '../common/components/skip-link/skip-link';
 
 export default function Layout({
   children,
@@ -31,12 +32,17 @@ export default function Layout({
         <meta name="og:title" content={t('terminology')} />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
+
+      <SkipLink href="#main">
+        {t('skip-link-main')}
+      </SkipLink>
+
       <SiteContainer>
         <SmartHeader />
 
         <ContentContainer>
           <MarginContainer breakpoint={breakpoint}>
-            <Block variant="main">
+            <Block variant="main" id="main">
               {children}
             </Block>
           </MarginContainer>

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -39,7 +39,7 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
       </Breadcrumb>
 
       <PageContent breakpoint={breakpoint}>
-        <MainContent>
+        <MainContent id="main">
           <HeadingBlock>
             <Text>
               <PropertyValue

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -51,7 +51,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
       </Breadcrumb>
 
       <PageContent breakpoint={breakpoint}>
-        <MainContent>
+        <MainContent id="main">
           <HeadingBlock>
             <Text>
               <PropertyValue

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -44,7 +44,7 @@ export default function TerminologySearch() {
         </FilterMobileButton>
       }
       <ResultAndFilterContainer>
-        <ResultAndStatsWrapper>
+        <ResultAndStatsWrapper id="search-results">
           {data &&
             <>
               <SearchResults

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -53,7 +53,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
       }
       <ResultAndFilterContainer>
         {(concepts && urlState.type === 'concept') &&
-          <ResultAndStatsWrapper>
+          <ResultAndStatsWrapper id="search-results">
             <SearchResults data={concepts} />
             <PaginationWrapper>
               <Pagination
@@ -64,7 +64,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
           </ResultAndStatsWrapper>
         }
         {(collections && urlState.type === 'collection') &&
-          <ResultAndStatsWrapper>
+          <ResultAndStatsWrapper id="search-results">
             <SearchResults
               data={filterData(collections, urlState, i18n.language) ?? collections}
               type="collections"


### PR DESCRIPTION
Add two skip links:

- "Go to main content" link to the beginning of every page.
- "Go to search results" link to the beginning of filter pane in terminology list and terminology details pages.

Error pages are only exceptions without skip links. That's because translations are not available there and they are pretty simple pages so they don't even need any skip links.

YTI-1691