### PR TITLE
Added param for getting only terminology counts

### DIFF
--- a/src/common/components/counts/counts-slice.tsx
+++ b/src/common/components/counts/counts-slice.tsx
@@ -9,7 +9,7 @@ export const countsApi = createApi({
   endpoints: (builder) => ({
     getCounts: builder.query<Counts, null>({
       query: () => ({
-        url: '/counts',
+        url: '/counts?vocabularies=true',
         method: 'GET',
       }),
     }),


### PR DESCRIPTION
`vocabularies=true` parameter added to counts request for https://github.com/VRK-YTI/yti-terminology-api/pull/43.
This can be merged before api PR is merged (doesn't brake functionality, tested locally).