### PR TITLE
Matomo integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,3 @@
-# Matomo settings
-MATOMO_URL=https://suomi.matomo.cloud
-MATOMO_SITE_ID=25
-
 # curl -v http://yti-terminology-api:9103/terminology-api/actuator/info
 # API url to be used by SSR
 TERMINOLOGY_API_URL=http://yti-terminology-api:9103/terminology-api

--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
+# Matomo settings
+MATOMO_URL=https://suomi.matomo.cloud
+MATOMO_SITE_ID=25
+
 # curl -v http://yti-terminology-api:9103/terminology-api/actuator/info
 # API url to be used by SSR
 TERMINOLOGY_API_URL=http://yti-terminology-api:9103/terminology-api

--- a/docs/matomo.md
+++ b/docs/matomo.md
@@ -1,0 +1,28 @@
+# Configuring Matomo Integration
+
+## Development
+
+By default, Matomo is disabled in development. If you need to enable it, just
+add the following lines to `.env.local` and restart Next.js. These settings
+are the same as in development servers.
+
+Be careful not to typo any of these variables. Production site is still
+protected so you can't corrupt its analytics accidentally.
+
+```env
+# Matomo settings
+NEXT_PUBLIC_MATOMO_ENABLED=true
+NEXT_PUBLIC_MATOMO_URL=https://suomi.matomo.cloud
+NEXT_PUBLIC_MATOMO_SITE_ID=25
+```
+
+## Servers
+
+Add the following environment variables to the server config. Pick the values
+from site's settings in Matomo.
+
+| Name                         | Value                        | Notes                                                                     |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_MATOMO_ENABLED` | `true`                       | Value must be `true`, not `1` etc.                                        |
+| `NEXT_PUBLIC_MATOMO_URL`     | `https://suomi.matomo.cloud` | Check this from Matomo site settings. This must be without leading slash. |
+| `NEXT_PUBLIC_MATOMO_SITE_ID` | integer                      | Check this from Matomo site settings.                                     |

--- a/src/common/components/block/concept-list-block.tsx
+++ b/src/common/components/block/concept-list-block.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link } from 'suomifi-ui-components';
+import Link from 'next/link';
+import { Link as SuomiLink } from 'suomifi-ui-components';
 import { BasicBlock } from '.';
 import { Concept } from '@app/common/interfaces/concept.interface';
 import { getProperty } from '@app/common/utils/get-property';
@@ -28,14 +29,17 @@ export default function ConceptListBlock({
           <li key={concept.id}>
             <Link
               href={`/terminology/${concept.identifier.type.graph.id}/concept/${concept.id}`}
+              passHref
             >
-              <PropertyValue
-                property={getProperty(
-                  'prefLabel',
-                  concept.references.prefLabelXl
-                )}
-                fallbackLanguage="fi"
-              />
+              <SuomiLink href="">
+                <PropertyValue
+                  property={getProperty(
+                    'prefLabel',
+                    concept.references.prefLabelXl
+                  )}
+                  fallbackLanguage="fi"
+                />
+              </SuomiLink>
             </Link>
           </li>
         ))}

--- a/src/common/components/matomo/index.tsx
+++ b/src/common/components/matomo/index.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Script from 'next/script';
+
+declare global {
+  interface Window {
+    _paq?: string[][];
+  }
+}
+
+/**
+ * Matomo's "push" function. It takes action and optional params and pushes
+ * them to matomo's queue.
+ *
+ * @param args
+ */
+function matomo(...args: string[]): void {
+  if (!window._paq) {
+    window._paq = [];
+  }
+
+  window._paq.push(args);
+}
+
+export interface MatomoProps {
+  url: string;
+  siteId: string;
+}
+
+export function MatomoTracking({ url, siteId }: MatomoProps) {
+  const router = useRouter();
+  const [previousPath, setPreviousPath] = useState(router.asPath.split('?')[0]);
+
+  useEffect(() => {
+    matomo('disableCookies');
+    matomo('trackPageView');
+    matomo('enableLinkTracking');
+    matomo('setTrackerUrl', `${url}/matomo.php`);
+    matomo('setSiteId', siteId);
+  }, [siteId, url]);
+
+  useEffect(() => {
+    const onRouteChangeStart = (path: string) => {
+      const pathname = path.split('?')[0];
+
+      if (previousPath !== pathname) {
+        if (previousPath) {
+          matomo('setReferrerUrl', previousPath);
+        }
+        matomo('setCustomUrl', pathname);
+      }
+    };
+
+    router.events.on('routeChangeStart', onRouteChangeStart);
+    return () => router.events.off('routeChangeStart', onRouteChangeStart);
+  }, [router.events, previousPath]);
+
+  useEffect(() => {
+    const onRouteChangeComplete = (path: string) => {
+      const pathname = path.split('?')[0];
+
+      if (previousPath !== pathname) {
+        setPreviousPath(pathname);
+        setTimeout(() => {
+          matomo('setDocumentTitle', document.title);
+          matomo('trackPageView');
+        }, 0);
+      }
+    };
+
+    router.events.on('routeChangeComplete', onRouteChangeComplete);
+    return () => router.events.off('routeChangeComplete', onRouteChangeComplete);
+  }, [router.events, previousPath]);
+
+  console.log('rendering');
+
+  return (
+    <Script src={`${url}/matomo.js`} />
+  );
+}
+
+const withEnv = () => {
+  // disable this check if you want to use this in development
+  if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
+
+  // default values are pointing to development environment
+  return (
+    <MatomoTracking
+      url={process.env.MATOMO_URL ?? 'https://suomi.matomo.cloud'}
+      siteId={process.env.MATOMO_SITE_ID ?? '25'}
+    />
+  );
+};
+
+export default withEnv;

--- a/src/common/components/matomo/index.tsx
+++ b/src/common/components/matomo/index.tsx
@@ -69,14 +69,11 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
     };
 
     router.events.on('routeChangeComplete', onRouteChangeComplete);
-    return () => router.events.off('routeChangeComplete', onRouteChangeComplete);
+    return () =>
+      router.events.off('routeChangeComplete', onRouteChangeComplete);
   }, [router.events, previousPath]);
 
-  console.log('rendering');
-
-  return (
-    <Script src={`${url}/matomo.js`} />
-  );
+  return <Script src={`${url}/matomo.js`} />;
 }
 
 const withEnv = () => {

--- a/src/common/components/matomo/index.tsx
+++ b/src/common/components/matomo/index.tsx
@@ -77,18 +77,16 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
 }
 
 const withEnv = () => {
-  // disable this check if you want to use this in development
-  if (process.env.NODE_ENV !== 'production') {
+  const isEnabled = process.env.NEXT_PUBLIC_MATOMO_ENABLED === 'true';
+  const url = process.env.NEXT_PUBLIC_MATOMO_URL;
+  const siteId = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+
+  // disable if any of required variables are missing
+  if (!isEnabled || !url || !siteId) {
     return null;
   }
 
-  // default values are pointing to development environment
-  return (
-    <MatomoTracking
-      url={process.env.MATOMO_URL ?? 'https://suomi.matomo.cloud'}
-      siteId={process.env.MATOMO_SITE_ID ?? '25'}
-    />
-  );
+  return <MatomoTracking url={url} siteId={siteId} />;
 };
 
 export default withEnv;

--- a/src/common/components/matomo/matomo.test.tsx
+++ b/src/common/components/matomo/matomo.test.tsx
@@ -1,51 +1,104 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { useRouter } from 'next/router';
+import { render, act } from '@testing-library/react';
 import Matomo, { MatomoTracking } from '.';
+import mockRouter from 'next-router-mock';
+import singletonRouter from 'next/router';
 
-jest.mock('next/router');
-const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+jest.useFakeTimers();
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('matomo', () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl('/');
+    delete window._paq;
+  });
   it('should not render in test when used smart version', () => {
-    mockedUseRouter.mockReturnValue({
-      asPath: '/',
-      events: {
-        on: jest.fn(),
-        off: jest.fn(),
-      },
-    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
     render(<Matomo />);
 
     expect(window._paq).toBeUndefined();
   });
 
   it('should render when used dummy version', () => {
-    mockedUseRouter.mockReturnValue({
-      asPath: '/',
-      events: {
-        on: jest.fn(),
-        off: jest.fn(),
-      },
-    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
     render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
 
     expect(window._paq).toBeDefined();
   });
 
   it('should use cookieless tracking', () => {
-    mockedUseRouter.mockReturnValue({
-      asPath: '/',
-      events: {
-        on: jest.fn(),
-        off: jest.fn(),
-      },
-    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-
     render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
 
-    expect(window._paq[0]).toStrictEqual(['disableCookies']);
+    expect(window._paq?.[0]).toStrictEqual(['disableCookies']);
+  });
+
+  it('should use correct url', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+
+    expect(window._paq?.[3]).toStrictEqual([
+      'setTrackerUrl',
+      'matamo-test-url/matomo.php',
+    ]);
+  });
+
+  it('should use correct siteId', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+
+    expect(window._paq?.[4]).toStrictEqual(['setSiteId', '1234']);
+  });
+
+  it('should track initial page view', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+
+    expect(window._paq?.[1]).toStrictEqual(['trackPageView']);
+  });
+
+  it('should track page changes', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+    act(() => {
+      singletonRouter.push('/another-page');
+      document.title = 'Another Page';
+    });
+
+    jest.runAllTimers();
+
+    expect(window._paq?.[6]).toStrictEqual(['setCustomUrl', '/another-page']);
+    expect(window._paq?.[8]).toStrictEqual(['trackPageView']);
+  });
+
+  it('should log referrer url when page changes', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+    act(() => {
+      singletonRouter.push('/another-page');
+      document.title = 'Another Page';
+    });
+
+    jest.runAllTimers();
+
+    expect(window._paq?.[5]).toStrictEqual(['setReferrerUrl', '/']);
+  });
+
+  it('should log new page title when page changes', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+    act(() => {
+      singletonRouter.push('/another-page');
+      document.title = 'Another Page';
+    });
+
+    jest.runAllTimers();
+
+    expect(window._paq?.[7]).toStrictEqual([
+      'setDocumentTitle',
+      'Another Page',
+    ]);
+  });
+
+  it('should ignore changes in query parameters', () => {
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
+    act(() => {
+      singletonRouter.push('/?q=qwerty');
+    });
+
+    jest.runAllTimers();
+
+    expect(window._paq).toHaveLength(5);
   });
 });

--- a/src/common/components/matomo/matomo.test.tsx
+++ b/src/common/components/matomo/matomo.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import Matomo, { MatomoTracking } from '.';
+
+jest.mock('next/router');
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe('matomo', () => {
+  it('should not render in test when used smart version', () => {
+    mockedUseRouter.mockReturnValue({
+      asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      }
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    render(
+      <Matomo />
+    );
+
+    expect(window._paq).toBeUndefined();
+  });
+
+  it('should render when used dummy version', () => {
+    mockedUseRouter.mockReturnValue({
+      asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      }
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    render(
+      <MatomoTracking url="matamo-test-url" siteId="1234" />
+    );
+
+    expect(window._paq).toBeDefined();
+  });
+
+  it('should use cookieless tracking', () => {
+    mockedUseRouter.mockReturnValue({
+      asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      }
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    render(
+      <MatomoTracking url="matamo-test-url" siteId="1234" />
+    );
+
+    expect(window._paq[0]).toStrictEqual(['disableCookies']);
+  });
+});

--- a/src/common/components/matomo/matomo.test.tsx
+++ b/src/common/components/matomo/matomo.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { useRouter } from 'next/router';
 import Matomo, { MatomoTracking } from '.';
 
@@ -13,12 +13,10 @@ describe('matomo', () => {
       events: {
         on: jest.fn(),
         off: jest.fn(),
-      }
+      },
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    render(
-      <Matomo />
-    );
+    render(<Matomo />);
 
     expect(window._paq).toBeUndefined();
   });
@@ -29,12 +27,10 @@ describe('matomo', () => {
       events: {
         on: jest.fn(),
         off: jest.fn(),
-      }
+      },
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    render(
-      <MatomoTracking url="matamo-test-url" siteId="1234" />
-    );
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
 
     expect(window._paq).toBeDefined();
   });
@@ -45,12 +41,10 @@ describe('matomo', () => {
       events: {
         on: jest.fn(),
         off: jest.fn(),
-      }
+      },
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    render(
-      <MatomoTracking url="matamo-test-url" siteId="1234" />
-    );
+    render(<MatomoTracking url="matamo-test-url" siteId="1234" />);
 
     expect(window._paq[0]).toStrictEqual(['disableCookies']);
   });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux';
 import { selectTitle } from '@app/common/components/title/title.slice';
 import { selectLogin } from '@app/common/components/login/login.slice';
 import { setAlert } from '@app/common/components/alert/alert.slice';
+import Matomo from '@app/common/components/matomo';
 
 // https://nextjs.org/docs/advanced-features/custom-app
 function App({ Component, pageProps }: AppProps) {
@@ -39,22 +40,25 @@ function App({ Component, pageProps }: AppProps) {
   });
 
   return (
-    <SWRConfig
-      value={{
-        fetcher: async (url: string, init?: RequestInit) =>
-          axios.get(url).then((res) => res.data),
-        onError: (err) => {
-          console.error(err);
-        },
-      }}
-    >
-      <VisuallyHidden>
-        <div role="region" aria-live="assertive">
-          {t('navigated-to')} {title}
-        </div>
-      </VisuallyHidden>
-      <Component {...pageProps} />
-    </SWRConfig>
+    <>
+      <Matomo />
+      <SWRConfig
+        value={{
+          fetcher: async (url: string, init?: RequestInit) =>
+            axios.get(url).then((res) => res.data),
+          onError: (err) => {
+            console.error(err);
+          },
+        }}
+      >
+        <VisuallyHidden>
+          <div role="region" aria-live="assertive">
+            {t('navigated-to')} {title}
+          </div>
+        </VisuallyHidden>
+        <Component {...pageProps} />
+      </SWRConfig>
+    </>
   );
 }
 export default wrapper.withRedux(appWithTranslation(App));


### PR DESCRIPTION
Add Matomo integration. It is disabled in local/development by default. And in dev/test/prod servers it tries to use configs defined in environment variables.

No visual changes in this PR.

YTI-1780