### PR TITLE
Add SKIP_COVERAGE build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/junit.xml ./
+COPY --from=builder /app/coverage ./coverage
 
 USER nextjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,23 @@ ENV NEXT_TELEMETRY_DISABLED 1
 ARG REWRITE_PROFILE=none
 ENV REWRITE_PROFILE $REWRITE_PROFILE
 ARG SKIP_TESTS
+ARG SKIP_COVERAGE
 ARG VERSION
 
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN if [ -z "$SKIP_TESTS" ] ; then \
-    npm run test:ci; \
-  else \
+
+RUN if [ "$SKIP_TESTS" ]; then \
     echo "Skipping tests"; \
+    mkdir -p coverage; \
+  elif [ "$SKIP_COVERAGE" ]; then \
+    echo "Running tests without coverage"; \
+    npm run test:ci:no-coverage; \
+    mkdir -p coverage; \
+  else \
+    echo "Running tests with coverage"; \
+    npm run test:ci; \
   fi
 
 # Create version.txt

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,5 @@ docker build \
   -t yti-terminology-ui \
   --build-arg REWRITE_PROFILE=${REWRITE_PROFILE:=docker} \
   --build-arg SKIP_TESTS=${SKIP_TESTS:=} \
+  --build-arg SKIP_COVERAGE=${SKIP_COVERAGE:=} \
   .

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "test": "TZ=UTC jest",
     "test:watch": "TZ=UTC jest --watch",
-    "test:ci": "TZ=UTC jest --ci --runInBand --coverage"
+    "test:ci": "TZ=UTC jest --ci --runInBand --coverage",
+    "test:ci:no-coverage": "TZ=UTC jest --ci --runInBand"
   },
   "dependencies": {
     "@fontsource/source-sans-pro": "^4.5.1",


### PR DESCRIPTION
Add SKIP_COVERAGE build argument. If it is passed (e.g. via environment variables), the coverage directory is excluded from the built image. The idea is to not bloat the production image with development-related stuff.

YTI-1890