### PR TITLE
Include coverage dir in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/junit.xml ./
+COPY --from=builder /app/coverage ./coverage
 
 USER nextjs
 


### PR DESCRIPTION
At this point, it will be passed there always but in the following PR, I'll include it conditionally. I excluded it from this PR as copying a file if it exists is a little tricky task in Dockerfile.

No visual changes in this PR.