### PR TITLE
Use CheckboxGroup component from suomifi-ui-components

### DIFF
--- a/src/common/components/filter/checkbox-filter.tsx
+++ b/src/common/components/filter/checkbox-filter.tsx
@@ -1,9 +1,4 @@
-import { Text } from 'suomifi-ui-components';
-import {
-  FilterFieldset,
-  FilterCheckbox,
-  FilterFieldsetLegend,
-} from './filter.styles';
+import { Checkbox, CheckboxGroup } from 'suomifi-ui-components';
 
 export interface Item {
   value: string;
@@ -26,23 +21,18 @@ export default function CheckboxFilter({
   checkboxVariant,
 }: CheckboxFilterProps) {
   return (
-    <FilterFieldset>
-      <FilterFieldsetLegend>
-        <Text variant="bold" smallScreen>
-          {title}
-        </Text>
-      </FilterFieldsetLegend>
+    <CheckboxGroup labelText={title}>
       {items.map(({ value, label }: Item) => (
-        <FilterCheckbox
+        <Checkbox
           key={value}
           onClick={({ checkboxState }) => update(value, checkboxState)}
           checked={selectedItems.includes(value)}
           variant={checkboxVariant}
         >
           {label}
-        </FilterCheckbox>
+        </Checkbox>
       ))}
-    </FilterFieldset>
+    </CheckboxGroup>
   );
 
   function update(item: string, isSelected: boolean) {

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -13,22 +13,6 @@ export const DropdownWrapper = styled.div`
   }
 `;
 
-export const FilterFieldset = styled.fieldset`
-  margin: 0;
-  padding: 0;
-  border: none;
-`;
-
-export const FilterFieldsetLegend = styled.legend`
-  padding: 0;
-  line-height: 1;
-`;
-
-export const FilterCheckbox = styled(Checkbox)`
-  font-size: ${(props) => props.theme.suomifi.typography.bodyTextSmall};
-  padding-top: ${(props) => props.theme.suomifi.spacing.xs};
-`;
-
 export const FilterRadioButton = styled(RadioButton)`
   font-size: ${(props) => props.theme.suomifi.typography.bodyTextSmall};
 `;


### PR DESCRIPTION
Replace own checkbox group implementation with suomifi-ui-component's new CheckboxGroup component.

Spacings are changed by a pixel or two.

Before: 
![image](https://user-images.githubusercontent.com/1504091/164726856-eaf10bcb-ba6f-4a9c-88ac-2be4c8fe6bbb.png)

After: 
![image](https://user-images.githubusercontent.com/1504091/164726912-4d253439-8ae1-4547-b1b5-367c7a7dd053.png)

_Note: Screenshots are taken from different environments so ignore counts._

YTI-1805