### PR TITLE
Fix some a11y issues from multiple pages

### DIFF
--- a/public/locales/en/collection.json
+++ b/public/locales/en/collection.json
@@ -1,6 +1,5 @@
 {
   "description": "Collection is a way to group concepts related to the same topic.",
-  "field-broader": "Broader concepts of concepts in the collection",
   "field-definition": "Definition",
   "field-member": "Concepts in the collection",
   "field-name": "Name",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "additional-technical-information": "Additional technical information",
   "terminology-search": "Search",
   "terminology-title": "Terminologies",
   "datamodel-title": "Data Vocabularies",

--- a/public/locales/fi/collection.json
+++ b/public/locales/fi/collection.json
@@ -1,6 +1,5 @@
 {
   "description": "Käsitekokoelma on tapa ryhmitellä tietyn aihepiirin käsitteitä.",
-  "field-broader": "Valikoimaan kuuluvien käsitteiden yläkäsitteet",
   "field-definition": "Kuvaus",
   "field-member": "Valikoimaan kuuluvat käsitteet",
   "field-name": "Nimi",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,4 +1,5 @@
 {
+  "additional-technical-information": "Tekniset lisätiedot",
   "terminology-search": "Haku",
   "terminology-title": "Sanastot",
   "datamodel-title": "Tietomallit",

--- a/src/common/components/block/block.styles.tsx
+++ b/src/common/components/block/block.styles.tsx
@@ -15,6 +15,12 @@ export const BasicBlockWrapper = styled.div<{ largeGap?: boolean }>`
 
 export const BasicBlockHeader = styled.div`
   font-weight: 600;
+
+  h2 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+  }
 `;
 
 export const BasicBlockExtraWrapper = styled.div`

--- a/src/common/components/block/concept-list-block.tsx
+++ b/src/common/components/block/concept-list-block.tsx
@@ -16,6 +16,10 @@ export default function ConceptListBlock({
   data,
   extra,
 }: ConceptListBlockProps) {
+  if (!data?.length) {
+    return null;
+  }
+  
   return (
     <BasicBlock title={title} extra={extra}>
       <List>

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Button, ExpanderContent, ExpanderTitleButton } from 'suomifi-ui-components';
+import { Button, ExpanderContent, ExpanderTitleButton, VisuallyHidden } from 'suomifi-ui-components';
 import { InfoExpanderWrapper } from './info-expander.styles';
 import { VocabularyInfoDTO } from '../../interfaces/vocabulary.interface';
 import Separator from '../separator';
@@ -69,6 +69,11 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         </BasicBlock>
 
         <Separator isLarge />
+
+
+        <VisuallyHidden as="h3">
+          {t('additional-technical-information', { ns: 'common' })}
+        </VisuallyHidden>
 
         <PropertyBlock
           title={t('vocabulary-info-organization')}

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import React, { useEffect, useRef } from 'react';
-import { Heading, Text } from 'suomifi-ui-components';
+import { Heading, Text, VisuallyHidden } from 'suomifi-ui-components';
 import { setAlert } from '../../common/components/alert/alert.slice';
 import { BasicBlock, MultilingualPropertyBlock, PropertyBlock } from '../../common/components/block';
 import { ConceptListBlock } from '../../common/components/block';
@@ -122,15 +122,15 @@ export default function Collection({ terminologyId, collectionId, setCollectionT
             data={collection?.properties.definition}
           />
           <ConceptListBlock
-            title={t('field-broader')}
-            data={collection?.references.broader}
-          />
-          <ConceptListBlock
-            title={t('field-member')}
+            title={<h2>{t('field-member')}</h2>}
             data={collection?.references.member}
           />
 
           <Separator />
+
+          <VisuallyHidden as="h2">
+            {t('additional-technical-information', { ns: 'common' })}
+          </VisuallyHidden>
 
           <PropertyBlock
             title={t('vocabulary-info-organization', { ns: 'common' })}

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import React, { useEffect, useRef } from 'react';
-import { ExternalLink, Heading, Text } from 'suomifi-ui-components';
+import { ExternalLink, Heading, Text, VisuallyHidden } from 'suomifi-ui-components';
 import {
   BasicBlock,
   MultilingualPropertyBlock,
@@ -136,7 +136,7 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
           </HeadingBlock>
 
           <MultilingualPropertyBlock
-            title={t('field-definition')}
+            title={<h2>{t('field-definition')}</h2>}
             data={concept?.properties.definition}
           />
           <MultilingualPropertyBlock
@@ -144,7 +144,7 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
             data={concept?.properties.example}
           />
           <TermBlock
-            title={t('field-terms-label')}
+            title={<h2>{t('field-terms-label')}</h2>}
             data={[
               ...(concept?.references.prefLabelXl ?? []).map(term => ({ term, type: t('field-terms-preferred') })),
               ...(concept?.references.altLabelXl ?? []).map(term => ({ term, type: t('field-terms-alternative') })),
@@ -153,6 +153,7 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
               ...(concept?.references.hiddenTerm ?? []).map(term => ({ term, type: t('field-terms-hidden') })),
             ]}
           />
+
           <MultilingualPropertyBlock
             title={t('field-note')}
             data={concept?.properties.note}
@@ -161,6 +162,10 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
           <DetailsExpander concept={concept} />
 
           <Separator isLarge />
+
+          <VisuallyHidden as="h2">
+            {t('additional-technical-information', { ns: 'common' })}
+          </VisuallyHidden>
 
           <PropertyBlock
             title={t('vocabulary-info-organization', { ns: 'common' })}


### PR DESCRIPTION
- Remove broader concepts section from collection page.
- Hide heading of collection members if the list is empty.
- Convert some detail headings into actual h2 and h3 elements.
- Add additional technical information heading for screen readers
  in all pages.

YTI-1714, YTI-1703, YTI-1705, YTI-1725