### PR TITLE
YTI-1894: fix unintended change

### DIFF
--- a/src/modules/new-terminology/new-terminology-modal.tsx
+++ b/src/modules/new-terminology/new-terminology-modal.tsx
@@ -80,9 +80,6 @@ export default function NewTerminologyModal({
   };
 
   const handlePost = () => {
-    if (userPosted) {
-      return;
-    }
     if (inputType === 'self') {
       setUserPosted(true);
       if (!isValid || !manualData) {


### PR DESCRIPTION
Changelog:
 - remove not doing anything if userposted

This change was leftover from testing and if left like this it will not allow the user press the add vocabulary button more than once meaning if the user fixes errors and presses again it does nothing