### PR TITLE
add github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: yti-terminology-ui CI
+
+on:
+  pull_request:
+    branches:
+      - v2
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run test:ci
+    - run: npm run lint
+    - run: npm run build
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -37,3 +37,6 @@ yarn-error.log*
 .vercel
 
 .vscode/*.json
+
+# github actions
+.github


### PR DESCRIPTION
This is a duplicate CI process only meant to aid with pull requests on github.

The workflow is essentially the same as in #30, where at the time we decided to not add a secondary CI process.
