### PR TITLE
Fixed bug with concept's uri going missing

### DIFF
--- a/src/modules/edit-concept/generate-concept-test-expected.tsx
+++ b/src/modules/edit-concept/generate-concept-test-expected.tsx
@@ -1,6 +1,5 @@
 export const conceptWithOneTerm = [
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '0',
@@ -117,10 +116,8 @@ export const conceptWithOneTerm = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '1',
@@ -230,13 +227,260 @@ export const conceptWithOneTerm = [
       id: 'Concept',
       uri: 'http://www.w3.org/2004/02/skos/core#Concept',
     },
-    uri: '',
+  },
+];
+
+export const conceptWithOneTermWithInitialData = [
+  {
+    code: 'term-1000',
+    createdBy: 'Admin User',
+    createdDate: '1970-01-01T00:00:00.000Z',
+    id: '789',
+    lastModifiedBy: 'Admin User',
+    lastModifiedDate: '1970-01-01T00:00:00.000Z',
+    properties: {
+      changeNote: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      draftComment: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      editorialNote: [],
+      historyNote: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      prefLabel: [
+        {
+          lang: 'fi',
+          regex: '(?s)^.*$',
+          value: 'prefLabel',
+        },
+      ],
+      scope: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      source: [],
+      status: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: 'DRAFT',
+        },
+      ],
+      termConjugation: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termEquivalency: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termEquivalencyRelation: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termFamily: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termHomographNumber: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termInfo: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      termStyle: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      wordClass: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+    },
+    references: {},
+    referrers: {
+      prefLabelXl: [
+        {
+          id: '123',
+          type: {
+            graph: {
+              id: 'terminologyId',
+            },
+            id: 'Concept',
+            uri: '',
+          },
+        },
+      ],
+    },
+    type: {
+      graph: {
+        id: 'terminologyId',
+      },
+      id: 'Term',
+      uri: '',
+    },
+    uri: 'sanastot.suomi.fi/sanasto/term-1000',
+  },
+  {
+    code: 'concept-1000',
+    createdBy: 'Admin User',
+    createdDate: '1970-01-01T00:00:00.000Z',
+    id: '1',
+    lastModifiedBy: '',
+    lastModifiedDate: '1970-01-01T00:00:00.000Z',
+    properties: {
+      changeNote: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      conceptClass: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      conceptScope: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      definition: [],
+      editorialNote: [],
+      example: [],
+      externalLink: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      historyNote: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      notation: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      note: [],
+      source: [],
+      status: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: 'DRAFT',
+        },
+      ],
+      subjectArea: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+      wordClass: [
+        {
+          lang: '',
+          regex: '(?s)^.*$',
+          value: '',
+        },
+      ],
+    },
+    references: {
+      altLabelXl: [],
+      broader: [],
+      closeMatch: [],
+      exactMatch: [],
+      hasPart: [],
+      hiddenTerm: [],
+      isPartOf: [],
+      narrower: [],
+      notRecommendedSynonym: [],
+      prefLabelXl: [
+        {
+          id: '789',
+          type: {
+            graph: {
+              id: 'terminologyId',
+            },
+            id: 'Term',
+            uri: '',
+          },
+        },
+      ],
+      related: [],
+      relatedMatch: [],
+      searchTerm: [],
+    },
+    referrers: {},
+    type: {
+      graph: {
+        id: 'terminologyId',
+      },
+      id: 'Concept',
+      uri: '',
+    },
+    uri: 'sanastot.suomi.fi/sanasto/concept-1000',
   },
 ];
 
 export const conceptWithInternalRelations = [
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '0',
@@ -353,10 +597,8 @@ export const conceptWithInternalRelations = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '',
@@ -521,13 +763,11 @@ export const conceptWithInternalRelations = [
       id: 'Concept',
       uri: 'http://www.w3.org/2004/02/skos/core#Concept',
     },
-    uri: '',
   },
 ];
 
 export const differentTerms = [
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '0',
@@ -656,10 +896,8 @@ export const differentTerms = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '1',
@@ -788,10 +1026,8 @@ export const differentTerms = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '2',
@@ -920,10 +1156,8 @@ export const differentTerms = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '3',
@@ -1052,10 +1286,8 @@ export const differentTerms = [
       id: 'Term',
       uri: 'http://www.w3.org/2008/05/skos-xl#Label',
     },
-    uri: '',
   },
   {
-    code: '',
     createdBy: '',
     createdDate: '1970-01-01T00:00:00.000Z',
     id: '6e00b816-c077-4747-8597-46047005584d',
@@ -1228,6 +1460,5 @@ export const differentTerms = [
       id: 'Concept',
       uri: 'http://www.w3.org/2004/02/skos/core#Concept',
     },
-    uri: '',
   },
 ];

--- a/src/modules/edit-concept/generate-concept.test.tsx
+++ b/src/modules/edit-concept/generate-concept.test.tsx
@@ -2,6 +2,7 @@ import generateConcept from './generate-concept';
 import {
   conceptWithInternalRelations,
   conceptWithOneTerm,
+  conceptWithOneTermWithInitialData,
   differentTerms,
 } from './generate-concept-test-expected';
 
@@ -76,6 +77,186 @@ describe('generate-concept', () => {
     returned[1].id = '1';
 
     expect(returned).toStrictEqual(conceptWithOneTerm);
+  });
+
+  it('should generate concept with one term with initial data provided', () => {
+    const input = {
+      terms: [
+        {
+          changeNote: '',
+          draftComment: '',
+          editorialNote: [],
+          historyNote: '',
+          id: '789',
+          language: 'fi',
+          prefLabel: 'prefLabel',
+          scope: '',
+          source: '',
+          status: 'draft',
+          termConjugation: '',
+          termEquivalency: '',
+          termEquivalencyRelation: '',
+          termFamily: '',
+          termHomographNumber: '',
+          termInfo: '',
+          termStyle: '',
+          termType: 'recommended-term',
+          wordClass: '',
+        },
+      ],
+      basicInformation: {
+        definition: {},
+        example: [],
+        subject: '',
+        note: [],
+        diagramAndSource: {
+          diagram: [],
+          sources: '',
+        },
+        orgInfo: {
+          changeHistory: '',
+          editorialNote: [],
+          etymology: '',
+        },
+        otherInfo: {
+          conceptClass: '',
+          wordClass: '',
+        },
+        relationalInfo: {
+          broaderConcept: [],
+          narrowerConcept: [],
+          relatedConcept: [],
+          isPartOfConcept: [],
+          hasPartConcept: [],
+          relatedConceptInOther: [],
+          matchInOther: [],
+        },
+      },
+    };
+
+    const returned = generateConcept({
+      data: input,
+      terminologyId: 'terminologyId',
+      initialValue: {
+        code: 'concept-1000',
+        createdBy: 'Admin User',
+        createdDate: '1970-01-01T00:00:00.000Z',
+        id: '123',
+        identifier: {
+          id: '123',
+          type: {
+            graph: {
+              id: '456',
+            },
+            id: 'Concept',
+            uri: '',
+          },
+        },
+        lastModifiedBy: 'Admin User',
+        lastModifiedDate: '1970-01-01T00:00:00.000Z',
+        number: 0,
+        properties: {
+          status: [{ lang: '', value: 'DRAFT', regex: '(?s)^.*$' }],
+        },
+        references: {
+          prefLabelXl: [
+            {
+              code: 'term-1000',
+              createdBy: 'Admin User',
+              createdDate: '1970-01-01T00:00:00.000Z',
+              id: '789',
+              identifier: {
+                id: '789',
+                type: {
+                  graph: {
+                    id: '456',
+                  },
+                  id: 'Term',
+                  uri: '',
+                },
+              },
+              lastModifiedBy: 'Admin User',
+              lastModifiedDate: '1970-01-01T00:00:00.000Z',
+              number: 0,
+              properties: {
+                prefLabel: [
+                  {
+                    lang: 'fi',
+                    value: 'termi',
+                    regex: '(?s)^.*$',
+                  },
+                ],
+                status: [{ lang: '', value: 'DRAFT', regex: '(?s)^.*$' }],
+              },
+              references: {},
+              referrers: {
+                prefLabelXl: [
+                  {
+                    code: 'concept-1000',
+                    createdBy: 'Admin User',
+                    createdDate: '1970-01-01T00:00:00.000Z',
+                    id: '123',
+                    identifier: {
+                      id: '123',
+                      type: {
+                        graph: {
+                          id: '456',
+                        },
+                        id: 'Concept',
+                        uri: '',
+                      },
+                    },
+                    number: 0,
+                    properties: {
+                      status: [{ lang: '', value: 'DRAFT', regex: '(?s)^.*$' }],
+                    },
+                    references: {},
+                    referreres: {},
+                    type: {
+                      graph: {
+                        id: '456',
+                      },
+                      id: 'Concept',
+                      uri: '',
+                    },
+                    uri: 'sanastot.suomi.fi/sanasto/concept-1000',
+                  },
+                ],
+              },
+              type: {
+                graph: {
+                  id: '456',
+                },
+                id: 'Term',
+                uri: '',
+              },
+              uri: 'sanastot.suomi.fi/sanasto/term-1000',
+            },
+          ],
+        },
+        referrers: {},
+        type: {
+          graph: {
+            id: '456',
+          },
+          id: 'Concept',
+          uri: '',
+        },
+        uri: 'sanastot.suomi.fi/sanasto/concept-1000',
+      },
+      lastModifiedBy: 'Admin User',
+    }).map((json) => {
+      // Replacing generated time stamps with expected values
+      json.createdDate = '1970-01-01T00:00:00.000Z';
+      json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
+      return json;
+    });
+
+    // Replacing the last object's id with expected value
+    // since it's randombly generated in the function
+    returned[1].id = '1';
+
+    expect(returned).toStrictEqual(conceptWithOneTermWithInitialData);
   });
 
   it('should generate concept with one term that has relations to same vocabulary concepts', () => {

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -57,8 +57,7 @@ export default function generateConcept({
       ? getInitialTerm(term.id, initialValue.references)
       : null;
 
-    return {
-      code: initialTerm ? initialTerm.code : '',
+    const obj: any = {
       createdBy: initialValue ? initialTerm?.createdBy ?? '' : '',
       createdDate: initialValue
         ? initialTerm?.createdDate ?? ''
@@ -207,8 +206,14 @@ export default function generateConcept({
         id: 'Term',
         uri: initialValue ? '' : 'http://www.w3.org/2008/05/skos-xl#Label',
       },
-      uri: initialTerm ? initialTerm.uri : '',
     };
+
+    if (initialTerm) {
+      obj.code = initialTerm.code;
+      obj.uri = initialTerm.uri;
+    }
+
+    return obj;
   });
 
   let externalTerms =
@@ -332,11 +337,10 @@ export default function generateConcept({
       ] ?? [];
   }
 
-  return [
+  const retVal = [
     ...terms,
     ...externalTerms,
     {
-      code: initialValue?.code ?? '',
       createdBy: initialValue ? initialValue.createdBy : '',
       createdDate: now.toISOString(),
       id: initialValue ? initialValue.id : v4(),
@@ -600,9 +604,15 @@ export default function generateConcept({
         id: 'Concept',
         uri: initialValue ? '' : 'http://www.w3.org/2004/02/skos/core#Concept',
       },
-      uri: initialValue?.uri ?? '',
     },
   ];
+
+  if (initialValue) {
+    retVal[retVal.length - 1].code = initialValue.code ?? '';
+    retVal[retVal.length - 1].uri = initialValue.uri ?? '';
+  }
+
+  return retVal;
 }
 
 function getInitialTerm(id: string, terms: Concept['references']): Term | null {


### PR DESCRIPTION
Changes in this PR:
- Fixed a bug with concept's uri going missing. Initial values are checked when generating object used in API and added if necessary. Also removed `code` and `uri` keys from added to object if initial values isn't provided (when creating new concept both of these key-value pairs are left out)