### PR TITLE
Fixed modal button and chip styles

### DIFF
--- a/src/common/components/term-modal/index.tsx
+++ b/src/common/components/term-modal/index.tsx
@@ -132,7 +132,6 @@ export default function TermModal({ data }: TermModalProps) {
         */}
         <TermModalChip
           aria-disabled={true}
-          disabled={true}
           isvalid={value[0].value === 'VALID' ? 'true' : undefined}
         >
           {t(getPropertyValue({ property: value }) ?? '', { ns: 'common' })}

--- a/src/common/components/term-modal/term-modal.style.tsx
+++ b/src/common/components/term-modal/term-modal.style.tsx
@@ -1,25 +1,31 @@
 import styled from 'styled-components';
-import { Button, Chip, Heading, Text } from 'suomifi-ui-components';
+import { Button, Heading, Text } from 'suomifi-ui-components';
 
 export const TermHeading = styled(Heading)`
   font-size: 16px !important;
 `;
 
 export const TermModalButton = styled(Button)`
+  font-size: 16px;
+  font-weight: 400;
   padding: 0;
   min-height: auto;
 `;
 
-export const TermModalChip = styled(Chip)<{ isvalid?: string }>`
-  background: ${props => props.isvalid === 'true' ? props.theme.suomifi.colors.successBase : props.theme.suomifi.colors.depthDark2} !important;
-  display: grid;
+export const TermModalChip = styled.span<{ isvalid?: string }>`
+  align-items: center;
+  background: ${props => props.isvalid === 'true' ? props.theme.suomifi.colors.successBase : props.theme.suomifi.colors.depthDark2};
+  border-radius: 10px;
+  display: flex;
+  color: ${props => props.theme.suomifi.colors.whiteBase};
   font-size: 12px;
   height: 18px;
   margin-top: 5px;
   margin-bottom: 20px;
   max-width: min-content;
-  padding: 0px 5px !important;
+  padding: 0px 5px;
   text-transform: uppercase;
+  white-space: nowrap;
 `;
 
 export const TermText = styled(Text)`


### PR DESCRIPTION
Changes in this PR:
- Fixed styling for Button and Chip. Chip was changed from suomifi-components Chip to span

Font style is now same with other similar components:
![image](https://user-images.githubusercontent.com/82932696/156974945-48d76d5c-d23a-4bbe-b5f5-3ef01301bc93.png)