### PR TITLE
Yti 1704 improving footer

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -109,5 +109,6 @@
   "try-again": "Try again",
   "skip-link-main": "Go directly to contents.",
   "skip-link-search-results": "Go directly to search results.",
-  "navigated-to": "Navigated to"
+  "navigated-to": "Navigated to",
+  "site-open-new-email": "Open a new email to"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -102,5 +102,6 @@
   "try-again": "Yritä uudestaan",
   "skip-link-main": "Siirry suoraan sisältöön.",
   "skip-link-search-results": "Siirry suoraan hakutuloksiin.",
-  "navigated-to": "Siirrytty sivulle"
+  "navigated-to": "Siirrytty sivulle",
+  "site-open-new-email": "Aloita uuden sähköpostin kirjoitus osoitteeseen"
 }

--- a/src/common/components/footer/footer.tsx
+++ b/src/common/components/footer/footer.tsx
@@ -18,7 +18,7 @@ export default function Footer({ feedbackSubject }: FooterProps) {
   return (
     <>
       <FooterContentWrapper>
-        <Image src="/logo-suomi.fi.png" width="254" height="70" alt="Logo" />
+        <Image src="/logo-suomi.fi.png" width="254" height="70" alt="" aria-hidden />
         <Paragraph>
           <Text>{t('terminology-footer-text')}</Text>
         </Paragraph>
@@ -27,24 +27,24 @@ export default function Footer({ feedbackSubject }: FooterProps) {
       <FooterLinkWrapper breakpoint={breakpoint}>
         <ExternalLink
           href={`mailto:yhteentoimivuus@dvv.fi?subject=${subject}`}
-          labelNewWindow={t('site-open-link-new-window')}
+          labelNewWindow={`${t('site-open-new-email')} yhteentoimivuus@dvv.fi`}
         >
           {t('terminology-footer-feedback')}
         </ExternalLink>
         <ExternalLink
           href="https://wiki.dvv.fi/display/YTIJD/Tietosuojaseloste"
-          labelNewWindow={t('site-open-link-new-window')}
+          labelNewWindow={`${t('site-open-link-new-window')} wiki.dvv.fi/Tietosuojaseloste`}
         >
           {t('terminology-footer-information-security')}
         </ExternalLink>
         <ExternalLink
           href="https://wiki.dvv.fi/display/YTIJD/Saavutettavuusseloste"
-          labelNewWindow={t('site-open-link-new-window')}
+          labelNewWindow={`${t('site-open-link-new-window')} wiki.dvv.fi/Saavutettavuusseloste`}
         >
           {t('terminology-footer-accessibility')}
         </ExternalLink>
       </FooterLinkWrapper>
-      <VersionInfo>
+      <VersionInfo aria-hidden>
         {publicRuntimeConfig?.versionInfo}
       </VersionInfo>
     </>

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -25,7 +25,10 @@ export default function Title({ info }: TitleProps) {
       language: i18n.language,
       fallbackLanguage: 'fi'
     }) ?? '';
-  dispatch(setTitle(title));
+
+  useEffect(() => {
+    dispatch(setTitle(title));
+  }, [dispatch, title]);
 
   useEffect(() => {
     if (titleRef.current) {

--- a/src/modules/footer/index.tsx
+++ b/src/modules/footer/index.tsx
@@ -4,6 +4,10 @@ import Image from 'next/image';
 import { FooterContentWrapper, FooterLinkWrapper } from './footer.style';
 import { useBreakpoints } from '../../common/components/media-query/media-query-context';
 
+/**
+ * @deprecated | use footer from ~/common/components
+ */
+
 export default function Footer() {
   const { t } = useTranslation('common');
   const { breakpoint } = useBreakpoints();


### PR DESCRIPTION
Changes in this PR:
- Footer logo and version info are hidden from screen readers
- External links describe to screen readers which service the user is opening the link to
- Email receiver information is added to screen reader
- Fixed a bug with `<Title>` state