### PR TITLE
Use environment variables with Matomo

### DIFF
--- a/docs/matomo.md
+++ b/docs/matomo.md
@@ -11,9 +11,9 @@ protected so you can't corrupt its analytics accidentally.
 
 ```env
 # Matomo settings
-NEXT_PUBLIC_MATOMO_ENABLED=true
-NEXT_PUBLIC_MATOMO_URL=https://suomi.matomo.cloud
-NEXT_PUBLIC_MATOMO_SITE_ID=25
+MATOMO_ENABLED=true
+MATOMO_URL=https://suomi.matomo.cloud
+MATOMO_SITE_ID=25
 ```
 
 ## Servers
@@ -21,8 +21,8 @@ NEXT_PUBLIC_MATOMO_SITE_ID=25
 Add the following environment variables to the server config. Pick the values
 from site's settings in Matomo.
 
-| Name                         | Value                        | Notes                                                                     |
-| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_MATOMO_ENABLED` | `true`                       | Value must be `true`, not `1` etc.                                        |
-| `NEXT_PUBLIC_MATOMO_URL`     | `https://suomi.matomo.cloud` | Check this from Matomo site settings. This must be without leading slash. |
-| `NEXT_PUBLIC_MATOMO_SITE_ID` | integer                      | Check this from Matomo site settings.                                     |
+| Name             | Value                        | Notes                                                                     |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `MATOMO_ENABLED` | `true`                       | Value must be `true`, not `1` etc.                                        |
+| `MATOMO_URL`     | `https://suomi.matomo.cloud` | Check this from Matomo site settings. This must be without leading slash. |
+| `MATOMO_SITE_ID` | integer                      | Check this from Matomo site settings.                                     |

--- a/next.config.js
+++ b/next.config.js
@@ -34,13 +34,15 @@ module.exports = (phase, { defaultConfig }) => {
     },
     async headers() {
       const isProd = process.env.NODE_ENV === 'production';
+      const matomoUrl = process.env.MATOMO_URL ?? '';
 
       const ProductionContentSecurityPolicy = [
         "base-uri 'self';",
         "default-src 'self';",
         "font-src 'self';",
         "img-src 'self' data:;",
-        "script-src 'self' 'unsafe-inline';",
+        `script-src 'self' 'unsafe-inline' ${matomoUrl};`,
+        `connect-src 'self' ${matomoUrl};`,
         "style-src 'self' 'unsafe-inline' data:;",
         "frame-src 'self';",
       ];
@@ -50,7 +52,8 @@ module.exports = (phase, { defaultConfig }) => {
         "default-src 'self';",
         "font-src 'self';",
         "img-src 'self' 'unsafe-eval' 'unsafe-inline' data:;",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval';",
+        `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${matomoUrl};`,
+        `connect-src 'self' ${matomoUrl};`,
         "style-src 'self' 'unsafe-inline' data:;",
         "frame-src 'self';",
       ];

--- a/src/common/components/common-context-provider/index.tsx
+++ b/src/common/components/common-context-provider/index.tsx
@@ -1,22 +1,22 @@
 import { createContext } from 'react';
 
 // Note. Undefined is not allowed here so null must be used instead.
-export interface CommonContextInterface {
+export interface CommonContextState {
   isSSRMobile: boolean;
   isMatomoEnabled: boolean;
   matomoUrl: string | null;
   matomoSiteId: string | null;
 }
 
-export const defaultCommonContextValue: CommonContextInterface = {
+export const initialCommonContextState: CommonContextState = {
   isSSRMobile: false,
   isMatomoEnabled: false,
   matomoUrl: null,
   matomoSiteId: null,
 };
 
-export const CommonContext = createContext<CommonContextInterface>(
-  defaultCommonContextValue
+export const CommonContext = createContext<CommonContextState>(
+  initialCommonContextState
 );
 
 export const CommonContextProvider = CommonContext.Provider;

--- a/src/common/components/common-context-provider/index.tsx
+++ b/src/common/components/common-context-provider/index.tsx
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+// Note. Undefined is not allowed here so null must be used instead.
+export interface CommonContextInterface {
+  isSSRMobile: boolean;
+  isMatomoEnabled: boolean;
+  matomoUrl: string | null;
+  matomoSiteId: string | null;
+}
+
+export const defaultCommonContextValue: CommonContextInterface = {
+  isSSRMobile: false,
+  isMatomoEnabled: false,
+  matomoUrl: null,
+  matomoSiteId: null,
+};
+
+export const CommonContext = createContext<CommonContextInterface>(
+  defaultCommonContextValue
+);
+
+export const CommonContextProvider = CommonContext.Provider;

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Button, Checkbox, RadioButton } from 'suomifi-ui-components';
+import { Button, RadioButton } from 'suomifi-ui-components';
 
 export const CloseWrapper = styled.div`
   * {

--- a/src/common/components/matomo/index.tsx
+++ b/src/common/components/matomo/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
+import { CommonContext } from '../common-context-provider';
 
 declare global {
   interface Window {
@@ -76,23 +77,16 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
   return <Script src={`${url}/matomo.js`} />;
 }
 
-const withEnv = () => {
-  console.log('matomo config', {
-    enabled: process.env.NEXT_PUBLIC_MATOMO_ENABLED,
-    url: process.env.NEXT_PUBLIC_MATOMO_URL,
-    siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID,
-  });
-
-  const isEnabled = process.env.NEXT_PUBLIC_MATOMO_ENABLED === 'true';
-  const url = process.env.NEXT_PUBLIC_MATOMO_URL;
-  const siteId = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+const WithEnv = () => {
+  const { isMatomoEnabled, matomoUrl, matomoSiteId } =
+    useContext(CommonContext);
 
   // disable if any of required variables are missing
-  if (!isEnabled || !url || !siteId) {
+  if (!isMatomoEnabled || !matomoUrl || !matomoSiteId) {
     return null;
   }
 
-  return <MatomoTracking url={url} siteId={siteId} />;
+  return <MatomoTracking url={matomoUrl} siteId={matomoSiteId} />;
 };
 
-export default withEnv;
+export default WithEnv;

--- a/src/common/components/matomo/matomo.test.tsx
+++ b/src/common/components/matomo/matomo.test.tsx
@@ -12,6 +12,7 @@ describe('matomo', () => {
     mockRouter.setCurrentUrl('/');
     delete window._paq;
   });
+
   it('should not render in test when used smart version', () => {
     render(<Matomo />);
 

--- a/src/common/components/media-query/media-query-context.tsx
+++ b/src/common/components/media-query/media-query-context.tsx
@@ -1,9 +1,6 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useMediaQuery } from '@material-ui/core';
-
-const MediaQueryContext = React.createContext({ isSSRMobile: false });
-
-export const MediaQueryContextProvider = MediaQueryContext.Provider;
+import { CommonContext } from '../common-context-provider';
 
 export const mediaQueries = {
   s: '(max-width:767px)',
@@ -31,7 +28,7 @@ export interface UseBreakpointsResult {
 }
 
 export function useBreakpoints(): UseBreakpointsResult {
-  const { isSSRMobile } = useContext(MediaQueryContext);
+  const { isSSRMobile } = useContext(CommonContext);
   const matchSmall = useMediaQuery(mediaQueries.s);
   const matchMedium = useMediaQuery(mediaQueries.m);
   const matchLarge = useMediaQuery(mediaQueries.l);

--- a/src/common/utils/create-getserversideprops.ts
+++ b/src/common/utils/create-getserversideprops.ts
@@ -11,7 +11,7 @@ import { ParsedUrlQuery } from 'querystring';
 import { Redirect } from 'next/dist/lib/load-custom-routes';
 import { SSRConfig } from 'next-i18next';
 import { setLogin } from '@app/common/components/login/login.slice';
-import { CommonContextInterface } from '../components/common-context-provider';
+import { CommonContextState } from '../components/common-context-provider';
 
 export interface LocalHandlerParams {
   req: NextIronRequest;
@@ -26,7 +26,7 @@ export type localHandler<T> = (context: LocalHandlerParams) => Promise<T>;
 
 export type CommonServerSideProps = UserProps &
   SSRConfig &
-  CommonContextInterface & {
+  CommonContextState & {
     isSSRMobile: boolean;
   };
 

--- a/src/common/utils/create-getserversideprops.ts
+++ b/src/common/utils/create-getserversideprops.ts
@@ -11,6 +11,7 @@ import { ParsedUrlQuery } from 'querystring';
 import { Redirect } from 'next/dist/lib/load-custom-routes';
 import { SSRConfig } from 'next-i18next';
 import { setLogin } from '@app/common/components/login/login.slice';
+import { CommonContextInterface } from '../components/common-context-provider';
 
 export interface LocalHandlerParams {
   req: NextIronRequest;
@@ -24,7 +25,8 @@ export interface LocalHandlerParams {
 export type localHandler<T> = (context: LocalHandlerParams) => Promise<T>;
 
 export type CommonServerSideProps = UserProps &
-  SSRConfig & {
+  SSRConfig &
+  CommonContextInterface & {
     isSSRMobile: boolean;
   };
 
@@ -83,6 +85,9 @@ export function createCommonGetServerSideProps<
                 /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
               )
             ),
+            isMatomoEnabled: process.env.MATOMO_ENABLED === 'true',
+            matomoUrl: process.env.MATOMO_URL ?? null,
+            matomoSiteId: process.env.MATOMO_SITE_ID ?? null,
           },
         };
       }

--- a/src/layouts/error-layout.tsx
+++ b/src/layouts/error-layout.tsx
@@ -12,6 +12,7 @@ import {
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import { HeaderWrapper } from '@app/modules/smart-header/smart-header.styles';
 import Logo from '@app/modules/smart-header/logo';
+import Matomo from '@app/common/components/matomo';
 
 export default function ErrorLayout({
   children,
@@ -22,6 +23,7 @@ export default function ErrorLayout({
 
   return (
     <ThemeProvider theme={lightTheme}>
+      <Matomo />
       <Head>
         <meta name="description" content="Terminology/React POC" />
         <meta name="og:title" content="Sanastot" />

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -14,6 +14,7 @@ import SmartHeader from '@app/modules/smart-header';
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import SkipLink from '@app/common/components/skip-link/skip-link';
 import { Alerts } from '@app/common/components/alert';
+import Matomo from '@app/common/components/matomo';
 
 export default function Layout({
   children,
@@ -27,6 +28,8 @@ export default function Layout({
 
   return (
     <ThemeProvider theme={lightTheme}>
+      <Matomo />
+
       <Head>
         <meta name="description" content="Terminology/React POC" />
         <meta name="og:title" content={t('terminology')} />

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,13 +1,16 @@
 import Head from 'next/head';
 import React from 'react';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import Error from '@app/common/components/error/error';
 import ErrorLayout from '@app/layouts/error-layout';
 import PageTitle from '@app/common/components/page-title';
+import {
+  CommonContextProvider,
+  defaultCommonContextValue,
+} from '@app/common/components/common-context-provider';
 
 export default function Custom404() {
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: false }}>
+    <CommonContextProvider value={defaultCommonContextValue}>
       <ErrorLayout>
         <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>
@@ -15,6 +18,6 @@ export default function Custom404() {
         </Head>
         <Error />
       </ErrorLayout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,12 +5,12 @@ import ErrorLayout from '@app/layouts/error-layout';
 import PageTitle from '@app/common/components/page-title';
 import {
   CommonContextProvider,
-  defaultCommonContextValue,
+  initialCommonContextState,
 } from '@app/common/components/common-context-provider';
 
 export default function Custom404() {
   return (
-    <CommonContextProvider value={defaultCommonContextValue}>
+    <CommonContextProvider value={initialCommonContextState}>
       <ErrorLayout>
         <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -4,12 +4,12 @@ import PageTitle from '@app/common/components/page-title';
 import ErrorLayout from '@app/layouts/error-layout';
 import {
   CommonContextProvider,
-  defaultCommonContextValue,
+  initialCommonContextState,
 } from '@app/common/components/common-context-provider';
 
 export default function Custom500() {
   return (
-    <CommonContextProvider value={defaultCommonContextValue}>
+    <CommonContextProvider value={initialCommonContextState}>
       <ErrorLayout>
         <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,12 +1,15 @@
 import Head from 'next/head';
 import Error from '@app/common/components/error/error';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import PageTitle from '@app/common/components/page-title';
 import ErrorLayout from '@app/layouts/error-layout';
+import {
+  CommonContextProvider,
+  defaultCommonContextValue,
+} from '@app/common/components/common-context-provider';
 
 export default function Custom500() {
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: false }}>
+    <CommonContextProvider value={defaultCommonContextValue}>
       <ErrorLayout>
         <PageTitle title="Error" siteTitle="Yhteentoimivuusalusta" />
         <Head>
@@ -14,6 +17,6 @@ export default function Custom500() {
         </Head>
         <Error errorCode={500} />
       </ErrorLayout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,6 @@ import { useSelector } from 'react-redux';
 import { selectTitle } from '@app/common/components/title/title.slice';
 import { selectLogin } from '@app/common/components/login/login.slice';
 import { setAlert } from '@app/common/components/alert/alert.slice';
-import Matomo from '@app/common/components/matomo';
 
 // https://nextjs.org/docs/advanced-features/custom-app
 function App({ Component, pageProps }: AppProps) {
@@ -43,25 +42,22 @@ function App({ Component, pageProps }: AppProps) {
   });
 
   return (
-    <>
-      <Matomo />
-      <SWRConfig
-        value={{
-          fetcher: async (url: string, init?: RequestInit) =>
-            axios.get(url).then((res) => res.data),
-          onError: (err) => {
-            console.error(err);
-          },
-        }}
-      >
-        <VisuallyHidden>
-          <div role="region" aria-live="assertive">
-            {t('navigated-to')} {title}
-          </div>
-        </VisuallyHidden>
-        <Component {...pageProps} />
-      </SWRConfig>
-    </>
+    <SWRConfig
+      value={{
+        fetcher: async (url: string, init?: RequestInit) =>
+          axios.get(url).then((res) => res.data),
+        onError: (err) => {
+          console.error(err);
+        },
+      }}
+    >
+      <VisuallyHidden>
+        <div role="region" aria-live="assertive">
+          {t('navigated-to')} {title}
+        </div>
+      </VisuallyHidden>
+      <Component {...pageProps} />
+    </SWRConfig>
   );
 }
 export default wrapper.withRedux(appWithTranslation(App));

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,12 +5,12 @@ import { SSRConfig, useTranslation } from 'next-i18next';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
 import {
   CommonContextProvider,
-  CommonContextInterface,
+  CommonContextState,
 } from '@app/common/components/common-context-provider';
 import TerminologySearch from '@app/modules/terminology-search';
 import PageTitle from '@app/common/components/page-title';
 
-interface IndexPageProps extends CommonContextInterface {
+interface IndexPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,18 +3,22 @@ import React from 'react';
 import Layout from '@app/layouts/layout';
 import { SSRConfig, useTranslation } from 'next-i18next';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
+import {
+  CommonContextProvider,
+  CommonContextInterface,
+} from '@app/common/components/common-context-provider';
 import TerminologySearch from '@app/modules/terminology-search';
 import PageTitle from '@app/common/components/page-title';
 
-export default function IndexPage(props: {
+interface IndexPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function IndexPage(props: IndexPageProps) {
   const { t } = useTranslation('common');
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       <Layout>
         <PageTitle title={t('terminology-site-title')} />
         <Head>
@@ -23,7 +27,7 @@ export default function IndexPage(props: {
 
         <TerminologySearch />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 

--- a/src/pages/own-information.tsx
+++ b/src/pages/own-information.tsx
@@ -2,24 +2,28 @@ import React from 'react';
 import Layout from '@app/layouts/layout';
 import { SSRConfig, useTranslation } from 'next-i18next';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import PageTitle from '@app/common/components/page-title';
 import OwnInformation from '@app/modules/own-information';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
-export default function OwnInformationPage(props: {
+interface OwnInformationPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function OwnInformationPage(props: OwnInformationPageProps) {
   const { t } = useTranslation('common');
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       <Layout>
         <PageTitle title={t('own-information')} />
 
         <OwnInformation />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 

--- a/src/pages/own-information.tsx
+++ b/src/pages/own-information.tsx
@@ -5,11 +5,11 @@ import { createCommonGetServerSideProps } from '@app/common/utils/create-getserv
 import PageTitle from '@app/common/components/page-title';
 import OwnInformation from '@app/modules/own-information';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
-interface OwnInformationPageProps extends CommonContextInterface {
+interface OwnInformationPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -5,7 +5,7 @@ import TerminologySearch from '@app/modules/terminology-search';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
 import PageTitle from '@app/common/components/page-title';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
@@ -13,7 +13,7 @@ import {
  * @deprecated Search-page has been replaced by Index-page.
  */
 
-interface SearchPageProps extends CommonContextInterface {
+interface SearchPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -3,26 +3,30 @@ import { SSRConfig } from 'next-i18next';
 import Layout from '@app/layouts/layout';
 import TerminologySearch from '@app/modules/terminology-search';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import PageTitle from '@app/common/components/page-title';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
 /*
  * @deprecated Search-page has been replaced by Index-page.
  */
 
-export default function SearchPage(props: {
+interface SearchPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function SearchPage(props: SearchPageProps) {
   console.warn('Search-page has been replaced by Index-page.');
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       <Layout>
         <PageTitle />
         <TerminologySearch />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -16,11 +16,11 @@ import {
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import { initialUrlState } from '@app/common/utils/hooks/useUrlState';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
-interface TerminologyPageProps extends CommonContextInterface {
+interface TerminologyPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -7,7 +7,6 @@ import {
   LocalHandlerParams,
 } from '@app/common/utils/create-getserversideprops';
 import Vocabulary from '@app/modules/vocabulary';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import PageTitle from '@app/common/components/page-title';
 import {
   getCollections,
@@ -16,11 +15,16 @@ import {
   getVocabulary,
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import { initialUrlState } from '@app/common/utils/hooks/useUrlState';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
-export default function TerminologyPage(props: {
+interface TerminologyPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function TerminologyPage(props: TerminologyPageProps) {
   const { t } = useTranslation('common');
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
@@ -29,7 +33,7 @@ export default function TerminologyPage(props: {
   >();
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('terminology-id')} ${terminologyId}`}>
         <PageTitle title={terminologyTitle} />
@@ -39,7 +43,7 @@ export default function TerminologyPage(props: {
           setTerminologyTitle={setTerminologyTitle}
         />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -6,7 +6,6 @@ import {
   createCommonGetServerSideProps,
   LocalHandlerParams,
 } from '@app/common/utils/create-getserversideprops';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import Collection from '@app/modules/collection';
 import {
   getCollection,
@@ -18,11 +17,16 @@ import {
   getRunningOperationPromises as getVocabularyRunningOperationPromises,
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import PageTitle from '@app/common/components/page-title';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
-export default function CollectionPage(props: {
+interface CollectionPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function CollectionPage(props: CollectionPageProps) {
   const { t } = useTranslation('common');
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
@@ -30,7 +34,7 @@ export default function CollectionPage(props: {
   const [collectionTitle, setCollectionTitle] = useState<string | undefined>();
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('collection-id')} ${collectionId}`}>
         <PageTitle title={collectionTitle} />
@@ -41,7 +45,7 @@ export default function CollectionPage(props: {
           setCollectionTitle={setCollectionTitle}
         />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 export const getServerSideProps = createCommonGetServerSideProps(

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -18,11 +18,11 @@ import {
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import PageTitle from '@app/common/components/page-title';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
-interface CollectionPageProps extends CommonContextInterface {
+interface CollectionPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -17,11 +17,11 @@ import {
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import PageTitle from '@app/common/components/page-title';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
-interface ConceptPageProps extends CommonContextInterface {
+interface ConceptPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -7,7 +7,6 @@ import {
   LocalHandlerParams,
 } from '@app/common/utils/create-getserversideprops';
 import Concept from '@app/modules/concept';
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import {
   getConcept,
   getRunningOperationPromises as getConceptRunningOperationPromises,
@@ -17,11 +16,16 @@ import {
   getRunningOperationPromises as getVocabularyRunningOperationPromises,
 } from '@app/common/components/vocabulary/vocabulary.slice';
 import PageTitle from '@app/common/components/page-title';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
-export default function ConceptPage(props: {
+interface ConceptPageProps extends CommonContextInterface {
   _netI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+}
+
+export default function ConceptPage(props: ConceptPageProps) {
   const { t } = useTranslation('common');
   const { query } = useRouter();
   const terminologyId = (query?.terminologyId ?? '') as string;
@@ -29,7 +33,7 @@ export default function ConceptPage(props: {
   const [conceptTitle, setConceptTitle] = useState<string | undefined>();
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       {/* todo: use better feedbackSubject once more data is available */}
       <Layout feedbackSubject={`${t('concept-id')} ${conceptId}`}>
         <PageTitle title={conceptTitle} />
@@ -40,7 +44,7 @@ export default function ConceptPage(props: {
           setConceptTitle={setConceptTitle}
         />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 

--- a/src/pages/terminology/[terminologyId]/new-concept.tsx
+++ b/src/pages/terminology/[terminologyId]/new-concept.tsx
@@ -4,11 +4,11 @@ import { default as NewConceptModule } from '@app/modules/new-concept';
 import { useRouter } from 'next/router';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
 import {
-  CommonContextInterface,
+  CommonContextState,
   CommonContextProvider,
 } from '@app/common/components/common-context-provider';
 
-interface NewConceptPageProps extends CommonContextInterface {
+interface NewConceptPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
 }
 

--- a/src/pages/terminology/[terminologyId]/new-concept.tsx
+++ b/src/pages/terminology/[terminologyId]/new-concept.tsx
@@ -1,14 +1,18 @@
-import { MediaQueryContextProvider } from '@app/common/components/media-query/media-query-context';
 import Layout from '@app/layouts/layout';
 import { SSRConfig } from 'next-i18next';
 import { default as NewConceptModule } from '@app/modules/new-concept';
 import { useRouter } from 'next/router';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
+import {
+  CommonContextInterface,
+  CommonContextProvider,
+} from '@app/common/components/common-context-provider';
 
-export default function NewConcept(props: {
-  _nextI18Next: SSRConfig;
-  isSSRMobile: boolean;
-}) {
+interface NewConceptPageProps extends CommonContextInterface {
+  _netI18Next: SSRConfig;
+}
+
+export default function NewConcept(props: NewConceptPageProps) {
   const { query } = useRouter();
   const conceptNames = {
     fi: query.fi as string,
@@ -18,14 +22,14 @@ export default function NewConcept(props: {
   const terminologyId = (query?.terminologyId ?? '') as string;
 
   return (
-    <MediaQueryContextProvider value={{ isSSRMobile: props.isSSRMobile }}>
+    <CommonContextProvider value={props}>
       <Layout>
         <NewConceptModule
           terminologyId={terminologyId}
           conceptNames={conceptNames}
         />
       </Layout>
-    </MediaQueryContextProvider>
+    </CommonContextProvider>
   );
 }
 


### PR DESCRIPTION
Environment variables can be accessed only on the server. If they are needed in the browser they must be passed via props. Made this easier by creating CommonContextProvider that is used on every page and takes all the page props. Currently, other components can access these values by simply using this context.

The first two use cases for CommonContextProvider are Matomo and guessing results of media queries in SSR. Later it would be useful with e.g. feature flags.

YTI-1800