### PR TITLE
Language should stay after login/logout

### DIFF
--- a/src/common/components/authentication-panel/user-info.tsx
+++ b/src/common/components/authentication-panel/user-info.tsx
@@ -10,14 +10,14 @@ export interface UserInfoProps {
 }
 
 export default function UserInfo({ breakpoint }: UserInfoProps) {
-  const { t } = useTranslation('common');
+  const { t , i18n} = useTranslation('common');
   const user = useSelector(selectLogin());
 
   if (!(user?.anonymous ?? true)) {
     return (
       <UserInfoWrapper $breakpoint={breakpoint}>
         <Text>{`${user?.firstName} ${user?.lastName}`}</Text>
-        <Link href="/api/auth/logout?target=/">{t('site-logout')}</Link>
+        <Link href={`/api/auth/logout?target=/${i18n.language}`}>{t('site-logout')}</Link>
       </UserInfoWrapper>
     );
   }

--- a/src/common/components/authentication-panel/user-info.tsx
+++ b/src/common/components/authentication-panel/user-info.tsx
@@ -10,14 +10,16 @@ export interface UserInfoProps {
 }
 
 export default function UserInfo({ breakpoint }: UserInfoProps) {
-  const { t , i18n} = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
   const user = useSelector(selectLogin());
 
   if (!(user?.anonymous ?? true)) {
     return (
       <UserInfoWrapper $breakpoint={breakpoint}>
         <Text>{`${user?.firstName} ${user?.lastName}`}</Text>
-        <Link href={`/api/auth/logout?target=/${i18n.language}`}>{t('site-logout')}</Link>
+        <Link href={`/api/auth/logout?target=/${i18n.language}`}>
+          {t('site-logout')}
+        </Link>
       </UserInfoWrapper>
     );
   }

--- a/src/common/components/impersonate/use-fakeable-users.ts
+++ b/src/common/components/impersonate/use-fakeable-users.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import useSWR from 'swr';
+import { useTranslation } from 'next-i18next';
 
 export interface UseFakeableUsersResult {
   id: string;
@@ -14,6 +15,7 @@ export default function useFakeableUsers(): UseFakeableUsersResult[] {
     (url) => axios.get(url).then((r) => r.data),
     {}
   );
+  const { i18n } = useTranslation();
 
   return (
     data?.map(({ id, email, displayName }) => ({
@@ -23,7 +25,7 @@ export default function useFakeableUsers(): UseFakeableUsersResult[] {
       impersonate: () =>
         (window.location.href = `/api/auth/fake-login?fake.login.mail=${encodeURIComponent(
           email
-        )}`),
+        )}&target=/${i18n.language}`),
     })) ?? []
   );
 }

--- a/src/common/components/login-modal/login-modal.tsx
+++ b/src/common/components/login-modal/login-modal.tsx
@@ -18,7 +18,7 @@ export default function LoginModalView({
 }: {
   setVisible: Function;
 }) {
-  const { t , i18n} = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
   const { isSmall } = useBreakpoints();
 
   return (

--- a/src/common/components/login-modal/login-modal.tsx
+++ b/src/common/components/login-modal/login-modal.tsx
@@ -18,7 +18,7 @@ export default function LoginModalView({
 }: {
   setVisible: Function;
 }) {
-  const { t } = useTranslation('common');
+  const { t , i18n} = useTranslation('common');
   const { isSmall } = useBreakpoints();
 
   return (
@@ -61,6 +61,6 @@ export default function LoginModalView({
 
   function login(e: MouseEvent | KeyboardEvent) {
     e.preventDefault();
-    window.location.href = '/api/auth/login?target=/';
+    window.location.href = `/api/auth/login?target=/${i18n.language}`;
   }
 }


### PR DESCRIPTION
Set the target to include language in login and logout api calls
- Logout and login will redirect user to frontpage with /{i18n.language} as the path.