### PR TITLE
Fix some i18n issues from page title

### DIFF
--- a/src/common/components/block/concept-list-block.tsx
+++ b/src/common/components/block/concept-list-block.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'suomifi-ui-components';
 import { BasicBlock } from '.';
 import { Concept } from '../../interfaces/concept.interface';
+import { getProperty } from '../../utils/get-property';
 import PropertyValue from '../property-value';
 import { List } from './block.styles';
 
@@ -16,6 +17,10 @@ export default function ConceptListBlock({
   data,
   extra,
 }: ConceptListBlockProps) {
+  if (!data?.length) {
+    return null;
+  }
+
   return (
     <BasicBlock title={title} extra={extra}>
       <List>
@@ -25,7 +30,7 @@ export default function ConceptListBlock({
               href={`/terminology/${concept.identifier.type.graph.id}/concept/${concept.id}`}
             >
               <PropertyValue
-                property={concept.references.prefLabelXl?.[0].properties.prefLabel}
+                property={getProperty('prefLabel', concept.references.prefLabelXl)}
                 fallbackLanguage='fi'
               />
             </Link>

--- a/src/common/components/page-title/index.tsx
+++ b/src/common/components/page-title/index.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'next-i18next';
+import Title from './title';
+
+export interface PageTitleProps {
+  title?: string | (string | undefined)[];
+  siteTitle?: string;
+}
+
+export default function PageTitle({ title, siteTitle }: PageTitleProps) {
+  const { t } = useTranslation();
+  const defaultSiteTitle = t('site-title');
+
+  if (! Array.isArray(title)) {
+    title = [title];
+  }
+
+  return (
+    <Title parts={[
+      ...title,
+      siteTitle ?? defaultSiteTitle
+    ]} />
+  );
+}
+

--- a/src/common/components/page-title/title.tsx
+++ b/src/common/components/page-title/title.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+
+export interface TitleProps {
+  parts?: (string | undefined)[];
+}
+
+export default function Title({ parts }: TitleProps) {
+  return (
+    <Head>
+      <title>
+        {parts?.filter(Boolean).join(' | ')}
+      </title>
+    </Head>
+  );
+}
+

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -7,6 +7,7 @@ import { getPropertyValue } from '../property-value/get-property-value';
 import { useStoreDispatch } from '../../../store';
 import { setTitle } from './title.slice';
 import { useEffect, useRef } from 'react';
+import { getProperty } from '../../utils/get-property';
 
 interface TitleProps {
   info: string | VocabularyInfoDTO;
@@ -53,7 +54,7 @@ export default function Title({ info }: TitleProps) {
     const status = info.properties.status?.[0].value ?? '';
 
     const contributor = getPropertyValue({
-      property: info.references.contributor?.[0].properties.prefLabel,
+      property: getProperty('prefLabel', info.references.contributor),
       language: i18n.language,
       fallbackLanguage: 'fi'
     }) ?? '';

--- a/src/common/utils/get-property.test.ts
+++ b/src/common/utils/get-property.test.ts
@@ -1,0 +1,52 @@
+import { Organization } from '../interfaces/organization.interface';
+import { Term } from '../interfaces/term.interface';
+import { getProperty } from './get-property';
+
+describe('getProperty', () => {
+  test('should work with Term', () => {
+    const items: Term[] = [{ properties: {} }] as Term[];
+
+    expect(getProperty('prefLabel', items)).toEqual([]);
+  });
+
+  test('should work with Organization', () => {
+    const items: Organization[] = [{ properties: {} }] as Organization[];
+
+    expect(getProperty('prefLabel', items)).toEqual([]);
+  });
+
+  test('should return correct property', () => {
+    const items: Term[] = [
+      {
+        properties: {
+          prefLabel: [{ value: 'A' }],
+          changeNote: [{ value: 'B' }],
+        },
+      },
+    ] as Term[];
+
+    expect(getProperty('prefLabel', items)).toEqual([
+      { value: 'A' },
+    ]);
+  });
+
+  test('should merge properties of multiple items', () => {
+    const items: Term[] = [
+      {
+        properties: {
+          prefLabel: [{ value: 'A' }],
+        },
+      },
+      {
+        properties: {
+          prefLabel: [{ value: 'B' }],
+        },
+      },
+    ] as Term[];
+
+    expect(getProperty('prefLabel', items)).toEqual([
+      { value: 'A' },
+      { value: 'B' },
+    ]);
+  });
+});

--- a/src/common/utils/get-property.ts
+++ b/src/common/utils/get-property.ts
@@ -1,0 +1,23 @@
+import { Organization } from '../interfaces/organization.interface';
+import { Term } from '../interfaces/term.interface';
+import { Property } from '../interfaces/termed-data-types.interface';
+
+export function getProperty(
+  propertyName: keyof Term['properties'],
+  items?: Term[]
+): Property[];
+
+export function getProperty(
+  propertyName: keyof Organization['properties'],
+  items?: Organization[]
+): Property[];
+
+export function getProperty(propertyName: string, items?: any[]) {
+  if (!items?.length) {
+    return [];
+  }
+
+  return items
+    ?.flatMap(item => item.properties[propertyName])
+    .filter((item): item is Property => !!item);
+}

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import React from 'react';
-import { Block } from 'suomifi-ui-components';
 import { ThemeProvider } from 'styled-components';
 import { lightTheme } from './theme';
 import {

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -18,11 +18,12 @@ import { useStoreDispatch } from '../../store';
 import CollectionSidebar from './collection-sidebar';
 import { BadgeBar, HeadingBlock, MainContent, PageContent } from './collection.styles';
 import { setTitle } from '../../common/components/title/title.slice';
+import { getProperty } from '../../common/utils/get-property';
 
 interface CollectionProps {
   terminologyId: string;
   collectionId: string;
-  setCollectionTitle: (title: string) => void;
+  setCollectionTitle: (title?: string) => void;
 }
 
 export default function Collection({ terminologyId, collectionId, setCollectionTitle }: CollectionProps) {
@@ -38,13 +39,14 @@ export default function Collection({ terminologyId, collectionId, setCollectionT
     router.push('/404');
   }
 
+  const prefLabel = getPropertyValue({
+    property: collection?.properties.prefLabel,
+    language: i18n.language,
+    fallbackLanguage: 'fi'
+  });
   useEffect(() => {
-    setCollectionTitle(getPropertyValue({
-      property: collection?.properties.prefLabel,
-      language: i18n.language,
-      fallbackLanguage: 'fi'
-    }) ?? '');
-  }, [collection]);
+    setCollectionTitle(prefLabel);
+  }, [setCollectionTitle, prefLabel]);
 
   useEffect(() => {
     dispatch(setAlert([
@@ -55,15 +57,9 @@ export default function Collection({ terminologyId, collectionId, setCollectionT
 
   useEffect(() => {
     if (collection) {
-      const title = getPropertyValue({
-        property: collection?.properties.prefLabel,
-        language: i18n.language,
-        fallbackLanguage: 'fi'
-      }) ?? '';
-
-      dispatch(setTitle(title));
+      dispatch(setTitle(prefLabel ?? ''));
     }
-  }, [collection, dispatch, i18n.language]);
+  }, [collection, dispatch, prefLabel]);
 
   useEffect(() => {
     if (titleRef.current) {
@@ -97,7 +93,7 @@ export default function Collection({ terminologyId, collectionId, setCollectionT
           <HeadingBlock>
             <Text>
               <PropertyValue
-                property={terminology?.references.contributor?.[0].properties.prefLabel}
+                property={getProperty('prefLabel', terminology?.references.contributor)}
                 fallbackLanguage='fi'
               />
             </Text>

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -28,13 +28,13 @@ import { useStoreDispatch } from '../../store';
 import { setAlert } from '../../common/components/alert/alert.slice';
 import { Error } from '../../common/interfaces/error.interface';
 import { useRouter } from 'next/router';
-import { Property } from '../../common/interfaces/termed-data-types.interface';
 import { setTitle } from '../../common/components/title/title.slice';
+import { getProperty } from '../../common/utils/get-property';
 
 export interface ConceptProps {
   terminologyId: string;
   conceptId: string;
-  setConceptTitle: (title: string) => void;
+  setConceptTitle: (title?: string) => void;
 }
 
 export default function Concept({ terminologyId, conceptId, setConceptTitle }: ConceptProps) {
@@ -44,20 +44,21 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
   const { t, i18n } = useTranslation('concept');
   const dispatch = useStoreDispatch();
   const router = useRouter();
-  const conceptTitles = (concept?.references.prefLabelXl?.map(plxl => plxl.properties.prefLabel).map(item => item?.[0]) ?? []) as Property[];
   const titleRef = useRef<HTMLHeadingElement>(null);
 
   if (conceptError && 'status' in conceptError && conceptError.status === 404) {
     router.push('/404');
   }
 
+  const prefLabel = getPropertyValue({
+    property: getProperty('prefLabel', concept?.references.prefLabelXl),
+    language: i18n.language,
+    fallbackLanguage: 'fi'
+  });
+
   useEffect(() => {
-    setConceptTitle(getPropertyValue({
-      property: concept?.references.prefLabelXl?.[0].properties.prefLabel,
-      language: i18n.language,
-      fallbackLanguage: 'fi'
-    }) ?? '');
-  }, [concept]);
+    setConceptTitle(prefLabel);
+  }, [setConceptTitle, prefLabel]);
 
   useEffect(() => {
     dispatch(setAlert([
@@ -68,15 +69,9 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
 
   useEffect(() => {
     if (concept) {
-      const title = getPropertyValue({
-        property: concept.references.prefLabelXl?.[0].properties.prefLabel,
-        language: i18n.language,
-        fallbackLanguage: 'fi'
-      }) ?? '';
-
-      dispatch(setTitle(title));
+      dispatch(setTitle(prefLabel ?? ''));
     }
-  }, [concept, dispatch, i18n.language]);
+  }, [concept, dispatch, prefLabel]);
 
   useEffect(() => {
     if (titleRef.current) {
@@ -94,10 +89,7 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
         }
         {!conceptError &&
           <BreadcrumbLink url={`/terminology/${terminologyId}/concepts/${conceptId}`} current>
-            <PropertyValue
-              property={conceptTitles}
-              fallbackLanguage='fi'
-            />
+            {prefLabel}
           </BreadcrumbLink>
         }
       </Breadcrumb>
@@ -107,15 +99,12 @@ export default function Concept({ terminologyId, conceptId, setConceptTitle }: C
           <HeadingBlock>
             <Text>
               <PropertyValue
-                property={terminology?.references.contributor?.[0].properties.prefLabel}
+                property={getProperty('prefLabel', terminology?.references.contributor)}
                 fallbackLanguage='fi'
               />
             </Text>
             <Heading variant="h1" tabIndex={-1} ref={titleRef}>
-              <PropertyValue
-                property={conceptTitles}
-                fallbackLanguage='fi'
-              />
+              {prefLabel}
             </Heading>
             <BadgeBar>
               <span>{t('heading')}</span>

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -27,7 +27,7 @@ import { getPropertyValue } from '../../common/components/property-value/get-pro
 
 interface VocabularyProps {
   id: string;
-  setTerminologyTitle: (title: string) =>  void;
+  setTerminologyTitle: (title?: string) =>  void;
 }
 
 export default function Vocabulary({ id, setTerminologyTitle }: VocabularyProps) {
@@ -58,13 +58,14 @@ export default function Vocabulary({ id, setTerminologyTitle }: VocabularyProps)
     router.push('/404');
   }
 
+  const prefLabel = getPropertyValue({
+    property: info?.properties.prefLabel,
+    language: i18n.language,
+    fallbackLanguage: 'fi'
+  });
   useEffect(() => {
-    setTerminologyTitle(getPropertyValue({
-      property: info?.properties.prefLabel,
-      language: i18n.language,
-      fallbackLanguage: 'fi'
-    }) ?? '');
-  }, [info]);
+    setTerminologyTitle(prefLabel);
+  }, [setTerminologyTitle, prefLabel]);
 
   useEffect(() => {
     dispatch(setAlert([

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { MediaQueryContextProvider } from '../common/components/media-query/media-query-context';
 import Error from '../common/components/error/error';
 import ErrorLayout from '../layouts/error-layout';
+import PageTitle from '../common/components/page-title';
 
 export default function Custom404() {
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: false }}>
       <ErrorLayout>
+        <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>
-          <title>Sanastot | Error</title>
           <link rel="shortcut icon" href="/favicon.ico" />
         </Head>
         <Error />

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,14 +1,15 @@
 import Head from 'next/head';
 import Error from '../common/components/error/error';
 import { MediaQueryContextProvider } from '../common/components/media-query/media-query-context';
+import PageTitle from '../common/components/page-title';
 import ErrorLayout from '../layouts/error-layout';
 
 export default function Custom500() {
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: false }}>
       <ErrorLayout>
+        <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>
-          <title>Sanastot | Error</title>
           <link rel="shortcut icon" href="/favicon.ico" />
         </Head>
         <Error errorCode={500} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { SSRConfig, useTranslation } from 'next-i18next';
 import { createCommonGetServerSideProps } from '../common/utils/create-getserversideprops';
 import { MediaQueryContextProvider } from '../common/components/media-query/media-query-context';
 import TerminologySearch from '../modules/terminology-search';
+import PageTitle from '../common/components/page-title';
 
 export default function IndexPage(props: {
   _netI18Next: SSRConfig;
@@ -15,8 +16,8 @@ export default function IndexPage(props: {
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       <Layout>
+        <PageTitle title={t('terminology-site-title')} />
         <Head>
-          <title>{t('terminology-site-title')} | {t('site-title')}</title>
           <link rel="shortcut icon" href="/favicon.ico" />
         </Head>
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,10 +1,10 @@
-import Head from 'next/head';
 import React from 'react';
-import { SSRConfig, useTranslation } from 'next-i18next';
+import { SSRConfig } from 'next-i18next';
 import Layout from '../layouts/layout';
 import TerminologySearch from '../modules/terminology-search';
 import { createCommonGetServerSideProps } from '../common/utils/create-getserversideprops';
 import { MediaQueryContextProvider } from '../common/components/media-query/media-query-context';
+import PageTitle from '../common/components/page-title';
 
 /*
  * @deprecated Search-page has been replaced by Index-page.
@@ -16,14 +16,10 @@ export default function SearchPage(props: {
 }) {
   console.warn('Search-page has been replaced by Index-page.');
 
-  const { t } = useTranslation('common');
-
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       <Layout>
-        <Head>
-          <title>{t('search-title')}</title>
-        </Head>
+        <PageTitle />
         <TerminologySearch />
       </Layout>
     </MediaQueryContextProvider>

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -2,10 +2,10 @@ import { SSRConfig, useTranslation } from 'next-i18next';
 import { useRouter } from 'next/dist/client/router';
 import React, { useState } from 'react';
 import Layout from '../../layouts/layout';
-import Head from 'next/head';
 import { createCommonGetServerSideProps } from '../../common/utils/create-getserversideprops';
 import Vocabulary from '../../modules/vocabulary';
 import { MediaQueryContextProvider } from '../../common/components/media-query/media-query-context';
+import PageTitle from '../../common/components/page-title';
 
 // TODO: perhaps move the component itself to components/
 export default function TerminologyPage(props: {
@@ -15,17 +15,18 @@ export default function TerminologyPage(props: {
   const { t } = useTranslation('common');
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
-  const [terminologyTitle, setTerminologyTitle] = useState<string | null>('');
+  const [terminologyTitle, setTerminologyTitle] = useState<string | undefined>();
 
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('terminology-id')} ${terminologyId}`}>
-        <Head>
-          <title>{terminologyTitle} | {t('site-title')}</title>
-        </Head>
+        <PageTitle title={terminologyTitle} />
 
-        <Vocabulary id={terminologyId} setTerminologyTitle={setTerminologyTitle} />
+        <Vocabulary
+          id={terminologyId}
+          setTerminologyTitle={setTerminologyTitle}
+        />
       </Layout>
     </MediaQueryContextProvider>
   );

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -2,10 +2,10 @@ import { SSRConfig, useTranslation } from 'next-i18next';
 import { useRouter } from 'next/dist/client/router';
 import React, { useState } from 'react';
 import Layout from '../../../../layouts/layout';
-import Head from 'next/head';
 import { createCommonGetServerSideProps } from '../../../../common/utils/create-getserversideprops';
 import { MediaQueryContextProvider } from '../../../../common/components/media-query/media-query-context';
 import Collection from '../../../../modules/collection';
+import PageTitle from '../../../../common/components/page-title';
 
 // TODO: perhaps move the component itself to components/
 export default function CollectionPage(props: {
@@ -16,17 +16,19 @@ export default function CollectionPage(props: {
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
   const collectionId = (query?.collectionId ?? '') as string;
-  const [collectionTitle, setCollectionTitle] = useState<string>('');
+  const [collectionTitle, setCollectionTitle] = useState<string | undefined>();
 
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('collection-id')} ${collectionId}`}>
-        <Head>
-          <title>{collectionTitle ?? t('collection-page')} | {t('site-title')}</title>
-        </Head>
+        <PageTitle title={collectionTitle} />
 
-        <Collection terminologyId={terminologyId} collectionId={collectionId} setCollectionTitle={setCollectionTitle} />
+        <Collection
+          terminologyId={terminologyId}
+          collectionId={collectionId}
+          setCollectionTitle={setCollectionTitle}
+        />
       </Layout>
     </MediaQueryContextProvider>
   );

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -2,10 +2,10 @@ import { SSRConfig, useTranslation } from 'next-i18next';
 import { useRouter } from 'next/dist/client/router';
 import React, { useState } from 'react';
 import Layout from '../../../../layouts/layout';
-import Head from 'next/head';
 import { createCommonGetServerSideProps } from '../../../../common/utils/create-getserversideprops';
 import Concept from '../../../../modules/concept';
 import { MediaQueryContextProvider } from '../../../../common/components/media-query/media-query-context';
+import PageTitle from '../../../../common/components/page-title';
 
 // TODO: perhaps move the component itself to components/
 export default function ConceptPage(props: {
@@ -16,17 +16,19 @@ export default function ConceptPage(props: {
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
   const conceptId = (query?.conceptId ?? '') as string;
-  const [conceptTitle, setConceptTitle] = useState<string>('');
+  const [conceptTitle, setConceptTitle] = useState<string | undefined>();
 
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('concept-id')} ${conceptId}`}>
-        <Head>
-          <title>{conceptTitle ?? t('concept-page')} | {t('site-title')}</title>
-        </Head>
+        <PageTitle title={conceptTitle} />
 
-        <Concept terminologyId={terminologyId} conceptId={conceptId} setConceptTitle={setConceptTitle} />
+        <Concept
+          terminologyId={terminologyId}
+          conceptId={conceptId}
+          setConceptTitle={setConceptTitle}
+        />
       </Layout>
     </MediaQueryContextProvider>
   );


### PR DESCRIPTION
In some cases, page title was not translated correctly.

For example, in concept page the title should contain prefLabel
from prefLabelXl term. Terms are language spesific so one term
contains prefLabel in one language. Thus is is not good enough to
get prefLabel from the first prefLabelXl but instead from all of
them.

In addition, refactored rendering of page title into single
component. Testing it was very hard (because of how next/head
works) so no tests for it in this commit.

YTI-1708