### PR TITLE
YTI-2063: new terminology no status error

### DIFF
--- a/src/modules/new-terminology/missing-info-alert.tsx
+++ b/src/modules/new-terminology/missing-info-alert.tsx
@@ -97,7 +97,7 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
   }
 
   function renderStatusAlerts() {
-    if (!data.status) {
+    if (Object.keys(data).includes('status') && !data.status) {
       return <li>{t('alert-no-status')}</li>;
     }
   }


### PR DESCRIPTION
Changelog:
- Status is only checked if the key is defined in the data
- Key is not defined when first creating a new terminology
- Key is defined after creating
  - When modifying the key is not removed, but value can be removed
- Error is only shown when trying to remove the status 