### PR TITLE
Added replace() to sites we don't want in history

### DIFF
--- a/src/modules/edit-collection/index.tsx
+++ b/src/modules/edit-collection/index.tsx
@@ -76,7 +76,7 @@ export default function EditCollection({
 
   useEffect(() => {
     if (result.isSuccess) {
-      router.push(
+      router.replace(
         `/terminology/${terminologyId}/collection/${newCollectionId}`
       );
     }
@@ -166,11 +166,11 @@ export default function EditCollection({
 
   const handleCancel = () => {
     if (collectionInfo?.collectionId) {
-      router.push(
+      router.replace(
         `/terminology/${terminologyId}/collection/${collectionInfo?.collectionId}`
       );
     } else {
-      router.push(`/terminology/${terminologyId}`);
+      router.replace(`/terminology/${terminologyId}`);
     }
   };
 

--- a/src/modules/edit-concept/form-footer.tsx
+++ b/src/modules/edit-concept/form-footer.tsx
@@ -14,7 +14,7 @@ export default function FormFooter({ handlePost, isEdit }: FormFooterProps) {
   const router = useRouter();
 
   const handleCancel = () => {
-    router.push(
+    router.replace(
       isEdit
         ? `/terminology/${router.query.terminologyId}/concept/${router.query.conceptId}`
         : `/terminology/${router.query.terminologyId}`

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -96,7 +96,7 @@ export default function EditConcept({
 
   useEffect(() => {
     if (addConceptStatus.isSuccess && postedData) {
-      router.push(
+      router.replace(
         `/terminology/${terminologyId}/concept/${
           postedData[postedData.length - 1].id
         }`

--- a/src/modules/edit-vocabulary/index.tsx
+++ b/src/modules/edit-vocabulary/index.tsx
@@ -58,7 +58,7 @@ export default function EditVocabulary({ terminologyId }: EditVocabularyProps) {
   };
 
   const handleReturn = useCallback(() => {
-    router.push(`/terminology/${terminologyId}`);
+    router.replace(`/terminology/${terminologyId}`);
   }, [router, terminologyId]);
 
   useEffect(() => {


### PR DESCRIPTION
Changes in this PR:
- Replaced router.push() to router.replace() in create and edit pages to disable them from going to browser history. This way if users want to go back in history, they don't wind up in editable pages accidentally.