### PR TITLE
show error messages from new terminology-modal

### DIFF
--- a/public/locales/en/alert.json
+++ b/public/locales/en/alert.json
@@ -1,11 +1,12 @@
 {
   "error-alert": "ERROR {{id}}: {{displayText}}",
-  "error-occured": "An error occured",
-  "error-occured_access-request": "An error occured with access request service",
-  "error-occured_counts": "An error occured while getting counts for statuses and information domains",
-  "error-occured_groups": "An error occured while getting information domains",
-  "error-occured_organization": "An error occured while getting organizations",
-  "error-occured_subscription": "An error occured with subscription service",
-  "error-occured_terminology-search": "An error occured while searching for terminologies",
-  "error-occured_unhandled-error": "An unknown error occured"
+  "error-occured": "An error occurred",
+  "error-occured_access-request": "An error occurred with access request service",
+  "error-occured_counts": "An error occurred while getting counts for statuses and information domains",
+  "error-occured_groups": "An error occurred while getting information domains",
+  "error-occured_organization": "An error occurred while getting organizations",
+  "error-occured_subscription": "An error occurred with subscription service",
+  "error-occured_terminology-search": "An error occurred while searching for terminologies",
+  "error-occured_unhandled-error": "An unknown error occurred",
+  "error-occurred_session": "An error occured with the session, try logging in again"
 }

--- a/public/locales/fi/alert.json
+++ b/public/locales/fi/alert.json
@@ -7,5 +7,6 @@
   "error-occured_organization": "Organisaatioiden haussa ilmeni ongelma",
   "error-occured_subscription": "Sähköpostitilauksen toiminnassa ilmeni ongelma",
   "error-occured_terminology-search": "Sanastojen listauksen haussa ilmeni ongelma",
-  "error-occured_unhandled-error": "Tapahtui odottamaton virhe"
+  "error-occured_unhandled-error": "Tapahtui odottamaton virhe",
+  "error-occurred_session": "Istunnossa ilmeni ongelma, kokeile kirjautua uudelleen"
 }

--- a/public/locales/sv/alert.json
+++ b/public/locales/sv/alert.json
@@ -6,5 +6,6 @@
   "error-occured_groups": "",
   "error-occured_organization": "",
   "error-occured_subscription": "",
-  "error-occured_terminology-search": ""
+  "error-occured_terminology-search": "",
+  "error-occurred_session": ""
 }

--- a/src/modules/new-terminology/new-terminology-modal.tsx
+++ b/src/modules/new-terminology/new-terminology-modal.tsx
@@ -1,3 +1,4 @@
+import { setAlert } from '@app/common/components/alert/alert.slice';
 import { usePostImportExcelMutation } from '@app/common/components/excel/excel.slice';
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import { terminologySearchApi } from '@app/common/components/terminology-search/terminology-search.slice';
@@ -65,7 +66,25 @@ export default function NewTerminologyModal({
       handleClose();
       dispatch(terminologySearchApi.util.invalidateTags(['TerminologySearch']));
     }
-  }, [newVocabulary, dispatch, handleClose]);
+    if (newVocabulary.isError) {
+      setIsCreating(false);
+      const errorMessage =
+        'status' in newVocabulary.error && newVocabulary.error.status === 401
+          ? t('error-occurred_session', { ns: 'alert' })
+          : t('error-occured', { ns: 'alert' });
+      dispatch(
+        setAlert(
+          [
+            {
+              note: newVocabulary.error,
+              displayText: errorMessage,
+            },
+          ],
+          []
+        )
+      );
+    }
+  }, [t, newVocabulary, dispatch, handleClose]);
 
   const handleCloseRequest = () => {
     handleClose();

--- a/src/modules/new-terminology/new-terminology-modal.tsx
+++ b/src/modules/new-terminology/new-terminology-modal.tsx
@@ -65,8 +65,7 @@ export default function NewTerminologyModal({
     if (newVocabulary.isSuccess) {
       handleClose();
       dispatch(terminologySearchApi.util.invalidateTags(['TerminologySearch']));
-    }
-    if (newVocabulary.isError) {
+    } else if (newVocabulary.isError) {
       setIsCreating(false);
       const errorMessage =
         'status' in newVocabulary.error && newVocabulary.error.status === 401


### PR DESCRIPTION
Changelog:
 - All alert translations have occured -> occurred
   - My spellcheck is complaining about this and all dictionaries seem to agree that is it written occurred
 - Show error message if newVocabulary post gives error
   - 401: no authorization shows special message
   - others show generic message

![image](https://user-images.githubusercontent.com/19401683/188623905-53e650a6-e99b-405e-9c35-2a91ee5afe86.png)