### PR TITLE
Use terminology's languages when creating new concept

### DIFF
--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -67,7 +67,14 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         {HasPermission({
           actions: 'CREATE_CONCEPT',
           targetOrganization: data.references.contributor?.[0].id,
-        }) && <NewConceptModal terminologyId={data.type.graph.id} />}
+        }) && (
+          <NewConceptModal
+            terminologyId={data.type.graph.id}
+            languages={
+              data.properties.language?.map(({ value }) => value) ?? []
+            }
+          />
+        )}
 
         <Separator isLarge />
 

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -18,19 +18,22 @@ import { TextInputBlock } from './new-concept-modal.styles';
 
 interface NewConceptModalProps {
   terminologyId: string;
+  languages: string[];
 }
 
 interface HandleChangeProps {
-  lang: 'FI' | 'SV' | 'EN';
+  lang: string;
   value: string;
 }
 
 export default function NewConceptModal({
   terminologyId,
+  languages,
 }: NewConceptModalProps) {
   const { t } = useTranslation('admin');
   const [visible, setVisible] = useState(false);
-  const [termName, setTermName] = useState({ FI: '', SV: '', EN: '' });
+  const [termName, setTermName] = useState({});
+  const queryParams = new URLSearchParams(termName).toString();
 
   const handleChange = ({ lang, value }: HandleChangeProps) => {
     setTermName((termName) => ({ ...termName, [lang]: value }));
@@ -69,29 +72,20 @@ export default function NewConceptModal({
           </Paragraph>
 
           <TextInputBlock>
-            <TextInput
-              labelText={t('recommended-term', { lang: 'FI' })}
-              visualPlaceholder={t('term-name-placeholder')}
-              onChange={(e) => handleChange({ lang: 'FI', value: e as string })}
-            />
-
-            <TextInput
-              labelText={t('recommended-term', { lang: 'SV' })}
-              visualPlaceholder={t('term-name-placeholder')}
-              onChange={(e) => handleChange({ lang: 'SV', value: e as string })}
-            />
-
-            <TextInput
-              labelText={t('recommended-term', { lang: 'EN' })}
-              visualPlaceholder={t('term-name-placeholder')}
-              onChange={(e) => handleChange({ lang: 'EN', value: e as string })}
-            />
+            {languages.map((lang) => (
+              <TextInput
+                key={lang}
+                labelText={t('recommended-term', { lang: lang.toUpperCase() })}
+                visualPlaceholder={t('term-name-placeholder')}
+                onChange={(e) => handleChange({ lang, value: e as string })}
+              />
+            ))}
           </TextInputBlock>
         </ModalContent>
 
         <ModalFooter>
           <Link
-            href={`/terminology/${terminologyId}/new-concept?${getTermNames()}`}
+            href={`/terminology/${terminologyId}/new-concept?${queryParams}`}
             passHref
           >
             <Button>{t('continue')}</Button>
@@ -103,21 +97,4 @@ export default function NewConceptModal({
       </Modal>
     </>
   );
-
-  function getTermNames() {
-    const names = [];
-    if (termName['FI']) {
-      names.push(`fi=${termName['FI']}`);
-    }
-
-    if (termName['SV']) {
-      names.push(`sv=${termName['SV']}`);
-    }
-
-    if (termName['EN']) {
-      names.push(`en=${termName['EN']}`);
-    }
-
-    return names.join('&');
-  }
 }


### PR DESCRIPTION
In the new Concept modal, the preferred term was asked always in Finnish, Swedish, and English. Change this by using languages of the terminology.

![image](https://user-images.githubusercontent.com/1504091/165709444-d7a80145-d198-4308-8d37-050124e8e0d8.png)

YTI-1814