### PR TITLE
Possibly empty label doesn't cause app to crash

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,6 +6,7 @@
   "close": "Close",
   "codelist-title": "Reference Data",
   "comments-title": "Comments",
+  "concept-label-undefined": "Concept label is undefined",
   "concepts": "Concepts",
   "confirm-page-leave": "Are you sure you want to leave the page? Changes you made won't be saved.",
   "datamodel-title": "Data Vocabularies",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -6,6 +6,7 @@
   "close": "Sulje",
   "codelist-title": "Koodistot",
   "comments-title": "Kommentointi",
+  "concept-label-undefined": "Käsitteen nimeä ei ole määritetty",
   "concepts": "Käsitteet",
   "confirm-page-leave": "Haluatko varmasti poistua sivulta? Tekemiäsi muutoksia ei tallenneta.",
   "datamodel-title": "Tietomallit",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -6,6 +6,7 @@
   "close": "",
   "codelist-title": "",
   "comments-title": "",
+  "concept-label-undefined": "",
   "concepts": "",
   "confirm-page-leave": "",
   "datamodel-title": "",

--- a/src/common/components/relational-information-block/index.tsx
+++ b/src/common/components/relational-information-block/index.tsx
@@ -42,6 +42,7 @@ export default function RelationalInformationBlock({
   updateData,
   fromOther,
 }: RelationalInformationBlockProps) {
+  const { t } = useTranslation('admin');
   const router = useRouter();
   const terminologyId = Array.isArray(router.query.terminologyId)
     ? router.query.terminologyId[0]
@@ -106,14 +107,17 @@ export default function RelationalInformationBlock({
                         )
                       }
                     >
-                      <PropertyValue
-                        property={Object.keys(concept.label).map((lang) => ({
-                          lang,
-                          value: concept.label[lang],
-                          regex: '',
-                        }))}
-                      />
-
+                      {concept.label ? (
+                        <PropertyValue
+                          property={Object.keys(concept.label).map((lang) => ({
+                            lang,
+                            value: concept.label[lang],
+                            regex: '',
+                          }))}
+                        />
+                      ) : (
+                        t('concept-label-undefined', { ns: 'common' })
+                      )}
                       {fromOther && ' - '}
                       {fromOther && (
                         <PropertyValue

--- a/src/common/components/relational-information-block/render-chosen.tsx
+++ b/src/common/components/relational-information-block/render-chosen.tsx
@@ -1,4 +1,5 @@
 import { Concepts } from '@app/common/interfaces/concepts.interface';
+import { useTranslation } from 'next-i18next';
 import { Chip, Label } from 'suomifi-ui-components';
 import { ChipBlock } from './relation-information-block.styles';
 
@@ -15,6 +16,7 @@ export default function RenderChosen({
   setShowChosen,
   chipLabel,
 }: RenderChosenProps) {
+  const { t } = useTranslation('admin');
   const handleChipRemove = (chose: Concepts) => {
     const updatedChosen = chosen.filter((c) => c.id !== chose.id);
     setChosen(updatedChosen);
@@ -35,7 +37,9 @@ export default function RenderChosen({
               onClick={() => handleChipRemove(chose)}
               key={`${chose.id}-${idx}`}
             >
-              {chose.label.fi}
+              {chose.label
+                ? chose.label.fi
+                : t('concept-label-undefined', { ns: 'common' })}
             </Chip>
           );
         })}

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -91,19 +91,21 @@ export default function RenderConcepts({
                 >
                   <SanitizedTextContent
                     text={
-                      getPropertyValue({
-                        property: Object.keys(concept.label).map((key) => {
-                          const obj = {
-                            lang: key,
-                            value: concept.label[key],
-                            regex: '',
-                          };
-                          return obj;
-                        }),
-                        language: i18n.language,
-                      }) ??
-                      concept.label[i18n.language] ??
-                      concept.label.fi
+                      concept.label
+                        ? getPropertyValue({
+                            property: Object.keys(concept.label).map((key) => {
+                              const obj = {
+                                lang: key,
+                                value: concept.label[key],
+                                regex: '',
+                              };
+                              return obj;
+                            }),
+                            language: i18n.language,
+                          }) ??
+                          concept.label[i18n.language] ??
+                          concept.label.fi
+                        : t('concept-label-undefined', { ns: 'common' })
                     }
                   />
                 </Checkbox>

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -306,26 +306,28 @@ export default function SearchResults({
 
     // If language is defined in urlState and dto is Concept
     // get label without trailing language code
-    if (isConcept && urlState.lang && dto.label[urlState.lang]) {
+    if (isConcept && urlState.lang && dto.label?.[urlState.lang]) {
       return dto.label[urlState.lang].replaceAll(/<\/*[^>]>/g, '');
     }
 
     // If label exists in current UI language get label without trailing language code
-    if (!urlState.lang && dto.label[i18n.language]) {
+    if (!urlState.lang && dto.label?.[i18n.language]) {
       return dto.label[i18n.language].replaceAll(/<\/*[^>]>/g, '');
     }
 
-    if (isConcept) {
+    if (isConcept && dto.label) {
       // Otherwise return label with trailing language code
       return `${dto?.label?.[Object.keys(dto.label)[0]].replaceAll(
         /<\/*[^>]>/g,
         ''
       )} (${Object.keys(dto.label)[0]})`;
-    } else {
+    } else if (dto.label) {
       return `${dto?.label?.[Object.keys(dto.label)[0]].replaceAll(
         /<\/*[^>]>/g,
         ''
       )}`;
+    } else {
+      return t('concept-label-undefined');
     }
   }
 


### PR DESCRIPTION
Changes in this PR:
- Concepts that don't have preferred labels would have crashed the program. This error occurred in `search-results` and `relational-information`. 