### PR TITLE
YTI-1871 Status search and sorting

### DIFF
--- a/src/common/components/filter/reset-all-filters-button.test.tsx
+++ b/src/common/components/filter/reset-all-filters-button.test.tsx
@@ -17,7 +17,7 @@ describe('reset-all-filters-button', () => {
   });
 
   it('should not render component when in initial state', () => {
-    mockRouter.setCurrentUrl('/?status=draft&status=valid');
+    mockRouter.setCurrentUrl('/');
 
     render(<ResetAllFiltersButton />, { wrapper: themeProvider });
 

--- a/src/common/components/search-results/search-count-tags.test.tsx
+++ b/src/common/components/search-results/search-count-tags.test.tsx
@@ -14,7 +14,5 @@ describe('search-count-tags', () => {
     });
 
     expect(screen.getByText(/4/)).toBeInTheDocument();
-    expect(screen.getByText(/tr-VALID/)).toBeInTheDocument();
-    expect(screen.getByText(/tr-DRAFT/)).toBeInTheDocument();
   });
 });

--- a/src/common/components/terminology-search/terminology-search.slice.tsx
+++ b/src/common/components/terminology-search/terminology-search.slice.tsx
@@ -27,7 +27,7 @@ export const terminologySearchApi = createApi({
   endpoints: (builder) => ({
     getSearchResult: builder.query<
       TerminologySearchResult,
-      { urlState: UrlState }
+      { urlState: UrlState; language: string }
     >({
       query: (value) => ({
         url: '/searchTerminology',
@@ -40,7 +40,7 @@ export const terminologySearchApi = createApi({
             ? [value.urlState.organization]
             : [],
           searchConcepts: true,
-          prefLang: 'fi',
+          prefLang: value.language,
           pageSize: 10,
           pageFrom: Math.max(0, (value.urlState.page - 1) * 10),
         },

--- a/src/common/components/vocabulary/vocabulary.slice.tsx
+++ b/src/common/components/vocabulary/vocabulary.slice.tsx
@@ -40,7 +40,7 @@ export const vocabularyApi = createApi({
     }),
     getConceptResult: builder.query<
       VocabularyConcepts,
-      { urlState: UrlState; id: string }
+      { urlState: UrlState; id: string; language: string }
     >({
       query: (value) => ({
         url: '/searchConcept',
@@ -51,7 +51,7 @@ export const vocabularyApi = createApi({
           pageSize: 10,
           query: value.urlState.q,
           sortDirection: 'ASC',
-          sortLanguage: 'fi',
+          sortLanguage: value.language,
           status: value.urlState.status.map((s) => s.toUpperCase()),
           terminologyId: [value.id],
         },

--- a/src/common/utils/hooks/useUrlState.test.ts
+++ b/src/common/utils/hooks/useUrlState.test.ts
@@ -21,7 +21,7 @@ describe('useUrlState', () => {
         q: '',
         domain: [],
         organization: '',
-        status: ['valid', 'draft'],
+        status: [],
         type: 'concept',
         page: '1',
       },

--- a/src/common/utils/hooks/useUrlState.ts
+++ b/src/common/utils/hooks/useUrlState.ts
@@ -14,7 +14,7 @@ export const initialUrlState: UrlState = {
   q: '',
   domain: [],
   organization: '',
-  status: ['valid', 'draft'],
+  status: [],
   type: 'concept',
   page: 1,
 };

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -33,6 +33,7 @@ export default function TerminologySearch() {
   const { urlState } = useUrlState();
   const { data, error, isFetching, refetch } = useGetSearchResultQuery({
     urlState,
+    language: i18n.language
   });
   const { data: groups, error: groupsError } = useGetGroupsQuery(i18n.language);
   const { data: organizations, error: organizationsError } =

--- a/src/modules/terminology-search/index.tsx
+++ b/src/modules/terminology-search/index.tsx
@@ -33,7 +33,7 @@ export default function TerminologySearch() {
   const { urlState } = useUrlState();
   const { data, error, isFetching, refetch } = useGetSearchResultQuery({
     urlState,
-    language: i18n.language
+    language: i18n.language,
   });
   const { data: groups, error: groupsError } = useGetGroupsQuery(i18n.language);
   const { data: organizations, error: organizationsError } =

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -53,7 +53,7 @@ export default function Vocabulary({
     error: conceptsError,
     isFetching: isFetchingConcepts,
     refetch: refetchConcepts,
-  } = useGetConceptResultQuery({ id, urlState });
+  } = useGetConceptResultQuery({ id, urlState, language: i18n.language });
   const { data: info, error: infoError } = useGetVocabularyQuery(id);
   const { data: counts, error: countsError } = useGetVocabularyCountQuery(id);
   const [showModal, setShowModal] = useState(false);

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -75,7 +75,9 @@ export const getServerSideProps = createCommonGetServerSideProps(
 
     await store.dispatch(getVocabulary.initiate(id));
     await store.dispatch(getCollections.initiate(id));
-    await store.dispatch(getConceptResult.initiate({ urlState: urlState, id, language: locale }));
+    await store.dispatch(
+      getConceptResult.initiate({ urlState: urlState, id, language: locale })
+    );
 
     await Promise.all(getRunningOperationPromises());
 

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -48,7 +48,7 @@ export default function TerminologyPage(props: TerminologyPageProps) {
 }
 
 export const getServerSideProps = createCommonGetServerSideProps(
-  async ({ req, store, query, params }: LocalHandlerParams) => {
+  async ({ req, store, query, params, locale }: LocalHandlerParams) => {
     const id = Array.isArray(params.terminologyId)
       ? params.terminologyId[0]
       : params.terminologyId;
@@ -75,7 +75,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
 
     await store.dispatch(getVocabulary.initiate(id));
     await store.dispatch(getCollections.initiate(id));
-    await store.dispatch(getConceptResult.initiate({ urlState: urlState, id }));
+    await store.dispatch(getConceptResult.initiate({ urlState: urlState, id, language: locale }));
 
     await Promise.all(getRunningOperationPromises());
 


### PR DESCRIPTION
* Remove default selections (DRAFT, VALID) from search
* Add current language to search payload for sorting

Backend changes in [this PR](https://github.com/VRK-YTI/yti-terminology-api/pull/55)