### PR TITLE
Removed looping dependency from useEffect

### DIFF
--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -60,7 +60,6 @@ export default function TerminologySearch() {
     groupsError,
     organizationsError,
     countsError,
-    previousAlerts,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
`previousAlerts` got added as an dependency for some reason and caused an infinite loop in terminology-search -module.