### PR TITLE
YTI-2047: scrollRestoration on history

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,9 @@ module.exports = (phase, { defaultConfig }) => {
   }
 
   let config = {
+    experimental: {
+      scrollRestoration: true,
+    },
     compiler: {
       styledComponents: true,
     },


### PR DESCRIPTION
Changelog:
- enable experimental flag for restoring scroll on 
  - this flag effects navigation based only on history. 

Cons:
- Not currently covered by next js semver
  - Shows the following message when running the application
```
warn  - You have enabled experimental feature (scrollRestoration) in next.config.js.
warn  - Experimental features are not covered by semver, and may cause unexpected or broken application behavior. Use at your own risk.
```

This is the commit that shows how this flag works: 
https://github.com/vercel/next.js/commit/38bd1a024cb25923d8ea15f269a7294d073684d8


Best case scenario would be to use native scrollrestoration supported by browsers using the history api. https://developer.mozilla.org/en-US/docs/Web/API/History_API
Unfortunately right now it seems that next js overrides this.


Looks like there is a issue about this and also a pr on the next.js project but it has not been touched:
Issue: https://github.com/vercel/next.js/issues/20951
PR: https://github.com/vercel/next.js/pull/22727/files