### PR TITLE
hasPermission checks if admin controls are enabled

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,3 @@ ENV_TYPE=dev
 # For local development, you should store it inside a `.env.local` gitignored file
 # See https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
 # next iron cookies are encrypted so the cookie password is for the app to unencrypt the content
-
-# change this in .env.local to true to enable admin features
-NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED=false

--- a/.env
+++ b/.env
@@ -15,3 +15,6 @@ ENV_TYPE=dev
 # For local development, you should store it inside a `.env.local` gitignored file
 # See https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
 # next iron cookies are encrypted so the cookie password is for the app to unencrypt the content
+
+# change this in .env.local to true to enable admin features
+NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED=false

--- a/src/common/components/admin-controls/admin-controls.slice.tsx
+++ b/src/common/components/admin-controls/admin-controls.slice.tsx
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { HYDRATE } from 'next-redux-wrapper';
+import { AppState, AppThunk } from '@app/store';
+
+interface AdminControlsState {
+  isAdminControlsDisabled: boolean;
+}
+
+export const initialState: AdminControlsState = {
+  isAdminControlsDisabled: false,
+};
+
+export const adminControlsSlice = createSlice({
+  name: 'adminControls',
+  initialState: initialState,
+  reducers: {
+    setAdminControls(state, action) {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    },
+  },
+  extraReducers: {
+    [HYDRATE]: (state, action) => {
+      return {
+        ...state,
+        ...action.payload.adminControls,
+      };
+    },
+  },
+});
+
+export function setAdminControls(value: boolean): AppThunk {
+  return (dispatch) => dispatch(adminControlsSlice.actions.setAdminControls({ isAdminControlsDisabled: value }));
+}
+
+export function selectAdminControls() {
+  return (state: AppState): boolean => state.adminControls.isAdminControlsDisabled;
+}
+
+export default adminControlsSlice.reducer;

--- a/src/common/components/admin-controls/admin-controls.slice.tsx
+++ b/src/common/components/admin-controls/admin-controls.slice.tsx
@@ -32,11 +32,17 @@ export const adminControlsSlice = createSlice({
 });
 
 export function setAdminControls(value: boolean): AppThunk {
-  return (dispatch) => dispatch(adminControlsSlice.actions.setAdminControls({ isAdminControlsDisabled: value }));
+  return (dispatch) =>
+    dispatch(
+      adminControlsSlice.actions.setAdminControls({
+        isAdminControlsDisabled: value,
+      })
+    );
 }
 
 export function selectAdminControls() {
-  return (state: AppState): boolean => state.adminControls.isAdminControlsDisabled;
+  return (state: AppState): boolean =>
+    state.adminControls.isAdminControlsDisabled;
 }
 
 export default adminControlsSlice.reducer;

--- a/src/common/utils/create-getserversideprops.ts
+++ b/src/common/utils/create-getserversideprops.ts
@@ -12,6 +12,7 @@ import { Redirect } from 'next/dist/lib/load-custom-routes';
 import { SSRConfig } from 'next-i18next';
 import { setLogin } from '@app/common/components/login/login.slice';
 import { CommonContextState } from '../components/common-context-provider';
+import { setAdminControls } from '../components/admin-controls/admin-controls.slice';
 
 export interface LocalHandlerParams {
   req: NextIronRequest;
@@ -66,6 +67,11 @@ export function createCommonGetServerSideProps<
         store.dispatch(
           setLogin(req.session.get<User>('user') || anonymousUser)
         );
+
+        store.dispatch(
+          setAdminControls(process.env.ADMIN_CONTROLS_DISABLED === 'true')
+        );
+
         const userAgent = req.headers['user-agent'] ?? '';
 
         return {

--- a/src/common/utils/has-permission.tsx
+++ b/src/common/utils/has-permission.tsx
@@ -36,6 +36,10 @@ export default function HasPermission({
 }: hasPermissionProps) {
   const user = useSelector(selectLogin());
 
+  if (process.env.NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED === 'false') {
+    return false;
+  }
+
   if (!user || user.anonymous) {
     return false;
   }
@@ -52,6 +56,11 @@ export function checkPermission({
   const rolesInOrganizations = Object.keys(user.rolesInOrganizations);
   const rolesInTargetOrganization =
     targetOrganization && user.rolesInOrganizations[targetOrganization];
+
+  // Return true if user is superuser
+  if (user.superuser) {
+    return true;
+  }
 
   // Return false if user doesn't have a role in target organization
   if (

--- a/src/common/utils/has-permission.tsx
+++ b/src/common/utils/has-permission.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { selectAdminControls } from '../components/admin-controls/admin-controls.slice';
 import { selectLogin } from '../components/login/login.slice';
 import { User } from '../interfaces/user.interface';
 
@@ -35,8 +36,9 @@ export default function HasPermission({
   targetOrganization,
 }: hasPermissionProps) {
   const user = useSelector(selectLogin());
+  const isAdminControlsDisabled = useSelector(selectAdminControls());
 
-  if (process.env.NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED !== 'true') {
+  if (isAdminControlsDisabled) {
     return false;
   }
 

--- a/src/common/utils/has-permission.tsx
+++ b/src/common/utils/has-permission.tsx
@@ -36,7 +36,7 @@ export default function HasPermission({
 }: hasPermissionProps) {
   const user = useSelector(selectLogin());
 
-  if (process.env.NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED === 'false') {
+  if (process.env.NEXT_PUBLIC_ADMIN_CONTROLS_ENABLED !== 'true') {
     return false;
   }
 

--- a/src/common/utils/has-permissions.test.ts
+++ b/src/common/utils/has-permissions.test.ts
@@ -7,14 +7,15 @@ const createMockUser = (
   },
   organizationsInRole: {
     [key: string]: string[];
-  }
+  },
+  superuser?: boolean
 ): User => ({
   anonymous: false,
   email: 'admin@admin.fi',
   firstName: 'Admin',
   lastName: 'Admin',
   id: '',
-  superuser: true,
+  superuser: superuser ? true : false,
   newlyCreated: false,
   rolesInOrganizations: rolesInOrganizations,
   organizationsInRole: organizationsInRole,
@@ -142,5 +143,17 @@ describe('has-permission', () => {
     });
 
     expect(rights).toBe(false);
+  });
+
+  it('should have superuser rights', () => {
+    const user = createMockUser({}, {}, true);
+
+    const rights = checkPermission({
+      user: user,
+      actions: ['CREATE_TERMINOLOGY', 'EDIT_TERMINOLOGY', 'DELETE_TERMINOLOGY'],
+      targetOrganization: 'foo',
+    });
+
+    expect(rights).toBe(true);
   });
 });

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -17,6 +17,7 @@ import { alertSlice } from '@app/common/components/alert/alert.slice';
 import { titleSlice } from '@app/common/components/title/title.slice';
 import { subscriptionApi } from '@app/common/components/subscription/subscription.slice';
 import { accessRequestApi } from '@app/common/components/access-request/access-request.slice';
+import { adminControlsSlice } from '@app/common/components/admin-controls/admin-controls.slice';
 
 export function makeStore() {
   return configureStore({
@@ -33,6 +34,7 @@ export function makeStore() {
       [titleSlice.name]: titleSlice.reducer,
       [subscriptionApi.reducerPath]: subscriptionApi.reducer,
       [accessRequestApi.reducerPath]: accessRequestApi.reducer,
+      [adminControlsSlice.name]: adminControlsSlice.reducer,
     },
 
     middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
`ADMIN_CONTROLS_DISABLED` can be added as an environmental variable to disable admin actions. If variable isn't defined, controls are enabled for users with admin rights.