### PR TITLE
Sidebar empty state

### DIFF
--- a/src/common/components/sidebar/sidebar.styles.tsx
+++ b/src/common/components/sidebar/sidebar.styles.tsx
@@ -7,6 +7,10 @@ export const SidebarWrapper = styled.aside<{ breakpoint: Breakpoint }>`
   background-color: ${props => props.theme.suomifi.colors.depthSecondary};
   max-width: ${props => small(props.breakpoint, '100%', '374px')};
   padding: ${props => props.theme.suomifi.spacing.m};
+
+  &[aria-hidden=true] {
+    padding: 0;
+  }
 `;
 
 export const SidebarHeader = styled.h1`

--- a/src/common/components/sidebar/sidebar.tsx
+++ b/src/common/components/sidebar/sidebar.tsx
@@ -4,13 +4,14 @@ import { SidebarWrapper } from './sidebar.styles';
 
 export interface SidebarProps {
   children: React.ReactNode;
+  isEmpty?: boolean;
 };
 
-export default function Sidebar({ children }: SidebarProps) {
+export default function Sidebar({ children, isEmpty }: SidebarProps) {
   const { breakpoint } = useBreakpoints();
 
   return (
-    <SidebarWrapper breakpoint={breakpoint}>
+    <SidebarWrapper breakpoint={breakpoint} aria-hidden={isEmpty}>
       {children}
     </SidebarWrapper>
   );

--- a/src/modules/collection/collection-sidebar.tsx
+++ b/src/modules/collection/collection-sidebar.tsx
@@ -19,11 +19,16 @@ export default function CollectionSidebar({ collection }: CollectionSidebarProps
   const { data: collections } = useGetCollectionsQuery(terminologyId);
   const otherCollections = collections?.filter(other => other.id !== collection.id);
 
-  return (
-    <Sidebar>
-      <SidebarHeader>{t('sidebar-header')}</SidebarHeader>
+  const isEmpty = otherCollections?.length === 0;
 
-      <Separator />
+  return (
+    <Sidebar isEmpty={isEmpty}>
+      {!isEmpty && (
+        <>
+          <SidebarHeader>{t('sidebar-header')}</SidebarHeader>
+          <Separator />
+        </>
+      )}
 
       <SidebarSection<Collection>
         heading={t('sidebar-section-heading-other-collections')}
@@ -31,12 +36,6 @@ export default function CollectionSidebar({ collection }: CollectionSidebarProps
         href={({ id }) => `/terminology/${terminologyId}/collection/${id}`}
         propertyAccessor={collection => collection.properties?.prefLabel}
       />
-
-      {otherCollections?.length === 0 && (
-        <>
-          TODO: Empty state
-        </>
-      )}
     </Sidebar>
   );
 };

--- a/src/modules/concept/concept-sidebar.tsx
+++ b/src/modules/concept/concept-sidebar.tsx
@@ -37,11 +37,13 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
     concept?.referrers.member
   ].flat().filter(Boolean).length > 0;
 
-  const shouldRenderEmptyState = !shouldRenderDivider1 && !shouldRenderDivider2 && !shouldRenderDivider3;
+  const isEmpty = !shouldRenderDivider1 && !shouldRenderDivider2 && !shouldRenderDivider3;
 
   return (
-    <Sidebar>
-      <SidebarHeader>{t('sidebar-header')}</SidebarHeader>
+    <Sidebar isEmpty={isEmpty}>
+      {!isEmpty && (
+        <SidebarHeader>{t('sidebar-header')}</SidebarHeader>
+      )}
 
       {shouldRenderDivider1 && <Separator />}
 
@@ -130,14 +132,6 @@ export default function ConceptSidebar({ concept }: ConceptSidebarProps) {
         href={({ id }) => `/terminology/${terminologyId}/collection/${id}`}
         propertyAccessor={({ properties }) => properties?.prefLabel}
       />
-
-      {shouldRenderEmptyState && (
-        <>
-          <Separator />
-
-          TODO: Empty state
-        </>
-      )}
     </Sidebar>
   );
 };


### PR DESCRIPTION
When sidebar is empty, it is rendered as an empty aside box in
desktop mode. In mobile, it is still hidden.

As it is only empty aside box, it is hidden from screen readers.

Empty sidebar in desktop mode:
![image](https://user-images.githubusercontent.com/1504091/156182411-ec67b19d-779b-48a3-b85a-c4362f6cec6d.png)

YTI-1665