### PR TITLE
Added 'broader' and 'related' as internal links

### DIFF
--- a/src/common/components/sanitized-text-content/index.tsx
+++ b/src/common/components/sanitized-text-content/index.tsx
@@ -15,6 +15,7 @@ interface ChildType extends ChildNode {
 
 export default function SanitizedTextContent({ text }: TextLinksProps) {
   const { t } = useTranslation('common');
+  const internalTypes = ['broader', 'internal', 'related'];
   const htmlChildNodes = new DOMParser().parseFromString(text, 'text/html').children[0].children[1].childNodes;
 
   const children = Array.from(htmlChildNodes).map((child: ChildType, idx: number) => {
@@ -27,7 +28,7 @@ export default function SanitizedTextContent({ text }: TextLinksProps) {
         return <span key={`${child.textContent}-${idx}`}>{child.textContent}</span>;
       }
 
-      if (child.dataset?.type === 'internal') {
+      if (child.dataset?.type && internalTypes.includes(child.dataset.type)) {
         return (
           <Link
             passHref

--- a/src/common/components/sanitized-text-content/sanitized-text-content.test.tsx
+++ b/src/common/components/sanitized-text-content/sanitized-text-content.test.tsx
@@ -17,21 +17,31 @@ describe('text-links', () => {
     expect(screen.queryByText('This is a test')).not.toHaveAttribute('href');
   });
 
-  test('should render component with internal link', () => {
+  test('should render component with different internal link', () => {
 
     render(
       <ThemeProvider theme={lightTheme}>
         <SanitizedTextContent text={
-          'This is a <a href=\'https://uri.suomi.fi/terminology/demo/concept-001\' data-type=\'internal\'>test</a> with a link'
+          `This is a <a href=\'https://uri.suomi.fi/terminology/demo/concept-001\' data-type=\'internal\'>internal test</a> with link.
+           This is a <a href=\'https://uri.suomi.fi/terminology/demo/concept-002\' data-type=\'broader\'>broader test</a> with link.
+           This is a <a href=\'https://uri.suomi.fi/terminology/demo/concept-003\' data-type=\'related\'>related test</a> with link.
+          `
         } />
       </ThemeProvider>
     );
 
-    expect(screen.queryByText('This is a')).toBeTruthy();
-    expect(screen.queryByText('test')).toBeTruthy();
-    expect(screen.queryByText('test')).toHaveAttribute('href');
-    expect(screen.queryByText('test')).not.toHaveClass('fi-link--external');
-    expect(screen.queryByText('with a link')).toBeTruthy();
+    expect(screen.queryByText('internal test')).toBeTruthy();
+    expect(screen.queryByText('internal test')).toHaveAttribute('href');
+    expect(screen.queryByText('internal test')).not.toHaveClass('fi-link--external');
+
+    expect(screen.queryByText('broader test')).toBeTruthy();
+    expect(screen.queryByText('broader test')).toHaveAttribute('href');
+    expect(screen.queryByText('broader test')).not.toHaveClass('fi-link--external');
+
+    expect(screen.queryByText('related test')).toBeTruthy();
+    expect(screen.queryByText('related test')).toHaveAttribute('href');
+    expect(screen.queryByText('related test')).not.toHaveClass('fi-link--external');
+
   });
 
   test('should render component with external link', () => {


### PR DESCRIPTION
Changes in this PR:
- Added two missing internal link data types and fixed unit tests 