### PR TITLE
YTI-1980: Frontpage default language filtering should be removed

### DIFF
--- a/src/common/components/terminology-search/terminology-search.slice.tsx
+++ b/src/common/components/terminology-search/terminology-search.slice.tsx
@@ -45,7 +45,7 @@ export const terminologySearchApi = createApi({
           prefLang: value.language ? value.language : 'fi',
           pageSize: 10,
           pageFrom: Math.max(0, (value.urlState.page - 1) * 10),
-          language: value.urlState.lang ? value.urlState.lang : 'fi',
+          language: value.urlState.lang ? value.urlState.lang : null,
         },
       }),
       providesTags: ['TerminologySearch'],


### PR DESCRIPTION
Changed frontpage search not to filter by language by default. Default preferred language is still fi. 

Unless specified all terminologies will be shown unless otherwise specified by filtering.

Integration tests for checking that the search is correct should probably be done on the api side