### PR TITLE
Fix some accessibility issues from search results

### DIFF
--- a/src/common/components/search-results/search-results.styles.tsx
+++ b/src/common/components/search-results/search-results.styles.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import { Heading, Icon, Link, StaticChip, Text } from 'suomifi-ui-components';
+import { Icon, Link, Paragraph, StaticChip, Text } from 'suomifi-ui-components';
 import { CardChipProps } from './search-count-tags.props';
 
-export const Card = styled.div`
+export const Card = styled.li`
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   border-bottom: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
   display: flex;
@@ -34,21 +34,21 @@ export const CardConcepts = styled(Text)`
   }
 `;
 
-export const CardContributor = styled(Text)`
+export const CardContributor = styled(Paragraph)`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
   font-size: 14px;
   margin-bottom: ${props => props.theme.suomifi.spacing.xxs};
 `;
 
-export const CardDescription = styled(Text)`
+export const CardDescription = styled(Paragraph)`
 
 `;
 
-export const CardInfoDomain = styled(Text)`
+export const CardInfoDomain = styled(Paragraph)`
   margin-top: ${props => props.theme.suomifi.spacing.s};
 `;
 
-export const CardSubtitle = styled(Text)`
+export const CardSubtitle = styled(Paragraph)`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
   display: flex;
   font-size: 12px;
@@ -58,8 +58,11 @@ export const CardSubtitle = styled(Text)`
   text-transform: uppercase;
 `;
 
-export const CardTitle = styled(Heading)`
+export const CardTitle = styled.h2`
   color: inherit;
+  font-size: 22px;
+  line-height: 28px;
+  margin: 0;
 `;
 
 export const CardTitleWrapper = styled.div`
@@ -81,10 +84,12 @@ export const CardTitleLink = styled(Link)`
   gap: ${props => props.theme.suomifi.spacing.xs};
 `;
 
-export const CardWrapper = styled.div<{ isSmall: boolean }>`
+export const CardWrapper = styled.ul<{ isSmall: boolean }>`
   border-top: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
   border-right:  ${props => props.isSmall ? 'none' : `1px solid ${props.theme.suomifi.colors.depthLight1}`};
   border-left: ${props => props.isSmall ? 'none' : `1px solid ${props.theme.suomifi.colors.depthLight1}`};
   margin-left: -${props => props.isSmall ? props.theme.suomifi.spacing.s : '0'};
   margin-right: -${props => props.isSmall ? props.theme.suomifi.spacing.s : '0'};
+  padding: 0;
+  margin-top: 0;
 `;

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -174,7 +174,9 @@ export default function SearchResults({ data, type, organizations, domains }: Se
                     </CardTitle>
 
                     <CardSubtitle>
-                      {t('vocabulary-info-concept')} &middot; {t(`${concept.status}`)}
+                      <div>{t('vocabulary-info-concept')}</div>
+                      <span aria-hidden="true">&middot;</span>
+                      <div>{t(`${concept.status}`)}</div>
                     </CardSubtitle>
 
                     <CardDescription>

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -23,6 +23,7 @@ import {
 import { Concept } from '../../interfaces/concept.interface';
 import useUrlState from '../../utils/hooks/useUrlState';
 import SanitizedTextContent from '../sanitized-text-content';
+import { VisuallyHidden } from 'suomifi-ui-components';
 
 interface SearchResultsProps {
   data: TerminologySearchResult | VocabularyConcepts | Collection[];
@@ -69,9 +70,9 @@ export default function SearchResults({ data, type, organizations, domains }: Se
             renderQBeforeStatus
           />
           <CardWrapper isSmall={isSmall}>
-            {data?.terminologies?.map((terminology, idx: number) => {
+            {data?.terminologies?.map(terminology => {
               return (
-                <Card key={`search-result-${idx}`}>
+                <Card key={terminology.id}>
                   <CardContributor>
                     {terminology.contributors[0].label[i18n.language]
                       ?? terminology.contributors[0].label['fi']
@@ -83,24 +84,32 @@ export default function SearchResults({ data, type, organizations, domains }: Se
                     <Link passHref href={'/terminology/' + terminology.id}>
                       <CardTitleLink href=''>
                         <CardTitleIcon icon='registers' />
-                        <CardTitle variant='h3'>
+                        <CardTitle>
                           {terminology.label[i18n.language]
                             ?
                             terminology.label[i18n.language].replaceAll(/<\/*[^>]>/g, '')
                             :
                             terminology?.label?.[Object.keys(terminology.label)[0]].replaceAll(/<\/*[^>]>/g, '')
                           }
+                          <VisuallyHidden>
+                            {terminology.contributors[0].label[i18n.language]
+                              ?? terminology.contributors[0].label['fi']
+                              ?? ''
+                            }
+                          </VisuallyHidden>
                         </CardTitle>
                       </CardTitleLink>
                     </Link>
                   </CardTitleWrapper>
 
                   <CardSubtitle>
-                    <span>{t('terminology-search-results-terminology')}</span>
-                    <span>&middot;</span>
-                    <CardChip valid={terminology.status === 'VALID' ? 'true' : undefined}>
-                      {t(terminology.status ?? '')}
-                    </CardChip>
+                    <div>{t('terminology-search-results-terminology')}</div>
+                    <span aria-hidden="true">&middot;</span>
+                    <div>
+                      <CardChip valid={terminology.status === 'VALID' ? 'true' : undefined}>
+                        {t(terminology.status ?? '')}
+                      </CardChip>
+                    </div>
                   </CardSubtitle>
 
                   <CardDescription>
@@ -121,7 +130,7 @@ export default function SearchResults({ data, type, organizations, domains }: Se
                     </b>
                     {terminology.informationDomains.map((term, i: number) => {
                       let comma = i !== terminology.informationDomains.length - 1 ? ',' : '';
-                      return <span key={`term-label-${term}-${i}`}> {term.label[i18n.language]}{comma}</span>;
+                      return <span key={term.id}> {term.label[i18n.language]}{comma}</span>;
                     })}
                   </CardInfoDomain>
                 </Card>
@@ -148,10 +157,10 @@ export default function SearchResults({ data, type, organizations, domains }: Se
               domains={domains}
             />
             <CardWrapper isSmall={isSmall}>
-              {data?.concepts.map((concept, idx) => {
+              {data?.concepts.map(concept => {
                 return (
-                  <Card key={`search-result-${idx}`}>
-                    <CardTitle variant='h2'>
+                  <Card key={concept.id}>
+                    <CardTitle>
                       <Link passHref href={`/terminology/${concept.terminology.id}/concept/${concept.id}`}>
                         <CardTitleLink href=''>
                           {concept.label[i18n.language]
@@ -213,8 +222,8 @@ export default function SearchResults({ data, type, organizations, domains }: Se
             }
 
             return (
-              <Card key={`search-result-${idx}`}>
-                <CardTitle variant='h2'>
+              <Card key={collection.id}>
+                <CardTitle>
                   <Link passHref href={`/terminology/${collection.type.graph.id}/collection/${collection.id}`}>
                     <CardTitleLink href=''>
                       <PropertyValue property={collection.properties.prefLabel} fallbackLanguage='fi' />


### PR DESCRIPTION
- Convert search results to list
- Use h2 as a card heading instead of h3
- Use p and div instead of span so that screen reader will not read
  everything by once.
- Add organization name after card heading for screen readers

Note. No visual changes in this PR.

YTI-1695