### PR TITLE
Fix reset filter button status

### DIFF
--- a/src/common/components/filter/reset-all-filters-button.test.tsx
+++ b/src/common/components/filter/reset-all-filters-button.test.tsx
@@ -15,4 +15,14 @@ describe('reset-all-filters-button', () => {
       screen.getByText('tr-vocabulary-filter-remove-all')
     ).toBeInTheDocument();
   });
+
+  it('should not render component when in initial state', () => {
+    mockRouter.setCurrentUrl('/?status=draft&status=valid');
+
+    render(<ResetAllFiltersButton />, { wrapper: themeProvider });
+
+    expect(
+      screen.queryByText('tr-vocabulary-filter-remove-all')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/common/utils/hooks/useUrlState.ts
+++ b/src/common/utils/hooks/useUrlState.ts
@@ -20,7 +20,10 @@ export const initialUrlState: UrlState = {
 };
 
 export function isInitial(state: UrlState, name: keyof UrlState) {
-  return _.isEqual(state[name], initialUrlState[name]);
+  return _.isEqual(
+    _.sortBy(asArray(state[name])),
+    _.sortBy(asArray(initialUrlState[name]))
+  );
 }
 
 interface UseURLStateResult {
@@ -131,4 +134,10 @@ function asNumber(value: QueryParamValue, defaultValue = 0): number {
   const parsed = parseInt(value);
 
   return !isNaN(parsed) ? parsed : defaultValue;
+}
+
+function asArray(
+  value: string | number | string[] | number[]
+): (string | number)[] {
+  return Array.isArray(value) ? value : [value];
 }


### PR DESCRIPTION
The reset filter button was still rendered after it was clicked. It occurred when valid and draft statuses were selected but they were in a different order than in the initial state.

Fixed by sorting items so that the order doesn't matter anymore.

YTI-1804