### PR TITLE
Yti 1814 concept base

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -82,5 +82,13 @@
   "allowed-file-formats": "Allowed file formats:",
   "add-file": "Add file",
   "file-added": "File added",
-  "remove": "Remove"
+  "remove": "Remove",
+  "continue": "Continue",
+  "cancel-variant": "Cancel",
+  "new-concept-to-terminology": "New concept to terminology",
+  "add-new-concept": "Add new concept",
+  "add-new-concept-description": "Concept's languages are inherited from the terminology information. Add a recommended term for the concept in at least one of the available languages.",
+  "you-have-right-new-concept": "You have the rights to create new concepts to this terminology",
+  "recommended-term": "Recommended term ({{lang}})",
+  "term-name-placeholder": "Give term name"
 }

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -82,5 +82,13 @@
   "allowed-file-formats": "Sallitut tiedostomuodot:",
   "add-file": "Lisää tiedosto",
   "file-added": "Tiedosto lisätty",
-  "remove": "Poista"
+  "remove": "Poista",
+  "continue": "Jatka",
+  "cancel-variant": "Peruuta",
+  "new-concept-to-terminology": "Uusi käsite sanastoon",
+  "add-new-concept": "Lisää uusi käsite",
+  "add-new-concept-description": "Käsitteen kielet periytyvät sanaston tiedoista. Lisää käsitteelle suositettava termi vähintään yhdellä kielellä.",
+  "you-have-right-new-concept": "Sinulla on oikeudet luoda uusia käsitteitä sanastoon",
+  "recommended-term": "Suositettava termi ({{lang}})",
+  "term-name-placeholder": "Kirjoita termin nimi"
 }

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -18,6 +18,8 @@ import FormattedDate from '@app/common/components/formatted-date';
 import { useSelector } from 'react-redux';
 import { selectLogin } from '@app/common/components/login/login.slice';
 import Subscription from '@app/common/components/subscription/subscription';
+import HasPermission from '@app/common/utils/has-permission';
+import NewConceptModal from '../new-concept-modal';
 
 interface InfoExpanderProps {
   data?: VocabularyInfoDTO;
@@ -61,6 +63,11 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         <BasicBlock title={t('vocabulary-info-vocabulary-type')}>
           {t('vocabulary-info-terminological-dictionary')}
         </BasicBlock>
+
+        {HasPermission({
+          actions: 'CREATE_CONCEPT',
+          targetOrganization: data.references.contributor?.[0].id,
+        }) && <NewConceptModal />}
 
         <Separator isLarge />
 

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -67,7 +67,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         {HasPermission({
           actions: 'CREATE_CONCEPT',
           targetOrganization: data.references.contributor?.[0].id,
-        }) && <NewConceptModal />}
+        }) && <NewConceptModal terminologyId={data.type.graph.id} />}
 
         <Separator isLarge />
 

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -25,13 +25,15 @@ interface HandleChangeProps {
   value: string;
 }
 
-export default function NewConceptModal({ terminologyId }: NewConceptModalProps) {
+export default function NewConceptModal({
+  terminologyId,
+}: NewConceptModalProps) {
   const { t } = useTranslation('admin');
   const [visible, setVisible] = useState(false);
   const [termName, setTermName] = useState({ FI: '', SV: '', EN: '' });
 
   const handleChange = ({ lang, value }: HandleChangeProps) => {
-    setTermName(termName => ({...termName, [lang]: value}));
+    setTermName((termName) => ({ ...termName, [lang]: value }));
   };
 
   return (
@@ -88,7 +90,10 @@ export default function NewConceptModal({ terminologyId }: NewConceptModalProps)
         </ModalContent>
 
         <ModalFooter>
-          <Link href={`/terminology/${terminologyId}/new-concept/${getTermName()}`} passHref>
+          <Link
+            href={`/terminology/${terminologyId}/new-concept/${getTermName()}`}
+            passHref
+          >
             <Button>{t('continue')}</Button>
           </Link>
           <Button variant="secondary" onClick={() => setVisible(false)}>

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -91,7 +91,7 @@ export default function NewConceptModal({
 
         <ModalFooter>
           <Link
-            href={`/terminology/${terminologyId}/new-concept/${getTermName()}`}
+            href={`/terminology/${terminologyId}/new-concept?${getTermNames()}`}
             passHref
           >
             <Button>{t('continue')}</Button>
@@ -104,17 +104,20 @@ export default function NewConceptModal({
     </>
   );
 
-  function getTermName() {
+  function getTermNames() {
+    const names = [];
     if (termName['FI']) {
-      return termName['FI'];
+      names.push(`fi=${termName['FI']}`);
     }
 
     if (termName['SV']) {
-      return termName['SV'];
+      names.push(`sv=${termName['SV']}`);
     }
 
     if (termName['EN']) {
-      return termName['EN'];
+      names.push(`en=${termName['EN']}`);
     }
+
+    return names.join('&');
   }
 }

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from 'next-i18next';
+import { useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalTitle,
+  Paragraph,
+  Text,
+  TextInput,
+} from 'suomifi-ui-components';
+import { BasicBlock } from '../block';
+import { BasicBlockExtraWrapper } from '../block/block.styles';
+import Separator from '../separator';
+import { TextInputBlock } from './new-concept-modal.styles';
+
+export default function NewConceptModal() {
+  const { t } = useTranslation('admin');
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <Separator isLarge />
+
+      <BasicBlock
+        title={t('new-concept-to-terminology')}
+        extra={
+          <BasicBlockExtraWrapper>
+            <Button
+              icon="plus"
+              variant="secondary"
+              onClick={() => setVisible(true)}
+            >
+              {t('add-new-concept')}
+            </Button>
+          </BasicBlockExtraWrapper>
+        }
+      >
+        {t('you-have-right-new-concept')}
+      </BasicBlock>
+
+      <Modal
+        appElementId="__next"
+        visible={visible}
+        onEscKeyDown={() => setVisible(false)}
+      >
+        <ModalContent>
+          <ModalTitle>{t('add-new-concept')}</ModalTitle>
+          <Paragraph>
+            <Text>{t('add-new-concept-description')}</Text>
+          </Paragraph>
+
+          <TextInputBlock>
+            <TextInput
+              labelText={t('recommended-term', { lang: 'FI' })}
+              visualPlaceholder={t('term-name-placeholder')}
+            />
+
+            <TextInput
+              labelText={t('recommended-term', { lang: 'SV' })}
+              visualPlaceholder={t('term-name-placeholder')}
+            />
+
+            <TextInput
+              labelText={t('recommended-term', { lang: 'EN' })}
+              visualPlaceholder={t('term-name-placeholder')}
+            />
+          </TextInputBlock>
+        </ModalContent>
+
+        <ModalFooter>
+          <Button>{t('continue')}</Button>
+          <Button variant="secondary" onClick={() => setVisible(false)}>
+            {t('cancel-variant')}
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+}

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'next-i18next';
+import Link from 'next/link';
 import { useState } from 'react';
 import {
   Button,
@@ -15,9 +16,23 @@ import { BasicBlockExtraWrapper } from '../block/block.styles';
 import Separator from '../separator';
 import { TextInputBlock } from './new-concept-modal.styles';
 
-export default function NewConceptModal() {
+interface NewConceptModalProps {
+  terminologyId: string;
+}
+
+interface HandleChangeProps {
+  lang: 'FI' | 'SV' | 'EN';
+  value: string;
+}
+
+export default function NewConceptModal({ terminologyId }: NewConceptModalProps) {
   const { t } = useTranslation('admin');
   const [visible, setVisible] = useState(false);
+  const [termName, setTermName] = useState({ FI: '', SV: '', EN: '' });
+
+  const handleChange = ({ lang, value }: HandleChangeProps) => {
+    setTermName(termName => ({...termName, [lang]: value}));
+  };
 
   return (
     <>
@@ -55,22 +70,27 @@ export default function NewConceptModal() {
             <TextInput
               labelText={t('recommended-term', { lang: 'FI' })}
               visualPlaceholder={t('term-name-placeholder')}
+              onChange={(e) => handleChange({ lang: 'FI', value: e as string })}
             />
 
             <TextInput
               labelText={t('recommended-term', { lang: 'SV' })}
               visualPlaceholder={t('term-name-placeholder')}
+              onChange={(e) => handleChange({ lang: 'SV', value: e as string })}
             />
 
             <TextInput
               labelText={t('recommended-term', { lang: 'EN' })}
               visualPlaceholder={t('term-name-placeholder')}
+              onChange={(e) => handleChange({ lang: 'EN', value: e as string })}
             />
           </TextInputBlock>
         </ModalContent>
 
         <ModalFooter>
-          <Button>{t('continue')}</Button>
+          <Link href={`/terminology/${terminologyId}/new-concept/${getTermName()}`} passHref>
+            <Button>{t('continue')}</Button>
+          </Link>
           <Button variant="secondary" onClick={() => setVisible(false)}>
             {t('cancel-variant')}
           </Button>
@@ -78,4 +98,18 @@ export default function NewConceptModal() {
       </Modal>
     </>
   );
+
+  function getTermName() {
+    if (termName['FI']) {
+      return termName['FI'];
+    }
+
+    if (termName['SV']) {
+      return termName['SV'];
+    }
+
+    if (termName['EN']) {
+      return termName['EN'];
+    }
+  }
 }

--- a/src/common/components/new-concept-modal/new-concept-modal.styles.tsx
+++ b/src/common/components/new-concept-modal/new-concept-modal.styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { Block } from 'suomifi-ui-components';
+
+export const TextInputBlock = styled(Block)`
+  margin-top: ${(props) => props.theme.suomifi.spacing.l};
+
+  > * {
+    margin-top: ${(props) => props.theme.suomifi.spacing.m};
+  }
+`;

--- a/src/modules/new-concept/index.tsx
+++ b/src/modules/new-concept/index.tsx
@@ -7,16 +7,16 @@ import { NewConceptBlock } from './new-concept.styles';
 
 interface NewConceptProps {
   terminologyId: string;
-  conceptName: string;
+  conceptNames: { [key: string]: string | undefined };
 }
 
 export default function NewConcept({
   terminologyId,
-  conceptName,
+  conceptNames,
 }: NewConceptProps) {
   const router = useRouter();
   const { data: terminology } = useGetVocabularyQuery(terminologyId);
-  console.log(terminology);
+
   return (
     <>
       <Breadcrumb>
@@ -28,16 +28,29 @@ export default function NewConcept({
             />
           </BreadcrumbLink>
         )}
-        {conceptName && (
+        {conceptNames && (
           <BreadcrumbLink url="" current>
-            {conceptName}
+            {getTermName()}
           </BreadcrumbLink>
         )}
       </Breadcrumb>
 
       <NewConceptBlock>
-        <Heading variant="h1">{conceptName}</Heading>
+        <Heading variant="h1">{getTermName()}</Heading>
       </NewConceptBlock>
     </>
   );
+
+  // Get first defined termName
+  // This would be smart to replace with a proper function
+  function getTermName() {
+    const conceptNameKeys = Object.keys(conceptNames);
+    for (let i = 0; i < conceptNameKeys.length; i++) {
+      if (conceptNames[conceptNameKeys[i]]) {
+        return conceptNames[conceptNameKeys[i]];
+      }
+    }
+
+    return '';
+  }
 }

--- a/src/modules/new-concept/index.tsx
+++ b/src/modules/new-concept/index.tsx
@@ -1,0 +1,43 @@
+import { Breadcrumb, BreadcrumbLink } from '@app/common/components/breadcrumb';
+import PropertyValue from '@app/common/components/property-value';
+import { useGetVocabularyQuery } from '@app/common/components/vocabulary/vocabulary.slice';
+import { useRouter } from 'next/router';
+import { Heading } from 'suomifi-ui-components';
+import { NewConceptBlock } from './new-concept.styles';
+
+interface NewConceptProps {
+  terminologyId: string;
+  conceptName: string;
+}
+
+export default function NewConcept({ terminologyId, conceptName }: NewConceptProps) {
+  const router = useRouter();
+  const { data: terminology } = useGetVocabularyQuery(terminologyId);
+  console.log(terminology);
+  return (
+    <>
+      <Breadcrumb>
+        {router.query.terminologyId &&
+          <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
+            <PropertyValue
+              property={terminology?.properties.prefLabel}
+              fallbackLanguage="fi"
+            />
+          </BreadcrumbLink>
+        }
+        {conceptName &&
+          <BreadcrumbLink url='' current>
+            {conceptName}
+          </BreadcrumbLink>
+        }
+      </Breadcrumb>
+
+      <NewConceptBlock>
+        <Heading variant='h1'>
+          {conceptName}
+        </Heading>
+
+      </NewConceptBlock>
+    </>
+  );
+}

--- a/src/modules/new-concept/index.tsx
+++ b/src/modules/new-concept/index.tsx
@@ -10,33 +10,33 @@ interface NewConceptProps {
   conceptName: string;
 }
 
-export default function NewConcept({ terminologyId, conceptName }: NewConceptProps) {
+export default function NewConcept({
+  terminologyId,
+  conceptName,
+}: NewConceptProps) {
   const router = useRouter();
   const { data: terminology } = useGetVocabularyQuery(terminologyId);
   console.log(terminology);
   return (
     <>
       <Breadcrumb>
-        {router.query.terminologyId &&
+        {router.query.terminologyId && (
           <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
             <PropertyValue
               property={terminology?.properties.prefLabel}
               fallbackLanguage="fi"
             />
           </BreadcrumbLink>
-        }
-        {conceptName &&
-          <BreadcrumbLink url='' current>
+        )}
+        {conceptName && (
+          <BreadcrumbLink url="" current>
             {conceptName}
           </BreadcrumbLink>
-        }
+        )}
       </Breadcrumb>
 
       <NewConceptBlock>
-        <Heading variant='h1'>
-          {conceptName}
-        </Heading>
-
+        <Heading variant="h1">{conceptName}</Heading>
       </NewConceptBlock>
     </>
   );

--- a/src/modules/new-concept/new-concept.styles.tsx
+++ b/src/modules/new-concept/new-concept.styles.tsx
@@ -3,8 +3,8 @@ import { Block } from 'suomifi-ui-components';
 
 export const NewConceptBlock = styled(Block)`
   background: white;
-  border: 1px solid ${props => props.theme.suomifi.colors.depthDark3};
+  border: 1px solid ${(props) => props.theme.suomifi.colors.depthDark3};
   margin-bottom: 80px;
-  margin-top: ${props => props.theme.suomifi.spacing.m};
+  margin-top: ${(props) => props.theme.suomifi.spacing.m};
   padding: 30px 80px 20px 80px;
 `;

--- a/src/modules/new-concept/new-concept.styles.tsx
+++ b/src/modules/new-concept/new-concept.styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { Block } from 'suomifi-ui-components';
+
+export const NewConceptBlock = styled(Block)`
+  background: white;
+  border: 1px solid ${props => props.theme.suomifi.colors.depthDark3};
+  margin-bottom: 80px;
+  margin-top: ${props => props.theme.suomifi.spacing.m};
+  padding: 30px 80px 20px 80px;
+`;

--- a/src/pages/terminology/[terminologyId]/new-concept.tsx
+++ b/src/pages/terminology/[terminologyId]/new-concept.tsx
@@ -10,7 +10,11 @@ export default function NewConcept(props: {
   isSSRMobile: boolean;
 }) {
   const { query } = useRouter();
-  const conceptName = (query?.conceptName ?? '') as string;
+  const conceptNames = {
+    fi: query.fi as string,
+    sv: query.sv as string,
+    en: query.en as string,
+  };
   const terminologyId = (query?.terminologyId ?? '') as string;
 
   return (
@@ -18,7 +22,7 @@ export default function NewConcept(props: {
       <Layout>
         <NewConceptModule
           terminologyId={terminologyId}
-          conceptName={conceptName}
+          conceptNames={conceptNames}
         />
       </Layout>
     </MediaQueryContextProvider>

--- a/src/pages/terminology/[terminologyId]/new-concept/[conceptName].tsx
+++ b/src/pages/terminology/[terminologyId]/new-concept/[conceptName].tsx
@@ -3,9 +3,7 @@ import Layout from '@app/layouts/layout';
 import { SSRConfig } from 'next-i18next';
 import { default as NewConceptModule } from '@app/modules/new-concept';
 import { useRouter } from 'next/router';
-import {
-  createCommonGetServerSideProps
-} from '@app/common/utils/create-getserversideprops';
+import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
 
 export default function NewConcept(props: {
   _nextI18Next: SSRConfig;
@@ -18,7 +16,10 @@ export default function NewConcept(props: {
   return (
     <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
       <Layout>
-        <NewConceptModule terminologyId={terminologyId} conceptName={conceptName} />
+        <NewConceptModule
+          terminologyId={terminologyId}
+          conceptName={conceptName}
+        />
       </Layout>
     </MediaQueryContextProvider>
   );

--- a/src/pages/terminology/[terminologyId]/new-concept/[conceptName].tsx
+++ b/src/pages/terminology/[terminologyId]/new-concept/[conceptName].tsx
@@ -1,0 +1,27 @@
+import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
+import Layout from '@app/layouts/layout';
+import { SSRConfig } from 'next-i18next';
+import { default as NewConceptModule } from '@app/modules/new-concept';
+import { useRouter } from 'next/router';
+import {
+  createCommonGetServerSideProps
+} from '@app/common/utils/create-getserversideprops';
+
+export default function NewConcept(props: {
+  _nextI18Next: SSRConfig;
+  isSSRMobile: boolean;
+}) {
+  const { query } = useRouter();
+  const conceptName = (query?.conceptName ?? '') as string;
+  const terminologyId = (query?.terminologyId ?? '') as string;
+
+  return (
+    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+      <Layout>
+        <NewConceptModule terminologyId={terminologyId} conceptName={conceptName} />
+      </Layout>
+    </MediaQueryContextProvider>
+  );
+}
+
+export const getServerSideProps = createCommonGetServerSideProps();


### PR DESCRIPTION
Changes in this PR:
- Added modal for creating new concept
- Modal directs to new page called `new-concept` where user finishes creating the concept. Currently there is only a blank page to allow other developers to create needed components
- `new-concept` takes terms in url params (e.g. `sanastot.fi/terminology/abc-def/new-concept?fi=uusitermi&en=newterm`)

Modal button in terminology information:
![image](https://user-images.githubusercontent.com/82932696/165229974-f9ecda1b-49ba-48db-9b38-47c10263bfe5.png)

Modal opened:
![image](https://user-images.githubusercontent.com/82932696/165230015-d59b44cd-8aed-4a10-b82c-2a07bbe65bb9.png)

Current state of new-concept -page:
![image](https://user-images.githubusercontent.com/82932696/165230072-b8543014-50d6-4b9f-a1b2-de191e3378d9.png)
Title is received from values retrieved from modal