### PR TITLE
Use draft as default status when rendering

### DIFF
--- a/src/common/components/block/term-block.tsx
+++ b/src/common/components/block/term-block.tsx
@@ -35,7 +35,7 @@ export default function TermBlock({
           <TermModal data={{ term: term, type: type }} />
         </span>
         <span>
-          {type}, {t(term.properties.status?.[0].value ?? '')}
+          {type}, {t(term.properties.status?.[0].value ?? 'DRAFT')}
         </span>
       </span>
     ),

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -80,9 +80,12 @@ export default function RenderConcepts({
                   toggleButtonAriaDescribedBy=""
                 >
                   <Checkbox
-                    hintText={`${organizationTitle} - ${t(concept.status, {
-                      ns: 'common',
-                    })}`}
+                    hintText={`${organizationTitle} - ${t(
+                      concept.status ?? 'DRAFT',
+                      {
+                        ns: 'common',
+                      }
+                    )}`}
                     onClick={(e) => handleCheckbox(e, concept)}
                     checked={chosen.some((chose) => chose.id === concept.id)}
                   >

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -112,7 +112,7 @@ export default function SearchResults({
                           terminology.status === 'VALID' ? 'true' : undefined
                         }
                       >
-                        {t(terminology.status ?? '')}
+                        {t(terminology.status ?? 'DRAFT')}
                       </CardChip>
                     </div>
                   </CardSubtitle>
@@ -181,7 +181,7 @@ export default function SearchResults({
                     <CardSubtitle>
                       <div>{t('vocabulary-info-concept')}</div>
                       <span aria-hidden="true">&middot;</span>
-                      <div>{t(`${concept.status}`)}</div>
+                      <div>{t(`${concept.status ?? 'DRAFT'}`)}</div>
                     </CardSubtitle>
 
                     <CardDescription>{getDefinition(concept)}</CardDescription>

--- a/src/common/components/term-modal/index.tsx
+++ b/src/common/components/term-modal/index.tsx
@@ -72,7 +72,11 @@ export default function TermModal({ data }: TermModalProps) {
           </ModalTitle>
 
           {renderInfo(t('term-modal-type'), data.type)}
-          {renderInfoChip(t('term-modal-status'), data.term.properties.status)}
+          {renderInfoChip(
+            t('term-modal-status'),
+            data.term.properties.status,
+            'DRAFT'
+          )}
           {renderInfo(
             t('term-modal-homograph-number'),
             data.term.properties.termHomographNumber?.[0].value
@@ -168,7 +172,11 @@ export default function TermModal({ data }: TermModalProps) {
     );
   }
 
-  function renderInfoChip(subtitle: string, value?: Property[]) {
+  function renderInfoChip(
+    subtitle: string,
+    value?: Property[],
+    defaultValue = ''
+  ) {
     if (!value) {
       return null;
     }
@@ -183,7 +191,9 @@ export default function TermModal({ data }: TermModalProps) {
           aria-disabled={true}
           $isValid={value[0].value === 'VALID' ? 'true' : undefined}
         >
-          {t(getPropertyValue({ property: value }) ?? '', { ns: 'common' })}
+          {t(getPropertyValue({ property: value }) ?? defaultValue, {
+            ns: 'common',
+          })}
         </TermModalChip>
       </>
     );

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -49,7 +49,7 @@ export default function Title({ info }: TitleProps) {
       </TitleWrapperNoBreadcrumb>
     );
   } else {
-    const status = info.properties.status?.[0].value ?? '';
+    const status = info.properties.status?.[0].value ?? 'DRAFT';
 
     const contributor =
       getPropertyValue({

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -76,7 +76,8 @@ export default function Concept({
     }
   }, [concept, dispatch, prefLabel]);
 
-  const status = getPropertyValue({ property: concept?.properties.status });
+  const status =
+    getPropertyValue({ property: concept?.properties.status }) ?? 'DRAFT';
 
   return (
     <>


### PR DESCRIPTION
Sometimes status is incorrectly empty or missing in the backend. In these situations use "draft" as a status instead of nothing.

YTI-1924