### PR TITLE
Fix don't confirm before leaving page without form

### DIFF
--- a/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.test.tsx
+++ b/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.test.tsx
@@ -20,7 +20,9 @@ describe('useConfirmBeforeLeavingPage', () => {
   });
 
   it('should register event listeners when initialized in enabled state', async () => {
-    const { unmount } = renderHook(() => useConfirmBeforeLeavingPage('enabled'));
+    const { unmount } = renderHook(() =>
+      useConfirmBeforeLeavingPage('enabled')
+    );
 
     expect(window.addEventListener).toHaveBeenCalledWith(
       'beforeunload',
@@ -35,7 +37,9 @@ describe('useConfirmBeforeLeavingPage', () => {
   });
 
   it('should not register event listeners when initialized in disabled state', async () => {
-    const { unmount } = renderHook(() => useConfirmBeforeLeavingPage('disabled'));
+    const { unmount } = renderHook(() =>
+      useConfirmBeforeLeavingPage('disabled')
+    );
 
     expect(window.addEventListener).not.toHaveBeenCalledWith(
       'beforeunload',
@@ -50,7 +54,9 @@ describe('useConfirmBeforeLeavingPage', () => {
   });
 
   it('should disable confirmation when disableConfirmation is called', async () => {
-    const { result, unmount } = renderHook(() => useConfirmBeforeLeavingPage('enabled'));
+    const { result, unmount } = renderHook(() =>
+      useConfirmBeforeLeavingPage('enabled')
+    );
 
     expect(window.removeEventListener).not.toHaveBeenCalledWith(
       'beforeunload',

--- a/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.test.tsx
+++ b/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.test.tsx
@@ -20,7 +20,7 @@ describe('useConfirmBeforeLeavingPage', () => {
   });
 
   it('should register event listeners when initialized in enabled state', async () => {
-    renderHook(() => useConfirmBeforeLeavingPage('enabled'));
+    const { unmount } = renderHook(() => useConfirmBeforeLeavingPage('enabled'));
 
     expect(window.addEventListener).toHaveBeenCalledWith(
       'beforeunload',
@@ -30,10 +30,12 @@ describe('useConfirmBeforeLeavingPage', () => {
       'routeChangeStart',
       expect.any(Function)
     );
+
+    unmount();
   });
 
   it('should not register event listeners when initialized in disabled state', async () => {
-    renderHook(() => useConfirmBeforeLeavingPage('disabled'));
+    const { unmount } = renderHook(() => useConfirmBeforeLeavingPage('disabled'));
 
     expect(window.addEventListener).not.toHaveBeenCalledWith(
       'beforeunload',
@@ -43,10 +45,12 @@ describe('useConfirmBeforeLeavingPage', () => {
       'routeChangeStart',
       expect.any(Function)
     );
+
+    unmount();
   });
 
   it('should disable confirmation when disableConfirmation is called', async () => {
-    const { result } = renderHook(() => useConfirmBeforeLeavingPage('enabled'));
+    const { result, unmount } = renderHook(() => useConfirmBeforeLeavingPage('enabled'));
 
     expect(window.removeEventListener).not.toHaveBeenCalledWith(
       'beforeunload',
@@ -67,10 +71,12 @@ describe('useConfirmBeforeLeavingPage', () => {
       'routeChangeStart',
       expect.any(Function)
     );
+
+    unmount();
   });
 
   it('should enable confirmation when enableConfirmation is called', async () => {
-    const { result } = renderHook(() =>
+    const { result, unmount } = renderHook(() =>
       useConfirmBeforeLeavingPage('disabled')
     );
 
@@ -93,5 +99,7 @@ describe('useConfirmBeforeLeavingPage', () => {
       'routeChangeStart',
       expect.any(Function)
     );
+
+    unmount();
   });
 });

--- a/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.tsx
+++ b/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.tsx
@@ -1,5 +1,6 @@
 import Router from 'next/router';
 import { useTranslation } from 'next-i18next';
+import { useEffect } from 'react';
 
 export type ConfirmationState = 'enabled' | 'disabled';
 
@@ -49,6 +50,9 @@ export default function useConfirmBeforeLeavingPage(
       disableConfirmation();
     }
   }
+
+  // Disable automatically on unmount (= when page changes)
+  useEffect(() => disableConfirmation, []);
 
   return {
     enableConfirmation,

--- a/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.tsx
+++ b/src/common/utils/hooks/use-confirm-before-leaving-page/use-confirm-before-leaving-page.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 export type ConfirmationState = 'enabled' | 'disabled';
 
-let confirmationState: ConfirmationState;
+let confirmationState: ConfirmationState | undefined;
 let message = '';
 
 const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
@@ -37,6 +37,11 @@ const disableConfirmation = () => {
   }
 };
 
+const resetConfirmation = () => {
+  disableConfirmation();
+  confirmationState = undefined;
+};
+
 export default function useConfirmBeforeLeavingPage(
   initialState: ConfirmationState
 ) {
@@ -51,8 +56,10 @@ export default function useConfirmBeforeLeavingPage(
     }
   }
 
-  // Disable automatically on unmount (= when page changes)
-  useEffect(() => disableConfirmation, []);
+  // Reset on unmount (= when page changes)
+  useEffect(() => {
+    return () => resetConfirmation();
+  }, []);
 
   return {
     enableConfirmation,


### PR DESCRIPTION
When confirm is correctly enabled and the user navigates to another page using next/router the confirmation is triggered. After this, the confirmation is not disabled and so it was still enabled even if the user has navigated to a page without form at all.

Fixed this by enabling disabling confirmation automatically when the page component is is unmounted.