### PR TITLE
Yti 1712 read url parts from getServerSideProps context

### DIFF
--- a/src/common/components/alert/alert.slice.tsx
+++ b/src/common/components/alert/alert.slice.tsx
@@ -27,11 +27,7 @@ export const alertSlice = createSlice({
 export const setAlert = (alerts: AlertState['alerts']): AppThunk => dispatch => {
   dispatch(
     alertSlice.actions.setAlert({
-      alerts: alerts.filter(alert => {
-        if (alert && alert.data) {
-          return true;
-        }
-      })
+      alerts: alerts.filter(alert => alert && alert.data)
     }),
   );
 };

--- a/src/common/utils/create-getserversideprops.ts
+++ b/src/common/utils/create-getserversideprops.ts
@@ -11,6 +11,7 @@ import { setLogin } from '../components/login/login-slice';
 export interface LocalHandlerParams {
   req: NextIronRequest;
   res: NextApiResponse;
+  params: ParsedUrlQuery;
   locale: string;
   store: AppStore;
 }
@@ -30,8 +31,8 @@ export function createCommonGetServerSideProps<T extends { [key: string]: any }>
 ): CreateCommonGetServerSidePropsResult<T> {
   return wrapper.getServerSideProps((store) => {
     return withSession<{ props: UserProps }>(
-      async ({ req, res, locale }: { req: NextIronRequest, res: NextApiResponse, locale: string }) => {
-        const results = await handler?.({ req, res, locale, store });
+      async ({ req, res, params, locale }: { req: NextIronRequest, res: NextApiResponse, params: ParsedUrlQuery, locale: string }) => {
+        const results = await handler?.({ req, res, params, locale, store });
         store.dispatch(setLogin(req.session.get<User>('user') || anonymousUser));
         const userAgent = req.headers['user-agent'] ?? '';
 

--- a/src/common/utils/session.ts
+++ b/src/common/utils/session.ts
@@ -1,6 +1,7 @@
 // this file is a wrapper with defaults to be used in both API routes and `getServerSideProps` functions
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Session, withIronSession } from 'next-iron-session';
+import { ParsedUrlQuery } from 'querystring';
 import { userCookieOptions } from './user-cookie-options';
 
 export type NextIronRequest = NextApiRequest & { session: Session, locale: string };
@@ -10,6 +11,7 @@ export type NextIronHandler<T> =
   ((context: {
     req: NextIronRequest;
     res: NextApiResponse;
+    params: ParsedUrlQuery;
     locale: string;
   }) => T | Promise<T>);
 

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -41,10 +41,16 @@ export default function CollectionPage(props: {
   );
 }
 export const getServerSideProps = createCommonGetServerSideProps(
-  async ({ req, store }: LocalHandlerParams) => {
-    const ids = req.url?.split('/').filter(part => part.includes('-'));
-    const terminologyId = ids?.[0] ?? '';
-    const collectionId = ids?.[1].split('.')[0] ?? '';
+  async ({ req, store, params }: LocalHandlerParams) => {
+
+    const terminologyId = Array.isArray(params.terminologyId) ?
+      params.terminologyId[0] : params.terminologyId;
+    const collectionId = Array.isArray(params.collectionId) ?
+      params.collectionId[0] : params.collectionId;
+
+    if (terminologyId === undefined || collectionId === undefined) {
+      throw new Error('Invalid parameters for page');
+    }
 
     store.dispatch(getVocabulary.initiate(terminologyId));
     store.dispatch(getCollection.initiate({ terminologyId, collectionId }));

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -41,10 +41,16 @@ export default function ConceptPage(props: {
 }
 
 export const getServerSideProps = createCommonGetServerSideProps<{ props: { data?: any } }>(
-  async ({ req, store }: LocalHandlerParams) => {
-    const ids = req.url?.split('/').filter(part => part.includes('-'));
-    const terminologyId = ids?.[0] ?? '';
-    const conceptId = ids?.[1].split('.')[0] ?? '';
+  async ({ req, store, params }: LocalHandlerParams) => {
+
+    const terminologyId = Array.isArray(params.terminologyId) ?
+      params.terminologyId[0] : params.terminologyId;
+    const conceptId = Array.isArray(params.conceptId) ?
+      params.conceptId[0] : params.conceptId;
+
+    if (terminologyId === undefined || conceptId === undefined) {
+      throw new Error('Invalid parameters for page');
+    }
 
     await store.dispatch(getVocabulary.initiate(terminologyId));
     await store.dispatch(getConcept.initiate({terminologyId, conceptId}));


### PR DESCRIPTION
The url params are available for `getServerSideProps`, but the common implementation didn't include them.

https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#context-parameter

Additionally `getServerSideProps` will now throw an error if the parameters are missing, instead of just setting them to empty strings.