### PR TITLE
YTI-1995: Kopioi pohjaksi toiminto

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -271,11 +271,8 @@
   "word-class-available": "Available word classes",
   "word-class-hint": "Toggle only if word class is either an adjective or a verb",
   "word-class-no-items": "No word classes available",
-<<<<<<< HEAD
-  "you-have-right-edit-terminology": "You have the rights to edit this terminology",
-=======
   "you-can-copy": "You can copy the terminology as a base for a newer version, where the original terminology will exist until the newer terminology is ready",
->>>>>>> Added copy as a base modal for terminology
+  "you-have-right-edit-terminology": "You have the rights to edit this terminology",
   "you-have-right-new-collection": "You have the rights to create new collections to this terminology",
   "you-have-right-new-concept": "You have the rights to create new concepts to this terminology"
 }

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -84,6 +84,9 @@
   "content-creator": "Contributor",
   "continue": "Continue",
   "contributor": "Contributor",
+  "copy-as-base": "Copy as a base",
+  "copy-as-base-description": "The prefix is a visible part of a vocabularies url-address and as such a part of the addresses of the concepts within the vocabulary",
+  "copy-from-terminology-as-base": "Create a new version of the terminology",
   "definition": "Definition",
   "definition-label-text": "Definition, $t({{lang}}) {{langUpper}}",
   "description": "Description",
@@ -150,6 +153,7 @@
   "new-concept-to-terminology": "New concept to terminology",
   "new-term": "New term",
   "new-term-modal-description": "All fields are required unless marked optional. It is recommended to fill in all the information.",
+  "new-terminology-created": "New terminology created",
   "no-info-domains-available": "No information domains available",
   "no-languages-available": "No languages available",
   "no-other-orgs-available": "No other contributors available",
@@ -267,7 +271,11 @@
   "word-class-available": "Available word classes",
   "word-class-hint": "Toggle only if word class is either an adjective or a verb",
   "word-class-no-items": "No word classes available",
+<<<<<<< HEAD
   "you-have-right-edit-terminology": "You have the rights to edit this terminology",
+=======
+  "you-can-copy": "You can copy the terminology as a base for a newer version, where the original terminology will exist until the newer terminology is ready",
+>>>>>>> Added copy as a base modal for terminology
   "you-have-right-new-collection": "You have the rights to create new collections to this terminology",
   "you-have-right-new-concept": "You have the rights to create new concepts to this terminology"
 }

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -271,11 +271,8 @@
   "word-class-available": "Saatavilla olevat sanaluokat",
   "word-class-hint": "Merkitään vain jos sanaluokka on adjektiivi tai verbi",
   "word-class-no-items": "Sanaluokka ei saatavilla",
-<<<<<<< HEAD
-  "you-have-right-edit-terminology": "Sinulla on oikeudet muokata tätä sanastoa",
-=======
   "you-can-copy": "Voit kopioida sanaston pohjaksi uudelle versiolle, jolloin nykyinen sanasto säilyy olemassa kunnes uusi sanasto on valmis",
->>>>>>> Added copy as a base modal for terminology
+  "you-have-right-edit-terminology": "Sinulla on oikeudet muokata tätä sanastoa",
   "you-have-right-new-collection": "Sinulla on oikeudet luoda uusia käsitekokoelmia sanastoon",
   "you-have-right-new-concept": "Sinulla on oikeudet luoda uusia käsitteitä sanastoon"
 }

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -84,6 +84,9 @@
   "content-creator": "Sisällöntuottaja",
   "continue": "Jatka",
   "contributor": "Vastuuorganisaatio",
+  "copy-as-base": "Kopioi pohjaksi",
+  "copy-as-base-description": "Tunnus on näkyvä osa sanaston url-osoitetta ja näin ollen myös osa sanastossa sijaitsevien käsitteiden osoitteita",
+  "copy-from-terminology-as-base": "Luo uusi versio sanastosta",
   "definition": "Määritelmä",
   "definition-label-text": "Määritelmä, $t({{lang}}) {{langUpper}}",
   "description": "Kuvaus",
@@ -150,6 +153,7 @@
   "new-concept-to-terminology": "Uusi käsite sanastoon",
   "new-term": "Uusi termi",
   "new-term-modal-description": "Tiedot ovat pakollisia, jos niitä ei ole merkitty valinnaisiksi. Suositeltavaa on täyttää kaikki tiedot.",
+  "new-terminology-created": "Uusi sanasto luotu",
   "no-info-domains-available": "Tietoalueita ei ole saatavilla",
   "no-languages-available": "Kieliä ei saatavilla",
   "no-other-orgs-available": "Muita vastuuorganisaatioita ei ole saatavilla",
@@ -267,7 +271,11 @@
   "word-class-available": "Saatavilla olevat sanaluokat",
   "word-class-hint": "Merkitään vain jos sanaluokka on adjektiivi tai verbi",
   "word-class-no-items": "Sanaluokka ei saatavilla",
+<<<<<<< HEAD
   "you-have-right-edit-terminology": "Sinulla on oikeudet muokata tätä sanastoa",
+=======
+  "you-can-copy": "Voit kopioida sanaston pohjaksi uudelle versiolle, jolloin nykyinen sanasto säilyy olemassa kunnes uusi sanasto on valmis",
+>>>>>>> Added copy as a base modal for terminology
   "you-have-right-new-collection": "Sinulla on oikeudet luoda uusia käsitekokoelmia sanastoon",
   "you-have-right-new-concept": "Sinulla on oikeudet luoda uusia käsitteitä sanastoon"
 }

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -84,6 +84,9 @@
   "content-creator": "",
   "continue": "",
   "contributor": "",
+  "copy-as-base": "",
+  "copy-as-base-description": "",
+  "copy-from-terminology-as-base": "",
   "definition": "",
   "definition-label-text": "",
   "description": "",
@@ -150,6 +153,7 @@
   "new-concept-to-terminology": "",
   "new-term": "",
   "new-term-modal-description": "",
+  "new-terminology-created": "",
   "no-info-domains-available": "",
   "no-languages-available": "",
   "no-other-orgs-available": "",
@@ -267,7 +271,11 @@
   "word-class-available": "",
   "word-class-hint": "",
   "word-class-no-items": "",
+<<<<<<< HEAD
   "you-have-right-edit-terminology": "",
+=======
+  "you-can-copy": "",
+>>>>>>> Added copy as a base modal for terminology
   "you-have-right-new-collection": "",
   "you-have-right-new-concept": ""
 }

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -271,11 +271,8 @@
   "word-class-available": "",
   "word-class-hint": "",
   "word-class-no-items": "",
-<<<<<<< HEAD
-  "you-have-right-edit-terminology": "",
-=======
   "you-can-copy": "",
->>>>>>> Added copy as a base modal for terminology
+  "you-have-right-edit-terminology": "",
   "you-have-right-new-collection": "",
   "you-have-right-new-concept": ""
 }

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
@@ -1,0 +1,38 @@
+import { makeStore } from '@app/store';
+import { getMockContext, themeProvider } from '@app/tests/test-utils';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import CopyTerminologyModal from './copy-terminology-modal';
+
+describe('render', () => {
+  let appRoot: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    appRoot = document.createElement('div');
+    appRoot.setAttribute('id', '__next');
+    document.body.appendChild(appRoot);
+  });
+
+  it('should render component', () => {
+    const store = makeStore(getMockContext());
+    render(
+      <Provider store={store}>
+        <CopyTerminologyModal
+          terminologyId={'testid'}
+          visible={true}
+          setVisible={() => {}}
+        />
+      </Provider>,
+      { wrapper: themeProvider }
+    );
+    //Normal components are on screen
+    expect(screen.getByText('tr-copy-as-base')).toBeInTheDocument();
+    expect(screen.getByText('tr-copy-as-base-description')).toBeInTheDocument();
+    //Prefix component is on screen
+    expect(screen.getByText('tr-prefix')).toBeInTheDocument();
+    expect(screen.getByText('tr-prefix-hint')).toBeInTheDocument();
+    expect(screen.getByText('tr-automatic-prefix')).toBeInTheDocument();
+    expect(screen.getByText('tr-manual-prefix')).toBeInTheDocument();
+    expect(screen.getByText('tr-url-preview')).toBeInTheDocument();
+  });
+});

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
@@ -1,3 +1,4 @@
+import '@app/tests/matchMedia.mock';
 import { makeStore } from '@app/store';
 import { getMockContext, themeProvider } from '@app/tests/test-utils';
 import { render, screen } from '@testing-library/react';
@@ -11,19 +12,6 @@ describe('render', () => {
     appRoot = document.createElement('div');
     appRoot.setAttribute('id', '__next');
     document.body.appendChild(appRoot);
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // deprecated
-        removeListener: jest.fn(), // deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
   });
 
   it('should render component', () => {

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
@@ -28,12 +28,13 @@ describe('render', () => {
 
   it('should render component', () => {
     const store = makeStore(getMockContext());
+    const mockFn = jest.fn();
     render(
       <Provider store={store}>
         <CopyTerminologyModal
           terminologyId={'testid'}
           visible={true}
-          setVisible={() => {}}
+          setVisible={mockFn}
         />
       </Provider>,
       { wrapper: themeProvider }

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
@@ -13,7 +13,7 @@ describe('render', () => {
     document.body.appendChild(appRoot);
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: jest.fn().mockImplementation(query => ({
+      value: jest.fn().mockImplementation((query) => ({
         matches: false,
         media: query,
         onchange: null,

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.test.tsx
@@ -11,6 +11,19 @@ describe('render', () => {
     appRoot = document.createElement('div');
     appRoot.setAttribute('id', '__next');
     document.body.appendChild(appRoot);
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   it('should render component', () => {

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.tsx
@@ -1,0 +1,112 @@
+import { useTranslation } from 'next-i18next';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalTitle,
+  Paragraph,
+  Text,
+} from 'suomifi-ui-components';
+import { useBreakpoints } from '../media-query/media-query-context';
+import { usePostCreateVersionMutation } from '../vocabulary/vocabulary.slice';
+import { v4 } from 'uuid';
+import { useStoreDispatch } from '@app/store';
+import { terminologySearchApi } from '../terminology-search/terminology-search.slice';
+import Prefix from '../terminology-components/prefix';
+import { UpdateTerminology } from '@app/modules/new-terminology/update-terminology.interface';
+import { setAlert } from '../alert/alert.slice';
+import { useRouter } from 'next/router';
+
+interface CopyTerminologyModalProps {
+  terminologyId: string;
+  visible: boolean;
+  setVisible: (value: boolean) => void;
+}
+
+export default function CopyTerminologyModal({
+  terminologyId,
+  visible,
+  setVisible,
+}: CopyTerminologyModalProps) {
+  const { t } = useTranslation('admin');
+  const dispatch = useStoreDispatch();
+  const { isSmall } = useBreakpoints();
+  const [randomURL] = useState(v4().substring(0, 8));
+  const [userPosted, setUserPosted] = useState(false);
+  const [newGraphId, setNewGraphId] = useState('');
+  const [postCreateVersion, createVersion] = usePostCreateVersionMutation();
+  const [newCode, setNewCode] = useState(randomURL);
+  const router = useRouter();
+
+  const handleUpdate = ({ key, data }: UpdateTerminology) => {
+    if (key === 'prefix') {
+      setNewCode((data as [string, boolean])[0]);
+    }
+  };
+
+  const handleClose = useCallback(() => {
+    setUserPosted(false);
+    setVisible(false);
+  }, [setVisible]);
+
+  useEffect(() => {
+    if (createVersion.isSuccess && newGraphId) {
+      handleClose();
+      dispatch(terminologySearchApi.util.invalidateTags(['TerminologySearch']));
+      dispatch(
+        setAlert(
+          [
+            {
+              note: {
+                status: 0,
+                data: '',
+              },
+              displayText: t('new-terminology-created'),
+            },
+          ],
+          []
+        )
+      );
+      router.push(`/terminology/${newGraphId}`);
+    }
+  }, [createVersion, newGraphId]);
+
+  const handlePost = () => {
+    if (!newCode) {
+      return;
+    }
+    setUserPosted(true);
+    var graphId = terminologyId;
+    postCreateVersion({ graphId, newCode })
+      .unwrap()
+      .then((data) => {
+        setNewGraphId(data.newGraphId);
+      });
+  };
+
+  return (
+    <Modal
+      appElementId="__next"
+      visible={visible}
+      onEscKeyDown={() => handleClose()}
+      variant={!isSmall ? 'default' : 'smallScreen'}
+    >
+      <ModalContent>
+        <ModalTitle>{t('copy-as-base')}</ModalTitle>
+        <Paragraph>
+          <Text>{t('copy-as-base-description')}</Text>
+        </Paragraph>
+        <Prefix update={handleUpdate} userPosted={userPosted} />
+      </ModalContent>
+
+      <ModalFooter>
+        <Button onClick={(e) => handlePost()}>{t('save')}</Button>
+        <Button variant="secondary" onClick={() => handleClose()}>
+          {t('cancel-variant')}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/common/components/copy-terminology-modal/copy-terminology-modal.tsx
+++ b/src/common/components/copy-terminology-modal/copy-terminology-modal.tsx
@@ -51,34 +51,38 @@ export default function CopyTerminologyModal({
     setVisible(false);
   }, [setVisible]);
 
+  const showCreatedAlert = () => {
+    dispatch(
+      setAlert(
+        [
+          {
+            note: {
+              status: 0,
+              data: '',
+            },
+            displayText: t('new-terminology-created'),
+          },
+        ],
+        []
+      )
+    );
+  };
+
   useEffect(() => {
     if (createVersion.isSuccess && newGraphId) {
       handleClose();
       dispatch(terminologySearchApi.util.invalidateTags(['TerminologySearch']));
-      dispatch(
-        setAlert(
-          [
-            {
-              note: {
-                status: 0,
-                data: '',
-              },
-              displayText: t('new-terminology-created'),
-            },
-          ],
-          []
-        )
-      );
+      showCreatedAlert();
       router.push(`/terminology/${newGraphId}`);
     }
-  }, [createVersion, newGraphId]);
+  }, [createVersion, newGraphId, dispatch, handleClose, router]);
 
   const handlePost = () => {
     if (!newCode) {
       return;
     }
     setUserPosted(true);
-    var graphId = terminologyId;
+    const graphId = terminologyId;
     postCreateVersion({ graphId, newCode })
       .unwrap()
       .then((data) => {

--- a/src/common/components/copy-terminology-modal/index.tsx
+++ b/src/common/components/copy-terminology-modal/index.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'next-i18next';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { Button } from 'suomifi-ui-components';
+import { BasicBlock } from '../block';
+import { BasicBlockExtraWrapper } from '../block/block.styles';
+import Separator from '../separator';
+
+const CopyTerminologyModalDynamic = dynamic(
+  () => import('./copy-terminology-modal')
+);
+
+interface CopyTerminologyModalProps {
+  terminologyId: string;
+}
+
+export default function CopyTerminologyModal({
+  terminologyId,
+}: CopyTerminologyModalProps) {
+  const { t } = useTranslation('admin');
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <Separator isLarge />
+
+      <BasicBlock
+        title={t('copy-from-terminology-as-base')}
+        extra={
+          <BasicBlockExtraWrapper>
+            <Button
+              icon="copy"
+              variant="secondary"
+              onClick={() => setVisible(true)}
+            >
+              {t('copy-as-base')}
+            </Button>
+          </BasicBlockExtraWrapper>
+        }
+      >
+        {t('you-can-copy')}
+      </BasicBlock>
+
+      {visible && (
+        <CopyTerminologyModalDynamic
+          terminologyId={terminologyId}
+          visible={visible}
+          setVisible={setVisible}
+        />
+      )}
+    </>
+  );
+}

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -30,6 +30,7 @@ const Subscription = dynamic(
   () => import('@app/common/components/subscription/subscription')
 );
 const NewConceptModal = dynamic(() => import('../new-concept-modal'));
+const CopyTerminologyModal = dynamic(() => import('../copy-terminology-modal'));
 
 interface InfoExpanderProps {
   data?: VocabularyInfoDTO;
@@ -170,6 +171,10 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         >
           {t('vocabulary-info-vocabulary-export-description')}
         </BasicBlock>
+
+        {HasPermission({
+          actions: 'CREATE_TERMINOLOGY',
+        }) && <CopyTerminologyModal terminologyId={data.type.graph.id} />}
 
         {!user.anonymous && (
           <>

--- a/src/common/components/vocabulary/vocabulary.slice.tsx
+++ b/src/common/components/vocabulary/vocabulary.slice.tsx
@@ -4,6 +4,7 @@ import { Collection } from '@app/common/interfaces/collection.interface';
 import {
   VocabulariesDTO,
   VocabularyConcepts,
+  VocabularyCopyInfo,
   VocabularyInfoDTO,
 } from '@app/common/interfaces/vocabulary.interface';
 import { UrlState } from '@app/common/utils/hooks/useUrlState';
@@ -73,6 +74,19 @@ export const vocabularyApi = createApi({
         data: newTerminology,
       }),
     }),
+    postCreateVersion: builder.mutation<
+      VocabularyCopyInfo,
+      { graphId: string; newCode: string }
+    >({
+      query: ({ graphId, newCode }) => ({
+        url: `/createVersion`,
+        method: 'POST',
+        data: {
+          graphId: graphId,
+          newCode: newCode,
+        },
+      }),
+    }),
     // Note! This can added to use at any point
     // deleteVocabulary: builder.mutation<any, any>({
     //   query: (uuid) => ({
@@ -100,6 +114,7 @@ export const {
   useGetConceptResultQuery,
   useGetVocabularyQuery,
   usePostNewVocabularyMutation,
+  usePostCreateVersionMutation,
   // useDeleteVocabularyMutation,
   useGetIfNamespaceInUseQuery,
   useGetVocabulariesQuery,

--- a/src/common/components/vocabulary/vocabulary.slice.tsx
+++ b/src/common/components/vocabulary/vocabulary.slice.tsx
@@ -79,7 +79,7 @@ export const vocabularyApi = createApi({
       { graphId: string; newCode: string }
     >({
       query: ({ graphId, newCode }) => ({
-        url: `/createVersion`,
+        url: '/createVersion',
         method: 'POST',
         data: {
           graphId: graphId,

--- a/src/common/interfaces/vocabulary.interface.ts
+++ b/src/common/interfaces/vocabulary.interface.ts
@@ -21,6 +21,11 @@ export interface VocabularyInfoDTO
   };
 }
 
+export interface VocabularyCopyInfo {
+  newGraphId: string;
+  uri: string;
+}
+
 export interface VocabularyConcepts {
   concepts: VocabularyConceptDTO[];
   resultStart: number;


### PR DESCRIPTION
Changelog:
- New button on drop-down info of terminology
- Open modal for copying terminology as a base
- New connection to backend api endpoint for copying as a base
- translations for english and finnish for all related components
- unit tests for checking if components are rendered properly

![image](https://user-images.githubusercontent.com/19401683/183891375-80619d0e-23d6-40e1-afd8-d1fa1c5bcc8b.png)
![image](https://user-images.githubusercontent.com/19401683/183891490-9c7559bd-93db-4615-a71c-d1ead54dd507.png)
![image](https://user-images.githubusercontent.com/19401683/183891770-1ad2aed5-4c6c-4ec4-b8ba-2a6d5af1ffae.png)
