### PR TITLE
Fix some accessibility issues from filter panel

### DIFF
--- a/src/common/components/filter/checkbox-filter.tsx
+++ b/src/common/components/filter/checkbox-filter.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'suomifi-ui-components';
-import { FilterCheckbox } from './filter.styles';
+import { FilterFieldset, FilterCheckbox, FilterFieldsetLegend } from './filter.styles';
 
 export interface Item {
   value: string;
@@ -22,10 +22,12 @@ export default function CheckboxFilter({
   checkboxVariant
 }: CheckboxFilterProps) {
   return (
-    <div>
-      <Text variant='bold' smallScreen>
-        {title}
-      </Text>
+    <FilterFieldset>
+      <FilterFieldsetLegend>
+        <Text variant='bold' smallScreen>
+          {title}
+        </Text>
+      </FilterFieldsetLegend>
       {items.map(({ value, label }: Item) => (
         <FilterCheckbox
           key={value}
@@ -36,7 +38,7 @@ export default function CheckboxFilter({
           {label}
         </FilterCheckbox>
       ))}
-    </div>
+    </FilterFieldset>
   );
 
   function update(item: string, isSelected: boolean) {

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -23,6 +23,17 @@ export const DropdownWrapper = styled.div`
   }
 `;
 
+export const FilterFieldset = styled.fieldset`
+  margin: 0;
+  padding: 0;
+  border: none;
+`;
+
+export const FilterFieldsetLegend = styled.legend`
+  padding: 0;
+  line-height: 1;
+`;
+
 export const FilterCheckbox = styled(Checkbox)`
   font-size: ${props => props.theme.suomifi.typography.bodyTextSmall};
   padding-top: ${props => props.theme.suomifi.spacing.xs};
@@ -32,7 +43,7 @@ export const FilterRadioButton = styled(RadioButton)`
   font-size: ${props => props.theme.suomifi.typography.bodyTextSmall};
 `;
 
-export const FilterWrapper = styled.div<{ isModal: boolean }>`
+export const FilterSection = styled.section<{ isModal: boolean }>`
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   border: ${(props) => props.isModal ? 'none' : `solid 1px ${props.theme.suomifi.colors.depthLight1}`};
   height: max-content;
@@ -49,6 +60,12 @@ export const Header = styled.div`
   font-weight: 600;
   justify-content: space-between;
   padding: 25px 20px 25px;
+
+  h2 {
+    font-size: inherit;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 `;
 
 export const HeaderButton = styled(Button)`

--- a/src/common/components/filter/filter.tsx
+++ b/src/common/components/filter/filter.tsx
@@ -5,7 +5,7 @@ import SkipLink from '../skip-link/skip-link';
 import {
   CloseWrapper,
   FilterContent,
-  FilterWrapper,
+  FilterSection,
   Header,
   HeaderButton
 } from './filter.styles';
@@ -28,18 +28,20 @@ export function Filter({
 
   return (
     <div>
-      <SkipLink href="#search-results">
-        {t('skip-link-search-results')}
-      </SkipLink>
+      {!isModal && (
+        <SkipLink href="#search-results">
+          {t('skip-link-search-results')}
+        </SkipLink>
+      )}
 
-      <FilterWrapper isModal={isModal}>
+      <FilterSection isModal={isModal} aria-labelledby="filter-title">
         {renderTitle()}
         <FilterContent>
           <ResetAllFiltersButton />
           {children}
           {renderModalFooter()}
         </FilterContent>
-      </FilterWrapper>
+      </FilterSection>
     </div>
   );
 
@@ -47,14 +49,18 @@ export function Filter({
     if (!isModal) {
       return (
         <Header>
-          {t('vocabulary-filter-filter-list')}
+          <h2 id="filter-title">
+            {t('vocabulary-filter-filter-list')}
+          </h2>
         </Header>
       );
     }
 
     return (
       <Header>
-        {t('vocabulary-filter-filter-list')}
+        <h2 id="filter-title">
+          {t('vocabulary-filter-filter-list')}
+        </h2>
         <HeaderButton
           iconRight='close'
           onClick={onModalClose}

--- a/src/common/components/filter/keyword-filter.tsx
+++ b/src/common/components/filter/keyword-filter.tsx
@@ -37,7 +37,7 @@ export function KeywordFilter({
         onKeyDown={e => e.key === 'Enter' && update(inputValue)}
         value={inputValue}
         visualPlaceholder={visualPlaceholder}
-        fullWidth={isModal}
+        fullWidth
       />
     </div>
   );

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -47,7 +47,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           {t('vocabulary-info-terminological-dictionary')}
         </BasicBlock>
 
-        <Separator large />
+        <Separator isLarge />
 
         <BasicBlock
           title={t('vocabulary-info-vocabulary-export')}
@@ -68,7 +68,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           {t('vocabulary-info-vocabulary-export-description')}
         </BasicBlock>
 
-        <Separator large />
+        <Separator isLarge />
 
         <PropertyBlock
           title={t('vocabulary-info-organization')}

--- a/src/common/components/separator/index.tsx
+++ b/src/common/components/separator/index.tsx
@@ -1,9 +1,11 @@
-import styled from 'styled-components';
+import { StyledHr } from './separator.styles';
 
-const Separator = styled.hr<{ large?: boolean }>`
-  border: 0;
-  border-top: 1px solid ${props => props.theme.suomifi.colors.depthLight1};
-  margin: ${props => props.large ? '30px' : '20px'} 0;
-`;
+export interface SeparatorProps {
+  isLarge?: boolean;
+}
 
-export default Separator;
+export default function Separator({ isLarge = false }: SeparatorProps) {
+  return (
+    <StyledHr isLarge={isLarge} aria-hidden="true" />
+  );
+}

--- a/src/common/components/separator/separator.styles.tsx
+++ b/src/common/components/separator/separator.styles.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const StyledHr = styled.hr<{ isLarge?: boolean }>`
+  border: 0;
+  border-top: 1px solid ${props => props.theme.suomifi.colors.depthLight1};
+  margin: ${props => props.isLarge ? '30px' : '20px'} 0;
+`;

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -124,7 +124,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
           <DetailsExpander concept={concept} />
 
-          <Separator large />
+          <Separator isLarge />
 
           <PropertyBlock
             title={t('vocabulary-info-organization', { ns: 'common' })}
@@ -141,7 +141,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
             {concept?.uri}
           </BasicBlock>
 
-          <Separator large />
+          <Separator isLarge />
 
           <BasicBlock
             extra={

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -65,29 +65,6 @@ export default function TerminologySearch() {
         </FilterMobileButton>
       }
       <ResultAndFilterContainer>
-        <ResultAndStatsWrapper id="search-results">
-          {(showLoading && isFetching) || error
-            ?
-            <LoadIndicator isFetching={isFetching} error={error} refetch={refetch} />
-            :
-            data &&
-            <>
-              <SearchResults
-                data={data}
-                type="terminology-search"
-                organizations={organizations}
-                domains={groups}
-              />
-              <PaginationWrapper>
-                <Pagination
-                  data={data}
-                  pageString={t('pagination-page')}
-                />
-              </PaginationWrapper>
-            </>
-
-          }
-        </ResultAndStatsWrapper>
         {!isSmall
           ?
           <SearchPageFilter
@@ -115,6 +92,29 @@ export default function TerminologySearch() {
             </ModalContent>
           </Modal>
         }
+        <ResultAndStatsWrapper id="search-results">
+          {(showLoading && isFetching) || error
+            ?
+            <LoadIndicator isFetching={isFetching} error={error} refetch={refetch} />
+            :
+            data &&
+            <>
+              <SearchResults
+                data={data}
+                type="terminology-search"
+                organizations={organizations}
+                domains={groups}
+              />
+              <PaginationWrapper>
+                <Pagination
+                  data={data}
+                  pageString={t('pagination-page')}
+                />
+              </PaginationWrapper>
+            </>
+
+          }
+        </ResultAndStatsWrapper>
       </ResultAndFilterContainer>
     </>
   );

--- a/src/modules/terminology-search/terminology-search.styles.tsx
+++ b/src/modules/terminology-search/terminology-search.styles.tsx
@@ -7,7 +7,7 @@ export const FilterMobileButton = styled(Button)`
 
 export const ResultAndFilterContainer = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   flex-wrap: nowrap;
   gap: ${props => props.theme.suomifi.spacing.xl};
   justify-content: space-between;

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -94,6 +94,27 @@ export default function Vocabulary({ id }: VocabularyProps) {
         </FilterMobileButton>
       }
       <ResultAndFilterContainer>
+        {!isSmall
+          ?
+          <TerminologyListFilter counts={counts} />
+          :
+          <Modal
+            appElementId='__next'
+            visible={showModal}
+            onEscKeyDown={() => setShowModal(false)}
+            variant='smallScreen'
+            style={{ border: 'none' }}
+          >
+            <ModalContent style={{ padding: '0' }}>
+              <TerminologyListFilter
+                isModal
+                onModalClose={() => setShowModal(false)}
+                resultCount={concepts?.totalHitCount}
+                counts={counts}
+              />
+            </ModalContent>
+          </Modal>
+        }
         <ResultAndStatsWrapper id="search-results">
           {urlState.type === 'concept' &&
             (
@@ -143,27 +164,6 @@ export default function Vocabulary({ id }: VocabularyProps) {
             )
           }
         </ResultAndStatsWrapper>
-        {!isSmall
-          ?
-          <TerminologyListFilter counts={counts} />
-          :
-          <Modal
-            appElementId='__next'
-            visible={showModal}
-            onEscKeyDown={() => setShowModal(false)}
-            variant='smallScreen'
-            style={{ border: 'none' }}
-          >
-            <ModalContent style={{ padding: '0' }}>
-              <TerminologyListFilter
-                isModal
-                onModalClose={() => setShowModal(false)}
-                resultCount={concepts?.totalHitCount}
-                counts={counts}
-              />
-            </ModalContent>
-          </Modal>
-        }
       </ResultAndFilterContainer>
     </>
   );

--- a/src/modules/vocabulary/vocabulary.styles.tsx
+++ b/src/modules/vocabulary/vocabulary.styles.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const ResultAndFilterContainer = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   flex-wrap: nowrap;
   gap: ${props => props.theme.suomifi.spacing.xl};
   justify-content: space-between;


### PR DESCRIPTION
- Make filter panel act as a region
- Filter header is h2
- Move filter before search results
- Group checkboxes into fieldset with legend
- Hide separators from screen readers

Note. No visual changes in this PR.

YTI-1690