### PR TITLE
Hack: Use alertOff icon without updating suomifi-ui-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "sass": "^1.42.1",
         "styled-components": "^5.3.1",
         "styled-jsx": "^4.0.1",
+        "suomifi-icons": "^6.1.0",
         "suomifi-ui-components": "^6.1.1",
         "swr": "^1.0.1"
       },
@@ -10178,10 +10179,9 @@
       "license": "MIT"
     },
     "node_modules/suomifi-icons": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-5.0.0.tgz",
-      "integrity": "sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-6.1.0.tgz",
+      "integrity": "sha512-plJc4nG8DR8Rv7dnZFvIgbX0GrnG3GWBMXCbd/yd54o76cmgAJfRZARziqCXqKwx13i8YmejdCJEgrFgHBW/CA==",
       "peerDependencies": {
         "react": ">=16.3",
         "react-dom": ">=16.3"
@@ -10232,6 +10232,15 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
+      }
+    },
+    "node_modules/suomifi-ui-components/node_modules/suomifi-icons": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-5.0.0.tgz",
+      "integrity": "sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==",
+      "peerDependencies": {
+        "react": ">=16.3",
+        "react-dom": ">=16.3"
       }
     },
     "node_modules/supports-color": {
@@ -18237,9 +18246,9 @@
       "integrity": "sha512-74RX9W99Hruk464ga11Fi+MaUYaQm5bLg8YI+kneGP9YktOXHtjgeQx75iDAqpNsXNBVnkQ/JjCfNsEX9hDz9g=="
     },
     "suomifi-icons": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-5.0.0.tgz",
-      "integrity": "sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-6.1.0.tgz",
+      "integrity": "sha512-plJc4nG8DR8Rv7dnZFvIgbX0GrnG3GWBMXCbd/yd54o76cmgAJfRZARziqCXqKwx13i8YmejdCJEgrFgHBW/CA==",
       "requires": {}
     },
     "suomifi-ui-components": {
@@ -18271,6 +18280,12 @@
             "react-lifecycles-compat": "^3.0.0",
             "warning": "^4.0.3"
           }
+        },
+        "suomifi-icons": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-5.0.0.tgz",
+          "integrity": "sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==",
+          "requires": {}
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sass": "^1.42.1",
     "styled-components": "^5.3.1",
     "styled-jsx": "^4.0.1",
+    "suomifi-icons": "^6.1.0",
     "suomifi-ui-components": "^6.1.1",
     "swr": "^1.0.1"
   },

--- a/src/common/components/subscription/remove-subscription.tsx
+++ b/src/common/components/subscription/remove-subscription.tsx
@@ -10,6 +10,7 @@ import {
 import { Resource } from '../../interfaces/subscription.interface';
 import getPrefLabel from '../../utils/get-preflabel';
 import IconButton from '../icon-button/icon-button';
+import { Icon } from '../suomifi-7-tweaks/icon';
 import { useBreakpoints } from '../media-query/media-query-context';
 import {
   RemoveModal,
@@ -67,16 +68,22 @@ export default function RemoveSubscription({
       {resources && (
         <Button
           variant="secondary"
-          icon="message"
+          // message="alertOff"
           onClick={() => setVisible(true)}
         >
+          <Icon
+            icon="alertOff"
+            mousePointer
+            color="currentColor"
+            className="fi-button_icon"
+          />
           {t('subscription-remove-all-notifications')}
         </Button>
       )}
       {resource && (
         <IconButton
           variant="secondary"
-          icon="message"
+          icon="alertOff"
           color="currentColor"
           onClick={() => setVisible(true)}
         />

--- a/src/common/components/suomifi-7-tweaks/icon-button.tsx
+++ b/src/common/components/suomifi-7-tweaks/icon-button.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { ButtonProps, Icon } from 'suomifi-ui-components';
-import { StyledButton } from './icon-button.styles';
+import { ButtonProps } from 'suomifi-ui-components';
+import { StyledButton } from '../icon-button/icon-button.styles';
+import { BaseIconKeys } from 'suomifi-icons';
+import { Icon } from './icon';
 
-export interface IconButtonProps extends ButtonProps {
-  icon: ButtonProps['icon'];
+export interface IconButtonProps extends Omit<ButtonProps, 'icon'> {
+  icon: BaseIconKeys;
   color?: string;
   isLarge?: boolean;
 }

--- a/src/common/components/suomifi-7-tweaks/icon.styles.tsx
+++ b/src/common/components/suomifi-7-tweaks/icon.styles.tsx
@@ -1,0 +1,33 @@
+// Extracted from suomifi-ui-components v7.0.0-beta.0
+
+import { css } from 'styled-components';
+
+export const iconBaseStyles = ({
+  color,
+  fill,
+}: {
+  color?: string;
+  fill: string;
+}) => {
+  const resolvedColor = fill ?? color ?? 'currentColor';
+  return css`
+    vertical-align: baseline;
+    &.fi-icon {
+      display: inline-block;
+    }
+    .fi-icon-base-fill {
+      fill: ${resolvedColor};
+    }
+
+    .fi-icon-base-stroke {
+      stroke: ${resolvedColor};
+    }
+
+    &.fi-icon--cursor-pointer {
+      cursor: pointer;
+      & * {
+        cursor: inherit;
+      }
+    }
+  `;
+};

--- a/src/common/components/suomifi-7-tweaks/icon.tsx
+++ b/src/common/components/suomifi-7-tweaks/icon.tsx
@@ -1,0 +1,57 @@
+// Extracted from suomifi-ui-components v7.0.0-beta.0
+
+import React, { Component } from 'react';
+import { default as styled } from 'styled-components';
+import classnames from 'classnames';
+import { SuomifiIcon, SuomifiIconInterface } from 'suomifi-icons';
+import { iconBaseStyles } from './icon.styles';
+
+export const baseClassName = 'fi-icon';
+export const cursorPointerClassName = `${baseClassName}--cursor-pointer`;
+
+export interface IconBaseProps {
+  ariaLabel?: string;
+  mousePointer?: boolean;
+  color?: string;
+  fill?: string;
+  testId?: string;
+}
+
+export interface IconProps extends IconBaseProps, SuomifiIconInterface {}
+
+const StyledSuomifiIcon = styled(
+  ({ ariaLabel, mousePointer, className, ...passProps }: IconProps) => (
+    <SuomifiIcon
+      className={classnames(baseClassName, className, {
+        [cursorPointerClassName]: !!mousePointer,
+      })}
+      {...passProps}
+      {...ariaLabelOrHidden(ariaLabel)}
+      {...ariaFocusableNoLabel(ariaLabel)}
+    />
+  )
+)`
+  ${iconBaseStyles}
+`;
+
+export class Icon extends Component<IconProps> {
+  render() {
+    const { icon, ...passProps } = this.props;
+
+    if (icon !== undefined) {
+      return <StyledSuomifiIcon {...passProps} icon={icon} />;
+    }
+
+    return;
+  }
+}
+
+export const ariaLabelOrHidden = (ariaLabel?: string) =>
+  ifAriaNoLabel(ariaLabel)
+    ? { 'aria-label': ariaLabel, role: 'img' }
+    : { 'aria-hidden': true };
+
+export const ariaFocusableNoLabel = (ariaLabel?: string) =>
+  ifAriaNoLabel(ariaLabel) ? {} : { focusable: false };
+
+const ifAriaNoLabel = (ariaLabel?: string) => !!ariaLabel || ariaLabel === '';


### PR DESCRIPTION
Extract some files from suomifi-ui-components v7.0.0-beta.0 and
tweak them to allow us to use alertOff icon without updating the
whole library.

Note: Pretty much revert this commit after suomifi-ui-components
is updated to v7.

![2022-03-28_14-46](https://user-images.githubusercontent.com/1504091/160392708-992e70fb-3b3f-4608-bc74-95e8e477f79d.png)
