### PR TITLE
Yti 2042 get property better fallback

### DIFF
--- a/src/common/components/block/concept-list-block.tsx
+++ b/src/common/components/block/concept-list-block.tsx
@@ -37,7 +37,6 @@ export default function ConceptListBlock({
                     'prefLabel',
                     concept.references.prefLabelXl
                   )}
-                  fallbackLanguage="fi"
                 />
               </SuomiLink>
             </Link>

--- a/src/common/components/block/property-block.tsx
+++ b/src/common/components/block/property-block.tsx
@@ -8,7 +8,6 @@ export interface PropertyBlockProps {
   title?: React.ReactNode;
   property?: Property[];
   valueAccessor?: (property: Property) => string;
-  fallbackLanguage?: string;
   delimiter?: string | false;
   extra?: React.ReactNode;
   id?: string;
@@ -18,7 +17,6 @@ export default function PropertyBlock({
   title,
   property,
   valueAccessor,
-  fallbackLanguage,
   delimiter = false,
   extra,
   id,
@@ -29,7 +27,6 @@ export default function PropertyBlock({
     property,
     valueAccessor,
     language: i18n.language,
-    fallbackLanguage,
     delimiter,
   });
 

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -69,7 +69,6 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
               getPropertyValue({
                 property: group.properties.prefLabel,
                 language: i18n.language,
-                fallbackLanguage: 'fi',
               })
             )
             .join(', ')}
@@ -223,7 +222,6 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         <PropertyBlock
           title={t('vocabulary-info-organization')}
           property={data.references.contributor?.[0]?.properties.prefLabel}
-          fallbackLanguage="fi"
           id="organization"
         />
         <BasicBlock title={t('vocabulary-info-created-at')} id="created-at">

--- a/src/common/components/property-value/get-property-value.ts
+++ b/src/common/components/property-value/get-property-value.ts
@@ -29,7 +29,7 @@ export function getPropertyValue({
 }
 
 function getMatchingProperties(properties: Property[], language: string) {
-  if(!language && properties.length){
+  if (!language && properties.length) {
     return properties;
   }
   const matchingProperties = properties.filter(({ lang }) => lang === language);

--- a/src/common/components/property-value/get-property-value.ts
+++ b/src/common/components/property-value/get-property-value.ts
@@ -4,7 +4,6 @@ export interface GetPropertyValueParams {
   property?: Property[];
   valueAccessor?: (property: Property) => string;
   language?: string;
-  fallbackLanguage?: string;
   delimiter?: string | false;
 }
 
@@ -12,12 +11,13 @@ export function getPropertyValue({
   property,
   valueAccessor = ({ value }) => value,
   language = '',
-  fallbackLanguage = '',
   delimiter = false,
 }: GetPropertyValueParams): string {
   const matchingProperties =
     getMatchingProperties(property ?? [], language) ??
-    getMatchingProperties(property ?? [], fallbackLanguage) ??
+    getMatchingProperties(property ?? [], 'fi') ??
+    getMatchingProperties(property ?? [], 'en') ??
+    getMatchingProperties(property ?? [], 'sv') ??
     getMatchingProperties(property ?? [], '') ??
     [];
 
@@ -29,6 +29,9 @@ export function getPropertyValue({
 }
 
 function getMatchingProperties(properties: Property[], language: string) {
+  if(!language && properties.length){
+    return properties;
+  }
   const matchingProperties = properties.filter(({ lang }) => lang === language);
 
   if (matchingProperties.length) {

--- a/src/common/components/property-value/index.tsx
+++ b/src/common/components/property-value/index.tsx
@@ -6,7 +6,6 @@ import { getPropertyValue } from './get-property-value';
 export interface PropertyValueProps {
   property?: Property[];
   valueAccessor?: (property: Property) => string;
-  fallbackLanguage?: string;
   delimiter?: string | false;
   fallback?: string;
 }
@@ -36,7 +35,6 @@ export interface PropertyValueProps {
 export default function PropertyValue({
   property,
   valueAccessor,
-  fallbackLanguage,
   delimiter = false,
   fallback,
 }: PropertyValueProps) {
@@ -46,7 +44,6 @@ export default function PropertyValue({
     property,
     valueAccessor,
     language: i18n.language,
-    fallbackLanguage,
     delimiter,
   });
 

--- a/src/common/components/property-value/property-value.test.tsx
+++ b/src/common/components/property-value/property-value.test.tsx
@@ -45,7 +45,7 @@ describe('propertyValue', () => {
           { lang: 'fi', value: 'Value (fi)', regex: '' },
           { lang: 'sv', value: 'Value (sv)', regex: '' },
         ]}
-     />
+      />
     );
 
     expect(screen.getByText('Value (fi)')).toBeInTheDocument();

--- a/src/common/components/property-value/property-value.test.tsx
+++ b/src/common/components/property-value/property-value.test.tsx
@@ -14,7 +14,6 @@ describe('propertyValue', () => {
     render(
       <PropertyValue
         property={[{ lang: '', value: 'Value (no-lang)', regex: '' }]}
-        fallbackLanguage="fi"
       />
     );
 
@@ -30,7 +29,6 @@ describe('propertyValue', () => {
           { lang: 'en', value: 'Value (en)', regex: '' },
           { lang: 'fi', value: 'Value (fi)', regex: '' },
         ]}
-        fallbackLanguage="fi"
       />
     );
 
@@ -38,7 +36,7 @@ describe('propertyValue', () => {
     expect(screen.queryByText('Value (fi)')).not.toBeInTheDocument();
   });
 
-  it('should render localized value in fallback language when found', () => {
+  it('should render localized value in fallback language order (fi, en, sv) when found', () => {
     mockedUseTranslation.mockReturnValue({ i18n: { language: 'en' } });
 
     render(
@@ -47,24 +45,10 @@ describe('propertyValue', () => {
           { lang: 'fi', value: 'Value (fi)', regex: '' },
           { lang: 'sv', value: 'Value (sv)', regex: '' },
         ]}
-        fallbackLanguage="fi"
-      />
+     />
     );
 
     expect(screen.getByText('Value (fi)')).toBeInTheDocument();
-    expect(screen.queryByText('Value (sv)')).not.toBeInTheDocument();
-  });
-
-  it('should not render value in wrong language', () => {
-    mockedUseTranslation.mockReturnValue({ i18n: { language: 'en' } });
-
-    render(
-      <PropertyValue
-        property={[{ lang: 'sv', value: 'Value (sv)', regex: '' }]}
-        fallbackLanguage="fi"
-      />
-    );
-
     expect(screen.queryByText('Value (sv)')).not.toBeInTheDocument();
   });
 

--- a/src/common/components/relational-information-block/index.tsx
+++ b/src/common/components/relational-information-block/index.tsx
@@ -112,7 +112,7 @@ export default function RelationalInformationBlock({
                           value: concept.label[lang],
                           regex: '',
                         }))}
-                     />
+                      />
 
                       {fromOther && ' - '}
                       {fromOther && (
@@ -124,7 +124,7 @@ export default function RelationalInformationBlock({
                               regex: '',
                             })
                           )}
-                       />
+                        />
                       )}
                     </Chip>
                   );

--- a/src/common/components/relational-information-block/index.tsx
+++ b/src/common/components/relational-information-block/index.tsx
@@ -112,8 +112,7 @@ export default function RelationalInformationBlock({
                           value: concept.label[lang],
                           regex: '',
                         }))}
-                        fallbackLanguage="fi"
-                      />
+                     />
 
                       {fromOther && ' - '}
                       {fromOther && (
@@ -125,8 +124,7 @@ export default function RelationalInformationBlock({
                               regex: '',
                             })
                           )}
-                          fallbackLanguage="fi"
-                        />
+                       />
                       )}
                     </Chip>
                   );

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -69,7 +69,7 @@ export default function RenderConcepts({
               : terminology?.properties.prefLabel;
 
           const organizationTitle = getPropertyValue({
-           language: i18n.language,
+            language: i18n.language,
             property: property,
           });
 
@@ -101,7 +101,7 @@ export default function RenderConcepts({
                           return obj;
                         }),
                         language: i18n.language,
-                     }) ??
+                      }) ??
                       concept.label[i18n.language] ??
                       concept.label.fi
                     }

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -69,8 +69,7 @@ export default function RenderConcepts({
               : terminology?.properties.prefLabel;
 
           const organizationTitle = getPropertyValue({
-            fallbackLanguage: 'fi',
-            language: i18n.language,
+           language: i18n.language,
             property: property,
           });
 
@@ -102,8 +101,7 @@ export default function RenderConcepts({
                           return obj;
                         }),
                         language: i18n.language,
-                        fallbackLanguage: 'fi',
-                      }) ??
+                     }) ??
                       concept.label[i18n.language] ??
                       concept.label.fi
                     }

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -167,22 +167,13 @@ export default function SearchResults({
                   }
                 })
                 .map((collection) => {
-                  const prefLabelLangs = collection.properties.prefLabel
-                    ?.map((pl) => pl.lang)
-                    .filter(
-                      (lang) =>
-                        (urlState.lang && lang !== urlState.lang) ||
-                        !urlState.lang
-                    );
-
                   return (
                     <ResultCard
                       key={collection.id}
                       description={
                         <PropertyValue
                           property={collection.properties.definition}
-                          fallbackLanguage={'fi'}
-                          fallback={t('vocabulary-results-no-description')}
+                         fallback={t('vocabulary-results-no-description')}
                         />
                       }
                       extra={
@@ -197,11 +188,7 @@ export default function SearchResults({
                       noStatus
                       title={getPropertyValue({
                         property: collection.properties.prefLabel,
-                        language: urlState.lang ? urlState.lang : i18n.language,
-                        fallbackLanguage:
-                          prefLabelLangs?.[0] !== urlState.lang
-                            ? prefLabelLangs?.[0]
-                            : 'fi',
+                        language: urlState.lang ? urlState.lang : i18n.language
                       })}
                       titleLink={`/terminology/${collection.type.graph.id}/collection/${collection.id}`}
                       type={t('vocabulary-info-collection')}

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -173,7 +173,7 @@ export default function SearchResults({
                       description={
                         <PropertyValue
                           property={collection.properties.definition}
-                         fallback={t('vocabulary-results-no-description')}
+                          fallback={t('vocabulary-results-no-description')}
                         />
                       }
                       extra={
@@ -188,7 +188,7 @@ export default function SearchResults({
                       noStatus
                       title={getPropertyValue({
                         property: collection.properties.prefLabel,
-                        language: urlState.lang ? urlState.lang : i18n.language
+                        language: urlState.lang ? urlState.lang : i18n.language,
                       })}
                       titleLink={`/terminology/${collection.type.graph.id}/collection/${collection.id}`}
                       type={t('vocabulary-info-collection')}

--- a/src/common/components/sidebar/sidebar-section.tsx
+++ b/src/common/components/sidebar/sidebar-section.tsx
@@ -53,8 +53,7 @@ export default function SidebarSection<T extends BaseEntity<string>>({
         return (
           <PropertyValue
             property={prefLabels as Property[]}
-            fallbackLanguage="fi"
-          />
+         />
         );
       } else {
         const prefLabels = Array.from(
@@ -69,16 +68,14 @@ export default function SidebarSection<T extends BaseEntity<string>>({
         return (
           <PropertyValue
             property={prefLabels as Property[]}
-            fallbackLanguage="fi"
-          />
+         />
         );
       }
     } else {
       return (
         <PropertyValue
           property={propertyAccessor(currItem) as Property[]}
-          fallbackLanguage="fi"
-        />
+       />
       );
     }
   }

--- a/src/common/components/sidebar/sidebar-section.tsx
+++ b/src/common/components/sidebar/sidebar-section.tsx
@@ -50,11 +50,7 @@ export default function SidebarSection<T extends BaseEntity<string>>({
       if ('member' in currItem.references) {
         const prefLabels = Array.from(propertyAccessor(currItem) as Property[]);
 
-        return (
-          <PropertyValue
-            property={prefLabels as Property[]}
-         />
-        );
+        return <PropertyValue property={prefLabels as Property[]} />;
       } else {
         const prefLabels = Array.from(
           propertyAccessor(currItem) as Term[],
@@ -65,17 +61,11 @@ export default function SidebarSection<T extends BaseEntity<string>>({
           }
         );
 
-        return (
-          <PropertyValue
-            property={prefLabels as Property[]}
-         />
-        );
+        return <PropertyValue property={prefLabels as Property[]} />;
       }
     } else {
       return (
-        <PropertyValue
-          property={propertyAccessor(currItem) as Property[]}
-       />
+        <PropertyValue property={propertyAccessor(currItem) as Property[]} />
       );
     }
   }

--- a/src/common/components/term-modal/index.tsx
+++ b/src/common/components/term-modal/index.tsx
@@ -50,9 +50,7 @@ export default function TermModal({ data }: TermModalProps) {
           be rendered. Same solution in <ModalTitle /> below.
         */}
         {data.term.properties.prefLabel?.[0].value ?? (
-          <PropertyValue
-            property={data.term.properties.prefLabel}
-         />
+          <PropertyValue property={data.term.properties.prefLabel} />
         )}
       </TermModalButton>
       <Modal
@@ -64,9 +62,7 @@ export default function TermModal({ data }: TermModalProps) {
         <ModalContent>
           <ModalTitle>
             {data.term.properties.prefLabel?.[0].value ?? (
-              <PropertyValue
-                property={data.term.properties.prefLabel}
-             />
+              <PropertyValue property={data.term.properties.prefLabel} />
             )}
           </ModalTitle>
 

--- a/src/common/components/term-modal/index.tsx
+++ b/src/common/components/term-modal/index.tsx
@@ -52,8 +52,7 @@ export default function TermModal({ data }: TermModalProps) {
         {data.term.properties.prefLabel?.[0].value ?? (
           <PropertyValue
             property={data.term.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
         )}
       </TermModalButton>
       <Modal
@@ -67,8 +66,7 @@ export default function TermModal({ data }: TermModalProps) {
             {data.term.properties.prefLabel?.[0].value ?? (
               <PropertyValue
                 property={data.term.properties.prefLabel}
-                fallbackLanguage="fi"
-              />
+             />
             )}
           </ModalTitle>
 

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -61,8 +61,7 @@ export default function Title({ info, noExpander }: TitleProps) {
       getPropertyValue({
         property: getProperty('prefLabel', info.references.contributor),
         language: i18n.language,
-        fallbackLanguage: 'fi',
-      }) ?? '';
+     }) ?? '';
 
     return (
       <TitleWrapper id="page-title-block">
@@ -93,8 +92,7 @@ export default function Title({ info, noExpander }: TitleProps) {
       getPropertyValue({
         property: info.properties.prefLabel,
         language: i18n.language,
-        fallbackLanguage: 'fi',
-      }) ?? ''
+     }) ?? ''
     );
   }
 }

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -61,7 +61,7 @@ export default function Title({ info, noExpander }: TitleProps) {
       getPropertyValue({
         property: getProperty('prefLabel', info.references.contributor),
         language: i18n.language,
-     }) ?? '';
+      }) ?? '';
 
     return (
       <TitleWrapper id="page-title-block">
@@ -92,7 +92,7 @@ export default function Title({ info, noExpander }: TitleProps) {
       getPropertyValue({
         property: info.properties.prefLabel,
         language: i18n.language,
-     }) ?? ''
+      }) ?? ''
     );
   }
 }

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -73,8 +73,7 @@ export default function Collection({
   const prefLabel = getPropertyValue({
     property: collection?.properties.prefLabel,
     language: i18n.language,
-    fallbackLanguage: 'fi',
-  });
+ });
 
   useEffect(() => {
     if (collection) {
@@ -96,8 +95,7 @@ export default function Collection({
             <BreadcrumbLink url={`/terminology/${terminologyId}`}>
               <PropertyValue
                 property={terminology?.properties.prefLabel}
-                fallbackLanguage="fi"
-              />
+             />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url={''} current>
@@ -140,8 +138,7 @@ export default function Collection({
           <BreadcrumbLink url={`/terminology/${terminologyId}`}>
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink
@@ -150,8 +147,7 @@ export default function Collection({
         >
           <PropertyValue
             property={collection?.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
         </BreadcrumbLink>
       </Breadcrumb>
 
@@ -163,21 +159,18 @@ export default function Collection({
                 'prefLabel',
                 terminology?.references.contributor
               )}
-              fallbackLanguage="fi"
-            />
+           />
           </SubTitle>
           <MainTitle>
             <PropertyValue
               property={collection?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
           </MainTitle>
           <BadgeBar>
             {t('heading')}
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
           </BadgeBar>
 
           <MultilingualPropertyBlock
@@ -232,8 +225,7 @@ export default function Collection({
             property={
               terminology?.references.contributor?.[0]?.properties.prefLabel
             }
-            fallbackLanguage="fi"
-          />
+         />
           <BasicBlock title={t('vocabulary-info-created-at', { ns: 'common' })}>
             <FormattedDate date={collection?.createdDate} />
             {collection?.createdBy && `, ${collection.createdBy}`}

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -73,7 +73,7 @@ export default function Collection({
   const prefLabel = getPropertyValue({
     property: collection?.properties.prefLabel,
     language: i18n.language,
- });
+  });
 
   useEffect(() => {
     if (collection) {
@@ -93,9 +93,7 @@ export default function Collection({
         <Breadcrumb>
           {!terminologyError && (
             <BreadcrumbLink url={`/terminology/${terminologyId}`}>
-              <PropertyValue
-                property={terminology?.properties.prefLabel}
-             />
+              <PropertyValue property={terminology?.properties.prefLabel} />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url={''} current>
@@ -136,18 +134,14 @@ export default function Collection({
       <Breadcrumb>
         {!terminologyError && (
           <BreadcrumbLink url={`/terminology/${terminologyId}`}>
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-           />
+            <PropertyValue property={terminology?.properties.prefLabel} />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink
           url={`/terminology/${terminologyId}/collections/${collectionId}`}
           current
         >
-          <PropertyValue
-            property={collection?.properties.prefLabel}
-         />
+          <PropertyValue property={collection?.properties.prefLabel} />
         </BreadcrumbLink>
       </Breadcrumb>
 
@@ -159,18 +153,14 @@ export default function Collection({
                 'prefLabel',
                 terminology?.references.contributor
               )}
-           />
+            />
           </SubTitle>
           <MainTitle>
-            <PropertyValue
-              property={collection?.properties.prefLabel}
-           />
+            <PropertyValue property={collection?.properties.prefLabel} />
           </MainTitle>
           <BadgeBar>
             {t('heading')}
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-           />
+            <PropertyValue property={terminology?.properties.prefLabel} />
           </BadgeBar>
 
           <MultilingualPropertyBlock
@@ -225,7 +215,7 @@ export default function Collection({
             property={
               terminology?.references.contributor?.[0]?.properties.prefLabel
             }
-         />
+          />
           <BasicBlock title={t('vocabulary-info-created-at', { ns: 'common' })}>
             <FormattedDate date={collection?.createdDate} />
             {collection?.createdBy && `, ${collection.createdBy}`}

--- a/src/modules/concept/administrative-details-expander.tsx
+++ b/src/modules/concept/administrative-details-expander.tsx
@@ -56,19 +56,19 @@ export default function AdministrativeDetailsExpander({
         <PropertyBlock
           title={t('field-change-note')}
           property={concept?.properties.changeNote}
-       />
+        />
         <PropertyBlock
           title={t('field-history-note')}
           property={concept?.properties.historyNote}
-       />
+        />
         <PropertyBlock
           title={t('field-editorial-note')}
           property={concept?.properties.editorialNote}
-       />
+        />
         <PropertyBlock
           title={t('field-notation')}
           property={concept?.properties.notation}
-       />
+        />
       </ExpanderContent>
     </Expander>
   );

--- a/src/modules/concept/administrative-details-expander.tsx
+++ b/src/modules/concept/administrative-details-expander.tsx
@@ -56,23 +56,19 @@ export default function AdministrativeDetailsExpander({
         <PropertyBlock
           title={t('field-change-note')}
           property={concept?.properties.changeNote}
-          fallbackLanguage="fi"
-        />
+       />
         <PropertyBlock
           title={t('field-history-note')}
           property={concept?.properties.historyNote}
-          fallbackLanguage="fi"
-        />
+       />
         <PropertyBlock
           title={t('field-editorial-note')}
           property={concept?.properties.editorialNote}
-          fallbackLanguage="fi"
-        />
+       />
         <PropertyBlock
           title={t('field-notation')}
           property={concept?.properties.notation}
-          fallbackLanguage="fi"
-        />
+       />
       </ExpanderContent>
     </Expander>
   );

--- a/src/modules/concept/diagrams-and-sources-expander.tsx
+++ b/src/modules/concept/diagrams-and-sources-expander.tsx
@@ -40,11 +40,11 @@ export default function DiagramsAndSourcesExpander({
         <PropertyBlock
           title={t('field-concept-diagrams')}
           property={undefined}
-       />
+        />
         <PropertyBlock
           title={t('field-sources')}
           property={concept?.properties.source}
-       />
+        />
       </ExpanderContent>
     </Expander>
   );

--- a/src/modules/concept/diagrams-and-sources-expander.tsx
+++ b/src/modules/concept/diagrams-and-sources-expander.tsx
@@ -40,13 +40,11 @@ export default function DiagramsAndSourcesExpander({
         <PropertyBlock
           title={t('field-concept-diagrams')}
           property={undefined}
-          fallbackLanguage="fi"
-        />
+       />
         <PropertyBlock
           title={t('field-sources')}
           property={concept?.properties.source}
-          fallbackLanguage="fi"
-        />
+       />
       </ExpanderContent>
     </Expander>
   );

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -68,7 +68,6 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
   const prefLabel = getPropertyValue({
     property: getProperty('prefLabel', concept?.references.prefLabelXl),
     language: i18n.language,
-    fallbackLanguage: 'fi',
   });
 
   useEffect(() => {
@@ -94,8 +93,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
             <BreadcrumbLink url={`/terminology/${terminologyId}`}>
               <PropertyValue
                 property={terminology?.properties.prefLabel}
-                fallbackLanguage="fi"
-              />
+             />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url="" current>
@@ -138,8 +136,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
           <BreadcrumbLink url={`/terminology/${terminologyId}`}>
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+             />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink
@@ -158,16 +155,14 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
                 'prefLabel',
                 terminology?.references.contributor
               )}
-              fallbackLanguage="fi"
-            />
+           />
           </SubTitle>
           <MainTitle>{prefLabel}</MainTitle>
           <BadgeBar>
             {t('heading')}
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
             <Badge $isValid={status === 'VALID'}>
               {translateStatus(status, t)}
             </Badge>
@@ -253,8 +248,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
             property={
               terminology?.references.contributor?.[0]?.properties.prefLabel
             }
-            fallbackLanguage="fi"
-          />
+         />
           <BasicBlock title={t('vocabulary-info-created-at', { ns: 'common' })}>
             <FormattedDate date={concept?.createdDate} />
             {concept?.createdBy && `, ${concept.createdBy}`}

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -91,9 +91,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
         <Breadcrumb>
           {!terminologyError && (
             <BreadcrumbLink url={`/terminology/${terminologyId}`}>
-              <PropertyValue
-                property={terminology?.properties.prefLabel}
-             />
+              <PropertyValue property={terminology?.properties.prefLabel} />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url="" current>
@@ -134,9 +132,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
       <Breadcrumb>
         {!terminologyError && (
           <BreadcrumbLink url={`/terminology/${terminologyId}`}>
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-             />
+            <PropertyValue property={terminology?.properties.prefLabel} />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink
@@ -155,14 +151,12 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
                 'prefLabel',
                 terminology?.references.contributor
               )}
-           />
+            />
           </SubTitle>
           <MainTitle>{prefLabel}</MainTitle>
           <BadgeBar>
             {t('heading')}
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-           />
+            <PropertyValue property={terminology?.properties.prefLabel} />
             <Badge $isValid={status === 'VALID'}>
               {translateStatus(status, t)}
             </Badge>
@@ -248,7 +242,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
             property={
               terminology?.references.contributor?.[0]?.properties.prefLabel
             }
-         />
+          />
           <BasicBlock title={t('vocabulary-info-created-at', { ns: 'common' })}>
             <FormattedDate date={concept?.createdDate} />
             {concept?.createdBy && `, ${concept.createdBy}`}

--- a/src/modules/edit-collection/index.tsx
+++ b/src/modules/edit-collection/index.tsx
@@ -190,8 +190,7 @@ export default function EditCollection({
           <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink url="" current>
@@ -206,16 +205,14 @@ export default function EditCollection({
               'prefLabel',
               terminology?.references.contributor
             )}
-            fallbackLanguage="fi"
-          />
+         />
         </SubTitle>
         <MainTitle>{collectionName}</MainTitle>
         <BadgeBar>
           {t('heading')}
           <PropertyValue
             property={terminology?.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
         </BadgeBar>
         <PageHelpText>{t('new-collection-page-help')}</PageHelpText>
 

--- a/src/modules/edit-collection/index.tsx
+++ b/src/modules/edit-collection/index.tsx
@@ -188,9 +188,7 @@ export default function EditCollection({
       <Breadcrumb>
         {router.query.terminologyId && (
           <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-           />
+            <PropertyValue property={terminology?.properties.prefLabel} />
           </BreadcrumbLink>
         )}
         <BreadcrumbLink url="" current>
@@ -205,14 +203,12 @@ export default function EditCollection({
               'prefLabel',
               terminology?.references.contributor
             )}
-         />
+          />
         </SubTitle>
         <MainTitle>{collectionName}</MainTitle>
         <BadgeBar>
           {t('heading')}
-          <PropertyValue
-            property={terminology?.properties.prefLabel}
-         />
+          <PropertyValue property={terminology?.properties.prefLabel} />
         </BadgeBar>
         <PageHelpText>{t('new-collection-page-help')}</PageHelpText>
 

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -120,8 +120,7 @@ export default function EditConcept({
             <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
               <PropertyValue
                 property={terminology?.properties.prefLabel}
-                fallbackLanguage="fi"
-              />
+             />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url="" current>
@@ -163,14 +162,12 @@ export default function EditConcept({
           <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
             <PropertyValue
               property={terminology?.properties.prefLabel}
-              fallbackLanguage="fi"
-            />
+           />
           </BreadcrumbLink>
         )}
         {!!preferredTerms?.length && (
           <BreadcrumbLink url="" current>
-            <PropertyValue property={preferredTerms} fallbackLanguage="fi" />
-          </BreadcrumbLink>
+         </BreadcrumbLink>
         )}
       </Breadcrumb>
 
@@ -181,18 +178,15 @@ export default function EditConcept({
               'prefLabel',
               terminology?.references.contributor
             )}
-            fallbackLanguage="fi"
-          />
+         />
         </SubTitle>
         <MainTitle>
-          <PropertyValue property={preferredTerms} fallbackLanguage="fi" />
-        </MainTitle>
+       </MainTitle>
         <BadgeBar>
           {t('heading')}
           <PropertyValue
             property={terminology?.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
           <Badge>{t('statuses.draft', { ns: 'common' })}</Badge>
         </BadgeBar>
         <PageHelpText>{t('new-concept-page-help')}</PageHelpText>

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -118,9 +118,7 @@ export default function EditConcept({
         <Breadcrumb>
           {router.query.terminologyId && (
             <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
-              <PropertyValue
-                property={terminology?.properties.prefLabel}
-             />
+              <PropertyValue property={terminology?.properties.prefLabel} />
             </BreadcrumbLink>
           )}
           <BreadcrumbLink url="" current>
@@ -160,14 +158,11 @@ export default function EditConcept({
       <Breadcrumb>
         {router.query.terminologyId && (
           <BreadcrumbLink url={`/terminology/${router.query.terminologyId}`}>
-            <PropertyValue
-              property={terminology?.properties.prefLabel}
-           />
+            <PropertyValue property={terminology?.properties.prefLabel} />
           </BreadcrumbLink>
         )}
         {!!preferredTerms?.length && (
-          <BreadcrumbLink url="" current>
-         </BreadcrumbLink>
+          <BreadcrumbLink url="" current></BreadcrumbLink>
         )}
       </Breadcrumb>
 
@@ -178,15 +173,12 @@ export default function EditConcept({
               'prefLabel',
               terminology?.references.contributor
             )}
-         />
+          />
         </SubTitle>
-        <MainTitle>
-       </MainTitle>
+        <MainTitle></MainTitle>
         <BadgeBar>
           {t('heading')}
-          <PropertyValue
-            property={terminology?.properties.prefLabel}
-         />
+          <PropertyValue property={terminology?.properties.prefLabel} />
           <Badge>{t('statuses.draft', { ns: 'common' })}</Badge>
         </BadgeBar>
         <PageHelpText>{t('new-concept-page-help')}</PageHelpText>

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -162,7 +162,9 @@ export default function EditConcept({
           </BreadcrumbLink>
         )}
         {!!preferredTerms?.length && (
-          <BreadcrumbLink url="" current></BreadcrumbLink>
+          <BreadcrumbLink url="" current>
+            <PropertyValue property={preferredTerms} />
+          </BreadcrumbLink>
         )}
       </Breadcrumb>
 
@@ -175,7 +177,9 @@ export default function EditConcept({
             )}
           />
         </SubTitle>
-        <MainTitle></MainTitle>
+        <MainTitle>
+          <PropertyValue property={preferredTerms} />
+        </MainTitle>
         <BadgeBar>
           {t('heading')}
           <PropertyValue property={terminology?.properties.prefLabel} />

--- a/src/modules/edit-vocabulary/generate-initial-data.ts
+++ b/src/modules/edit-vocabulary/generate-initial-data.ts
@@ -27,7 +27,7 @@ export default function generateInitialData(
       const label = getPropertyValue({
         property: group.properties.prefLabel,
         language: lang,
-     });
+      });
 
       return {
         checked: false,
@@ -42,7 +42,7 @@ export default function generateInitialData(
     const label = getPropertyValue({
       property: org.properties.prefLabel,
       language: lang,
-   });
+    });
 
     return {
       organizationId: org.type.graph.id,

--- a/src/modules/edit-vocabulary/generate-initial-data.ts
+++ b/src/modules/edit-vocabulary/generate-initial-data.ts
@@ -27,8 +27,7 @@ export default function generateInitialData(
       const label = getPropertyValue({
         property: group.properties.prefLabel,
         language: lang,
-        fallbackLanguage: 'fi',
-      });
+     });
 
       return {
         checked: false,
@@ -43,8 +42,7 @@ export default function generateInitialData(
     const label = getPropertyValue({
       property: org.properties.prefLabel,
       language: lang,
-      fallbackLanguage: 'fi',
-    });
+   });
 
     return {
       organizationId: org.type.graph.id,

--- a/src/modules/edit-vocabulary/index.tsx
+++ b/src/modules/edit-vocabulary/index.tsx
@@ -90,8 +90,7 @@ export default function EditVocabulary({ terminologyId }: EditVocabularyProps) {
         <BreadcrumbLink url={`/terminology/${terminologyId}`} current>
           <PropertyValue
             property={info.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
         </BreadcrumbLink>
       </Breadcrumb>
 

--- a/src/modules/edit-vocabulary/index.tsx
+++ b/src/modules/edit-vocabulary/index.tsx
@@ -88,9 +88,7 @@ export default function EditVocabulary({ terminologyId }: EditVocabularyProps) {
     <>
       <Breadcrumb>
         <BreadcrumbLink url={`/terminology/${terminologyId}`} current>
-          <PropertyValue
-            property={info.properties.prefLabel}
-         />
+          <PropertyValue property={info.properties.prefLabel} />
         </BreadcrumbLink>
       </Breadcrumb>
 

--- a/src/modules/own-information/index.tsx
+++ b/src/modules/own-information/index.tsx
@@ -184,8 +184,7 @@ export default function OwnInformation() {
           ?.filter((organization) => organization.id === id)
           .map((organization) => organization.properties.prefLabel),
         language: i18n.language,
-        fallbackLanguage: 'fi',
-      }) ?? ''
+     }) ?? ''
     );
   }
 }

--- a/src/modules/own-information/index.tsx
+++ b/src/modules/own-information/index.tsx
@@ -184,7 +184,7 @@ export default function OwnInformation() {
           ?.filter((organization) => organization.id === id)
           .map((organization) => organization.properties.prefLabel),
         language: i18n.language,
-     }) ?? ''
+      }) ?? ''
     );
   }
 }

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -127,8 +127,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
         <BreadcrumbLink url={`/terminology/${id}`} current>
           <PropertyValue
             property={info?.properties.prefLabel}
-            fallbackLanguage="fi"
-          />
+         />
         </BreadcrumbLink>
       </Breadcrumb>
 

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -125,9 +125,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
     <>
       <Breadcrumb>
         <BreadcrumbLink url={`/terminology/${id}`} current>
-          <PropertyValue
-            property={info?.properties.prefLabel}
-         />
+          <PropertyValue property={info?.properties.prefLabel} />
         </BreadcrumbLink>
       </Breadcrumb>
 

--- a/src/pages/terminology/[terminologyId].tsx
+++ b/src/pages/terminology/[terminologyId].tsx
@@ -99,13 +99,11 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const title = getPropertyValue({
       property: vocabularyData?.properties?.prefLabel,
       language: locale,
-      fallbackLanguage: 'fi',
     });
 
     const description = getPropertyValue({
       property: vocabularyData?.properties?.description,
       language: locale,
-      fallbackLanguage: 'fi',
     });
 
     return {

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -89,12 +89,12 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const vocabularyTitle = getPropertyValue({
       property: vocabularyData?.properties?.prefLabel,
       language: locale,
-   });
+    });
 
     const collectionTitle = getPropertyValue({
       property: collectionData?.properties.prefLabel,
       language: locale,
-   });
+    });
 
     return {
       props: {

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -89,14 +89,12 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const vocabularyTitle = getPropertyValue({
       property: vocabularyData?.properties?.prefLabel,
       language: locale,
-      fallbackLanguage: 'fi',
-    });
+   });
 
     const collectionTitle = getPropertyValue({
       property: collectionData?.properties.prefLabel,
       language: locale,
-      fallbackLanguage: 'fi',
-    });
+   });
 
     return {
       props: {

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
@@ -86,7 +86,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const collectionLabel = getPropertyValue({
       property: collectionData?.properties?.prefLabel,
       language: locale,
-   });
+    });
 
     return {
       props: {

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId]/edit.tsx
@@ -86,8 +86,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const collectionLabel = getPropertyValue({
       property: collectionData?.properties?.prefLabel,
       language: locale,
-      fallbackLanguage: 'fi',
-    });
+   });
 
     return {
       props: {

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -88,19 +88,16 @@ export const getServerSideProps = createCommonGetServerSideProps(
     const vocabularyTitle = getPropertyValue({
       property: vocabularyData?.properties?.prefLabel,
       language: locale,
-      fallbackLanguage: 'fi',
     });
 
     const conceptTitle = getPropertyValue({
       property: getProperty('prefLabel', conceptData?.references.prefLabelXl),
       language: locale,
-      fallbackLanguage: 'fi',
     });
 
     const conceptDescription = getPropertyValue({
       property: conceptData?.properties.definition,
       language: locale,
-      fallbackLanguage: 'fi',
     });
 
     return {


### PR DESCRIPTION
Changelog:
- Remove fallback language parameter
- Now as default fallback language will go from fi -> en -> sv
  - All fallback languages were using fi anyways
- if no language was specified just return the properties without filtering
  - Causes last fallback language to be first property value in list