### PR TITLE
Fix a bunch of small UI issues

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -145,6 +145,7 @@
   "new-concept-title": "New Concept",
   "new-concept-to-terminology": "New concept to terminology",
   "new-term": "New term",
+  "new-term-modal-description": "All fields are required unless marked optional. It is recommended to fill in all the information.",
   "no-info-domains-available": "No information domains available",
   "no-languages-available": "No languages available",
   "no-other-orgs-available": "No other contributors available",

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -145,6 +145,7 @@
   "new-concept-title": "Uusi käsite",
   "new-concept-to-terminology": "Uusi käsite sanastoon",
   "new-term": "Uusi termi",
+  "new-term-modal-description": "Tiedot ovat pakollisia, jos niitä ei ole merkitty valinnaisiksi. Suositeltavaa on täyttää kaikki tiedot.",
   "no-info-domains-available": "Tietoalueita ei ole saatavilla",
   "no-languages-available": "Kieliä ei saatavilla",
   "no-other-orgs-available": "Muita vastuuorganisaatioita ei ole saatavilla",

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -145,6 +145,7 @@
   "new-concept-title": "",
   "new-concept-to-terminology": "",
   "new-term": "",
+  "new-term-modal-description": "",
   "no-info-domains-available": "",
   "no-languages-available": "",
   "no-other-orgs-available": "",

--- a/src/common/components/relational-information-block/index.tsx
+++ b/src/common/components/relational-information-block/index.tsx
@@ -93,16 +93,27 @@ export default function RelationalInformationBlock({
                       }
                     >
                       <PropertyValue
-                        property={Object.keys(concept.label).map((key) => {
-                          const obj = {
-                            lang: key,
-                            value: concept.label[key],
-                            regex: '',
-                          };
-                          return obj;
-                        })}
-                        fallbackLanguage={'fi'}
+                        property={Object.keys(concept.label).map((lang) => ({
+                          lang,
+                          value: concept.label[lang],
+                          regex: '',
+                        }))}
+                        fallbackLanguage="fi"
                       />
+
+                      {fromOther && ' - '}
+                      {fromOther && (
+                        <PropertyValue
+                          property={Object.keys(concept.terminology.label).map(
+                            (lang) => ({
+                              lang,
+                              value: concept.terminology.label[lang],
+                              regex: '',
+                            })
+                          )}
+                          fallbackLanguage="fi"
+                        />
+                      )}
                     </Chip>
                   );
                 })}

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -2,6 +2,7 @@ import {
   Checkbox,
   Expander,
   ExpanderContent,
+  ExpanderGroup,
   ExpanderTitle,
 } from 'suomifi-ui-components';
 import { ResultList } from './relation-information-block.styles';
@@ -58,8 +59,8 @@ export default function RenderConcepts({
 
   return (
     <>
-      <ResultList>
-        {concepts?.map((concept, idx) => {
+      <ExpanderGroup openAllText="" closeAllText="">
+        {concepts?.map((concept) => {
           const conceptsVocabulary = vocabularies?.filter(
             (vocabulary) => vocabulary.type.graph.id === concept.terminology.id
           );
@@ -75,51 +76,49 @@ export default function RenderConcepts({
           });
 
           return (
-            <li key={`${concept.id}-${idx}`}>
-              <Expander>
-                <ExpanderTitle
-                  ariaCloseText={t('open-concept-expander')}
-                  ariaOpenText={t('close-concept-expander')}
-                  toggleButtonAriaDescribedBy=""
+            <Expander key={concept.id}>
+              <ExpanderTitle
+                ariaCloseText={t('open-concept-expander')}
+                ariaOpenText={t('close-concept-expander')}
+                toggleButtonAriaDescribedBy=""
+              >
+                <Checkbox
+                  hintText={`${organizationTitle} - ${translateStatus(
+                    concept.status ?? 'DRAFT',
+                    t
+                  )}`}
+                  onClick={(e) => handleCheckbox(e, concept)}
+                  checked={chosen.some((chose) => chose.id === concept.id)}
                 >
-                  <Checkbox
-                    hintText={`${organizationTitle} - ${translateStatus(
-                      concept.status ?? 'DRAFT',
-                      t
-                    )}`}
-                    onClick={(e) => handleCheckbox(e, concept)}
-                    checked={chosen.some((chose) => chose.id === concept.id)}
-                  >
-                    <SanitizedTextContent
-                      text={
-                        getPropertyValue({
-                          property: Object.keys(concept.label).map((key) => {
-                            const obj = {
-                              lang: key,
-                              value: concept.label[key],
-                              regex: '',
-                            };
-                            return obj;
-                          }),
-                          language: i18n.language,
-                          fallbackLanguage: 'fi',
-                        }) ??
-                        concept.label[i18n.language] ??
-                        concept.label.fi
-                      }
-                    />
-                  </Checkbox>
-                </ExpanderTitle>
+                  <SanitizedTextContent
+                    text={
+                      getPropertyValue({
+                        property: Object.keys(concept.label).map((key) => {
+                          const obj = {
+                            lang: key,
+                            value: concept.label[key],
+                            regex: '',
+                          };
+                          return obj;
+                        }),
+                        language: i18n.language,
+                        fallbackLanguage: 'fi',
+                      }) ??
+                      concept.label[i18n.language] ??
+                      concept.label.fi
+                    }
+                  />
+                </Checkbox>
+              </ExpanderTitle>
 
-                <RenderExpanderContent
-                  terminologyId={concept.terminology.id}
-                  conceptId={concept.id}
-                />
-              </Expander>
-            </li>
+              <RenderExpanderContent
+                terminologyId={concept.terminology.id}
+                conceptId={concept.id}
+              />
+            </Expander>
           );
         })}
-      </ResultList>
+      </ExpanderGroup>
     </>
   );
 

--- a/src/modules/edit-collection/index.tsx
+++ b/src/modules/edit-collection/index.tsx
@@ -30,6 +30,7 @@ import {
 import { useGetCollectionQuery } from '@app/common/components/collection/collection.slice';
 import { Collection } from '@app/common/interfaces/collection.interface';
 import useUser from '@app/common/utils/hooks/useUser';
+import { translateLanguage } from '@app/common/utils/translation-helpers';
 
 export default function EditCollection({
   terminologyId,
@@ -216,7 +217,10 @@ export default function EditCollection({
           {languages.map((language) => (
             <NameTextInput
               key={`name-input-${language}`}
-              labelText={`${t('field-name')}, ${language.toUpperCase()}`}
+              labelText={`${t('field-name')}, ${translateLanguage(
+                language,
+                t
+              )} ${language.toUpperCase()}`}
               visualPlaceholder={t('enter-collection-name')}
               onBlur={(e) => setName(language, e.target.value)}
               status={errors.name ? 'error' : 'default'}
@@ -229,7 +233,10 @@ export default function EditCollection({
           {languages.map((language) => (
             <DescriptionTextarea
               key={`description-textarea-${language}`}
-              labelText={`${t('field-definition')}, ${language.toUpperCase()}`}
+              labelText={`${t('field-definition')}, ${translateLanguage(
+                language,
+                t
+              )} ${language.toUpperCase()}`}
               visualPlaceholder={t('enter-collection-description')}
               onBlur={(e) => setDescription(language, e.target.value)}
               status={errors.definition ? 'error' : 'default'}

--- a/src/modules/new-concept/basic-information/concept-basic-information.tsx
+++ b/src/modules/new-concept/basic-information/concept-basic-information.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import { ExpanderGroup } from 'suomifi-ui-components';
 import { BasicInfo, ListType } from '../new-concept.types';
 import ListBlock from '../list-block';
+import { translateLanguage } from '@app/common/utils/translation-helpers';
 
 interface ConceptBasicInformationProps {
   updateBasicInformation: (value: BasicInfo) => void;
@@ -113,7 +114,7 @@ export default function ConceptBasicInformation({
     return (
       <WiderTextarea
         labelText={t('definition-label-text', {
-          lang: lang,
+          lang: translateLanguage(lang, t),
           langUpper: lang.toUpperCase(),
         })}
         optionalText={t('optional')}

--- a/src/modules/new-concept/concept-terms-block/concept-terms-block.styles.tsx
+++ b/src/modules/new-concept/concept-terms-block/concept-terms-block.styles.tsx
@@ -7,6 +7,7 @@ import {
   Heading,
   Icon,
   RadioButtonGroup,
+  Text,
   Textarea,
 } from 'suomifi-ui-components';
 
@@ -83,5 +84,10 @@ export const RadioButtonGroupSpaced = styled(RadioButtonGroup)<{
 `;
 
 export const OtherTermsExpanderGroup = styled(ExpanderGroup)`
+  margin-bottom: ${(props) => props.theme.suomifi.spacing.m};
+`;
+
+export const ModalDescription = styled(Text)`
+  display: inline-block;
   margin-bottom: ${(props) => props.theme.suomifi.spacing.m};
 `;

--- a/src/modules/new-concept/concept-terms-block/index.tsx
+++ b/src/modules/new-concept/concept-terms-block/index.tsx
@@ -145,6 +145,7 @@ export default function ConceptTermsBlock({
                 </OtherTermsExpanderGroup>
 
                 <Button
+                  variant="secondaryNoBorder"
                   onClick={() => handleRemoveTerms()}
                   disabled={checkedTerms.length < 1}
                 >

--- a/src/modules/new-concept/concept-terms-block/new-term-modal.tsx
+++ b/src/modules/new-concept/concept-terms-block/new-term-modal.tsx
@@ -23,6 +23,7 @@ import {
   DropdownBlock,
   GrammaticalBlock,
   MediumHeading,
+  ModalDescription,
   RadioButtonGroupSpaced,
   TermEquivalencyBlock,
   WiderTextareaBlock,
@@ -116,6 +117,7 @@ export default function NewTermModal({
     >
       <ModalContent>
         <ModalTitle>{t('new-term')}</ModalTitle>
+        <ModalDescription>{t('new-term-modal-description')}</ModalDescription>
 
         <TextInput
           labelText={t('term-name-label')}

--- a/src/modules/new-concept/index.tsx
+++ b/src/modules/new-concept/index.tsx
@@ -10,10 +10,9 @@ import { useGetVocabularyQuery } from '@app/common/components/vocabulary/vocabul
 import { getProperty } from '@app/common/utils/get-property';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import { Text } from 'suomifi-ui-components';
 import ConceptBasicInformation from './basic-information/concept-basic-information';
 import FormFooter from './form-footer';
-import { NewConceptBlock } from './new-concept.styles';
+import { NewConceptBlock, PageHelpText } from './new-concept.styles';
 import ConceptTermsBlock from './concept-terms-block';
 import { asString } from '@app/common/utils/hooks/useUrlState';
 import { useEffect, useState } from 'react';
@@ -173,7 +172,7 @@ export default function NewConcept({ terminologyId }: NewConceptProps) {
           />
           <Badge>{t('DRAFT')}</Badge>
         </BadgeBar>
-        <Text>{t('new-concept-page-help')}</Text>
+        <PageHelpText>{t('new-concept-page-help')}</PageHelpText>
 
         <ConceptTermsBlock
           languages={languages}

--- a/src/modules/new-concept/new-concept.styles.tsx
+++ b/src/modules/new-concept/new-concept.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Block } from 'suomifi-ui-components';
+import { Block, Text } from 'suomifi-ui-components';
 
 export const FooterBlock = styled(Block)`
   div {
@@ -14,4 +14,9 @@ export const NewConceptBlock = styled(Block)`
   margin-bottom: 80px;
   margin-top: ${(props) => props.theme.suomifi.spacing.m};
   padding: 30px 80px 20px 80px;
+`;
+
+export const PageHelpText = styled(Text)`
+  display: inline-block;
+  max-width: 700px;
 `;

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
@@ -95,7 +95,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
         terminologyId: terminologyId,
         collectionInfo: {
           collectionId: collectionId,
-          createdBy: collectionData.createdBy,
+          createdBy: collectionData.createdBy ?? null,
           collectionCode: collectionData.code,
           collectionUri: collectionData.uri,
         },


### PR DESCRIPTION
Add help text to the new term modal.

![image](https://user-images.githubusercontent.com/1504091/182319391-593fb517-3d8c-4759-a231-7465fcfa3635.png)

Render also the terminology's name in the relation chip if the target concept is not in the same terminology.

![image](https://user-images.githubusercontent.com/1504091/182319584-9fc0752b-877f-4e51-b327-723cb03cb620.png)

Turn a list of expanders into an expander group in relation modal.

![image](https://user-images.githubusercontent.com/1504091/182319742-6146137d-016f-4e27-ade1-82739db54e53.png)

Change remove term button style to match the design.

![image](https://user-images.githubusercontent.com/1504091/182320273-dfead4c8-bb7c-4d24-9495-c499de6e45ec.png)

Fix some broken texts.