### PR TITLE
Yti 1692 accessibility page change

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -105,5 +105,6 @@
   "front-page": "Front page",
   "breadcrumb": "Breadcrumb",
   "error-occured": "An error occured",
-  "try-again": "Try again"
+  "try-again": "Try again",
+  "navigated-to": "Navigated to"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -98,5 +98,6 @@
   "front-page": "Etusivu",
   "breadcrumb": "Murupolku",
   "error-occured": "Tapahtui virhe",
-  "try-again": "Yritä uudestaan"
+  "try-again": "Yritä uudestaan",
+  "navigated-to": "Siirrytty sivulle"
 }

--- a/src/common/components/pagination/pagination-props.tsx
+++ b/src/common/components/pagination/pagination-props.tsx
@@ -7,8 +7,3 @@ export interface PaginationProps {
   isSmall?: boolean;
   pageString: string;
 }
-
-export interface PaginationButtonProps {
-  active?: boolean;
-  disabled?: boolean;
-}

--- a/src/common/components/pagination/pagination.styles.tsx
+++ b/src/common/components/pagination/pagination.styles.tsx
@@ -40,7 +40,7 @@ export const PaginationButton = styled(Button)`
 `;
 
 export const PaginationMobile = styled.div`
-  height: 35px;
+  height: auto;
   width: auto;
   padding-left: ${props => props.theme.suomifi.spacing.m};
   padding-right: ${props => props.theme.suomifi.spacing.m};

--- a/src/common/components/pagination/pagination.styles.tsx
+++ b/src/common/components/pagination/pagination.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { PaginationButtonProps } from './pagination-props';
+import { Button } from 'suomifi-ui-components';
 
 export const PaginationWrapper = styled.div`
   display: flex;
@@ -10,24 +10,33 @@ export const PaginationWrapper = styled.div`
   border-right: solid 1px ${props => props.theme.suomifi.colors.depthLight1};
   background: ${props => props.theme.suomifi.colors.whiteBase};
   margin-top: ${props => props.theme.suomifi.spacing.m};
+
+  > * {
+    border-left: solid 1px ${props => props.theme.suomifi.colors.depthLight1} !important;
+  }
 `;
 
-export const PaginationButton = styled.div<PaginationButtonProps>`
+export const ChevronButton = styled(Button)`
   height: 35px;
   width: 35px;
-  border-style: none;
-  border-left: solid 1px ${props => props.theme.suomifi.colors.depthLight1};
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+
+  > svg {
+    line-height: 16px;
+    margin-right: 0px !important;
+  }
+`;
+
+export const PaginationButton = styled(Button)`
+  height: 35px;
+  width: 35px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: ${props => props.theme.suomifi.typography.bodyTextSmall};
-  color: ${props => props.active ? props.theme.suomifi.colors.whiteBase : props.theme.suomifi.colors.highlightBase};
-  background: ${props => props.active ? props.theme.suomifi.colors.highlightDark1 : props.theme.suomifi.colors.whiteBase};
-
-  :hover {
-    background: ${props => props.active ? props.theme.suomifi.colors.highlightBase : !props.disabled ? props.theme.suomifi.colors.depthLight2 : ''};
-    cursor: ${props => props.disabled ? '' : 'pointer'};
-  }
 `;
 
 export const PaginationMobile = styled.div`

--- a/src/common/components/pagination/pagination.tsx
+++ b/src/common/components/pagination/pagination.tsx
@@ -1,5 +1,4 @@
-import { Icon } from 'suomifi-ui-components';
-import { PaginationButton, PaginationMobile, PaginationWrapper } from './pagination.styles';
+import { ChevronButton, PaginationButton, PaginationMobile, PaginationWrapper } from './pagination.styles';
 import { PaginationProps } from './pagination-props';
 import { useBreakpoints } from '../media-query/media-query-context';
 import useUrlState from '../../utils/hooks/useUrlState';
@@ -24,17 +23,14 @@ export default function Pagination({
 
   return (
     <PaginationWrapper>
-      <PaginationButton
+      <ChevronButton
         disabled={urlState.page === 1}
-        onClick={() =>urlState.page !== 1 && patchUrlState({ page: urlState.page - 1 })}
+        onClick={() => urlState.page !== 1 && patchUrlState({ page: urlState.page - 1 })}
         data-testid='pagination-left'
-      >
-        {/* TODO: Update color after release in design system*/}
-        <Icon
-          icon='chevronLeft'
-          color={urlState.page === 1 ? 'hsl(202, 7%, 67%)' : 'hsl(212, 63%, 45%)'}
-        />
-      </PaginationButton>
+        icon='chevronLeft'
+        iconProps={{ icon: 'chevronLeft'}}
+        variant='secondaryNoBorder'
+      />
 
       {!breakPoints.isSmall
         ?
@@ -44,7 +40,7 @@ export default function Pagination({
               <PaginationButton
                 key={item !== '...' ? `pagination-item-${item}` : `pagination-item-${item}-${idx}`}
                 onClick={() => (urlState.page !== item && typeof item === 'number') && patchUrlState({ page: item })}
-                active={item === urlState.page}
+                variant={item === urlState.page ? 'default' : 'secondaryNoBorder'}
                 disabled={item === '...'}
               >
                 {item}
@@ -55,17 +51,14 @@ export default function Pagination({
         <PaginationMobile>{pageString} {urlState.page}/{items.length}</PaginationMobile>
       }
 
-      <PaginationButton
+      <ChevronButton
         disabled={urlState.page === items[items.length - 1]}
         onClick={() => urlState.page !== items[items.length - 1] && patchUrlState({ page: urlState.page + 1 })}
         data-testid='pagination-right'
-      >
-        {/* TODO: Update color*/}
-        <Icon
-          icon='chevronRight'
-          color={urlState.page === items[items.length - 1] ? 'hsl(202, 7%, 67%)' : 'hsl(212, 63%, 45%)'}
-        />
-      </PaginationButton>
+        icon='chevronRight'
+        iconProps={{ icon: 'chevronRight' }}
+        variant='secondaryNoBorder'
+      />
     </PaginationWrapper>
   );
 }

--- a/src/common/components/search-results/search-count-tags.tsx
+++ b/src/common/components/search-results/search-count-tags.tsx
@@ -32,7 +32,7 @@ export default function SearchCountTags({
 
   return (
     <CountWrapper isSmall={isSmall}>
-      <CountText>{title}</CountText>
+      <CountText aria-live='polite'>{title}</CountText>
       <ChipWrapper>
         {renderOrganizationTag()}
         {renderQBeforeStatus && renderQTag()}

--- a/src/common/components/title/title.slice.tsx
+++ b/src/common/components/title/title.slice.tsx
@@ -1,0 +1,35 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { AppState, AppThunk } from '../../../store';
+
+export interface TitleState {
+  title: string;
+}
+
+export const titleInitialState = {
+  title: '',
+};
+
+export const titleSlice = createSlice({
+  name: 'title',
+  initialState: titleInitialState,
+  reducers: {
+    setTitle(state, action) {
+      return {
+        ...state,
+        ...action.payload
+      };
+    }
+  }
+});
+
+export const setTitle = (title: TitleState['title']): AppThunk => dispatch => {
+  dispatch(
+    titleSlice.actions.setTitle({
+      title: title
+    })
+  );
+};
+
+export const selectTitle = () => (state: AppState): TitleState['title'] => state.title.title;
+
+export default titleSlice.reducer;

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { Heading, VisuallyHidden } from 'suomifi-ui-components';
+import { Heading } from 'suomifi-ui-components';
 import { Contributor, Description, StatusChip, TitleWrapper, TitleWrapperNoBreadcrumb } from './title.styles';
 import InfoExpander from '../info-dropdown/info-expander';
 import { VocabularyInfoDTO } from '../../interfaces/vocabulary.interface';
 import { getPropertyValue } from '../property-value/get-property-value';
 import { useStoreDispatch } from '../../../store';
 import { setTitle } from './title.slice';
+import { useEffect, useRef } from 'react';
 
 interface TitleProps {
   info: string | VocabularyInfoDTO;
@@ -13,8 +14,8 @@ interface TitleProps {
 
 export default function Title({ info }: TitleProps) {
   const { t, i18n } = useTranslation('common');
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const dispatch = useStoreDispatch();
-
   const title = typeof info === 'string'
     ?
     info
@@ -24,8 +25,13 @@ export default function Title({ info }: TitleProps) {
       language: i18n.language,
       fallbackLanguage: 'fi'
     }) ?? '';
-
   dispatch(setTitle(title));
+
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, [titleRef]);
 
   if (!info) {
     return <></>;
@@ -34,7 +40,9 @@ export default function Title({ info }: TitleProps) {
   if (typeof info === 'string') {
     return (
       <TitleWrapperNoBreadcrumb>
-        <Heading variant='h1'>{info}</Heading>
+        <Heading variant='h1'>
+          {info}
+        </Heading>
         <Description>{t('terminology-search-info')}</Description>
       </TitleWrapperNoBreadcrumb>
     );
@@ -51,7 +59,9 @@ export default function Title({ info }: TitleProps) {
       <TitleWrapper>
         <Contributor>{contributor}</Contributor>
 
-        <Heading variant='h1'>{title}</Heading>
+        <Heading variant='h1' tabIndex={-1} ref={titleRef}>
+          {title}
+        </Heading>
 
         <StatusChip valid={status === 'VALID' ? 'true' : undefined}>
           {t(`${status}`)}

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -1,9 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { Heading } from 'suomifi-ui-components';
+import { Heading, VisuallyHidden } from 'suomifi-ui-components';
 import { Contributor, Description, StatusChip, TitleWrapper, TitleWrapperNoBreadcrumb } from './title.styles';
 import InfoExpander from '../info-dropdown/info-expander';
 import { VocabularyInfoDTO } from '../../interfaces/vocabulary.interface';
 import { getPropertyValue } from '../property-value/get-property-value';
+import { useStoreDispatch } from '../../../store';
+import { setTitle } from './title.slice';
 
 interface TitleProps {
   info: string | VocabularyInfoDTO;
@@ -11,6 +13,19 @@ interface TitleProps {
 
 export default function Title({ info }: TitleProps) {
   const { t, i18n } = useTranslation('common');
+  const dispatch = useStoreDispatch();
+
+  const title = typeof info === 'string'
+    ?
+    info
+    :
+    getPropertyValue({
+      property: info.properties.prefLabel,
+      language: i18n.language,
+      fallbackLanguage: 'fi'
+    }) ?? '';
+
+  dispatch(setTitle(title));
 
   if (!info) {
     return <></>;
@@ -25,11 +40,7 @@ export default function Title({ info }: TitleProps) {
     );
   } else {
     const status = info.properties.status?.[0].value ?? '';
-    const title = getPropertyValue({
-      property: info.properties.prefLabel,
-      language: i18n.language,
-      fallbackLanguage: 'fi'
-    }) ?? '';
+
     const contributor = getPropertyValue({
       property: info.references.contributor?.[0].properties.prefLabel,
       language: i18n.language,

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Heading, Text } from 'suomifi-ui-components';
 import { setAlert } from '../../common/components/alert/alert.slice';
 import { BasicBlock, MultilingualPropertyBlock, PropertyBlock } from '../../common/components/block';
@@ -31,6 +31,7 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
   const { t, i18n } = useTranslation('collection');
   const dispatch = useStoreDispatch();
   const router = useRouter();
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   if (collectionError && 'status' in collectionError && collectionError.status === 404) {
     router.push('/404');
@@ -54,6 +55,12 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
       dispatch(setTitle(title));
     }
   }, [collection, dispatch, i18n.language]);
+
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, [titleRef]);
 
   return (
     <>
@@ -85,7 +92,7 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
                 fallbackLanguage='fi'
               />
             </Text>
-            <Heading variant="h1">
+            <Heading variant="h1" tabIndex={-1} ref={titleRef}>
               <PropertyValue
                 property={collection?.properties.prefLabel}
                 fallbackLanguage='fi'

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -10,12 +10,14 @@ import { useGetCollectionQuery } from '../../common/components/collection/collec
 import FormattedDate from '../../common/components/formatted-date';
 import { useBreakpoints } from '../../common/components/media-query/media-query-context';
 import PropertyValue from '../../common/components/property-value';
+import { getPropertyValue } from '../../common/components/property-value/get-property-value';
 import Separator from '../../common/components/separator';
 import { useGetVocabularyQuery } from '../../common/components/vocabulary/vocabulary-slice';
 import { Error } from '../../common/interfaces/error.interface';
 import { useStoreDispatch } from '../../store';
 import CollectionSidebar from './collection-sidebar';
 import { BadgeBar, HeadingBlock, MainContent, PageContent } from './collection.styles';
+import { setTitle } from '../../common/components/title/title.slice';
 
 interface CollectionProps {
   terminologyId: string;
@@ -26,7 +28,7 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
   const { breakpoint } = useBreakpoints();
   const { data: terminology, error: terminologyError } = useGetVocabularyQuery(terminologyId);
   const { data: collection, error: collectionError } = useGetCollectionQuery({ terminologyId, collectionId });
-  const { t } = useTranslation('collection');
+  const { t, i18n } = useTranslation('collection');
   const dispatch = useStoreDispatch();
   const router = useRouter();
 
@@ -40,6 +42,18 @@ export default function Collection({ terminologyId, collectionId }: CollectionPr
       collectionError as Error
     ]));
   }, [dispatch, terminologyError, collectionError]);
+
+  useEffect(() => {
+    if (collection) {
+      const title = getPropertyValue({
+        property: collection?.properties.prefLabel,
+        language: i18n.language,
+        fallbackLanguage: 'fi'
+      }) ?? '';
+
+      dispatch(setTitle(title));
+    }
+  }, [collection, dispatch, i18n.language]);
 
   return (
     <>

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'next-i18next';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ExternalLink, Heading, Text } from 'suomifi-ui-components';
 import {
   BasicBlock,
@@ -42,6 +42,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
   const { t, i18n } = useTranslation('concept');
   const dispatch = useStoreDispatch();
   const router = useRouter();
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   if (conceptError && 'status' in conceptError && conceptError.status === 404) {
     router.push('/404');
@@ -66,6 +67,11 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
     }
   }, [concept, dispatch, i18n.language]);
 
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, [titleRef]);
 
   return (
     <>
@@ -94,7 +100,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
                 fallbackLanguage='fi'
               />
             </Text>
-            <Heading variant="h1">
+            <Heading variant="h1" tabIndex={-1} ref={titleRef}>
               <PropertyValue
                 property={concept?.references.prefLabelXl?.[0].properties.prefLabel}
                 fallbackLanguage='fi'

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -28,6 +28,7 @@ import { useStoreDispatch } from '../../store';
 import { setAlert } from '../../common/components/alert/alert.slice';
 import { Error } from '../../common/interfaces/error.interface';
 import { useRouter } from 'next/router';
+import { setTitle } from '../../common/components/title/title.slice';
 
 export interface ConceptProps {
   terminologyId: string;
@@ -38,7 +39,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
   const { breakpoint } = useBreakpoints();
   const { data: terminology, error: terminologyError } = useGetVocabularyQuery(terminologyId);
   const { data: concept, error: conceptError } = useGetConceptQuery({ terminologyId, conceptId });
-  const { t } = useTranslation('concept');
+  const { t, i18n } = useTranslation('concept');
   const dispatch = useStoreDispatch();
   const router = useRouter();
 
@@ -52,6 +53,19 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
       conceptError as Error
     ]));
   }, [dispatch, terminologyError, conceptError]);
+
+  useEffect(() => {
+    if (concept) {
+      const title = getPropertyValue({
+        property: concept.references.prefLabelXl?.[0].properties.prefLabel,
+        language: i18n.language,
+        fallbackLanguage: 'fi'
+      }) ?? '';
+
+      dispatch(setTitle(title));
+    }
+  }, [concept, dispatch, i18n.language]);
+
 
   return (
     <>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,16 +1,22 @@
 import { SWRConfig } from 'swr';
 import '../../styles/globals.scss';
 import type { AppProps } from 'next/app';
-import { appWithTranslation } from 'next-i18next';
+import { appWithTranslation, useTranslation } from 'next-i18next';
 import axios from 'axios';
 import React from 'react';
 import { wrapper } from '../store';
 import '@fontsource/source-sans-pro/300.css';
 import '@fontsource/source-sans-pro/400.css';
 import '@fontsource/source-sans-pro/600.css';
+import { VisuallyHidden } from 'suomifi-ui-components';
+import { useSelector } from 'react-redux';
+import { selectTitle } from '../common/components/title/title.slice';
 
 // https://nextjs.org/docs/advanced-features/custom-app
 function App({ Component, pageProps }: AppProps) {
+  const title = useSelector(selectTitle());
+  const { t } = useTranslation('common');
+
   return (
     <SWRConfig
       value={{
@@ -22,6 +28,11 @@ function App({ Component, pageProps }: AppProps) {
         },
       }}
     >
+      <VisuallyHidden>
+        <div role='region' aria-live='assertive'>
+          {t('navigated-to')} {title}
+        </div>
+      </VisuallyHidden>
       <Component {...pageProps} />
     </SWRConfig>
   );

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -8,6 +8,7 @@ import { collectionApi } from '../common/components/collection/collection-slice'
 import { countsApi } from '../common/components/counts/counts-slice';
 import { loginSlice } from '../common/components/login/login-slice';
 import { alertSlice } from '../common/components/alert/alert.slice';
+import { titleSlice } from '../common/components/title/title.slice';
 
 export function makeStore() {
   return configureStore({
@@ -21,6 +22,7 @@ export function makeStore() {
       [countsApi.reducerPath]: countsApi.reducer,
       [loginSlice.name]: loginSlice.reducer,
       [alertSlice.name]: alertSlice.reducer,
+      [titleSlice.name]: titleSlice.reducer
     },
 
     middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
Changes in this PR:
- Reworked pagination to use `Button` instead of `div`.
- Added `VisuallyHidden` component to update user about which page has been moved to.
- Page focus is set to be page title (excluding front page) on load.