### PR TITLE
Yti 2062 multiple contributor info

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "additional-technical-information": "Additional technical information",
   "breadcrumb": "Breadcrumb",
+  "card-organizations": "organizations",
   "choose-language": "Choose a language",
   "clear-language-filter": "Clear language filter",
   "close": "Close",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,6 +1,7 @@
 {
   "additional-technical-information": "Tekniset lisätiedot",
   "breadcrumb": "Murupolku",
+  "card-organizations": "sisällöntuottajaa",
   "choose-language": "Valitse kieli",
   "clear-language-filter": "Tyhjennä kielivalinta",
   "close": "Sulje",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,6 +1,7 @@
 {
   "additional-technical-information": "",
   "breadcrumb": "",
+  "card-organizations": "",
   "choose-language": "",
   "clear-language-filter": "",
   "close": "",

--- a/src/common/components/info-dropdown/info-expander.styles.tsx
+++ b/src/common/components/info-dropdown/info-expander.styles.tsx
@@ -10,3 +10,15 @@ export const InfoExpanderDivider = styled.hr`
   border-top: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
   margin: ${(props) => props.theme.suomifi.spacing.xl} 0;
 `;
+
+export const PropertyList = styled.ul`
+  list-style: none;
+  padding: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  font-size: 16px;
+
+  li:not(:last-child) {
+    margin-bottom: ${(props) => props.theme.suomifi.spacing.xs};
+  }
+`;

--- a/src/common/components/info-dropdown/info-expander.test.tsx
+++ b/src/common/components/info-dropdown/info-expander.test.tsx
@@ -155,7 +155,7 @@ describe('infoExpander', () => {
     );
 
     expect(screen.getByText('testi 1')).toBeInTheDocument();
-    expect(screen.getByText(/testi 2/)).toBeInTheDocument();
+    expect(screen.getByText('testi 2')).toBeInTheDocument();
     expect(screen.getByText('testi 3')).toBeInTheDocument();
   });
 });

--- a/src/common/components/info-dropdown/info-expander.test.tsx
+++ b/src/common/components/info-dropdown/info-expander.test.tsx
@@ -104,4 +104,58 @@ describe('infoExpander', () => {
     expect(screen.getByText(/2.1.1970, 0.00/)).toBeInTheDocument();
     expect(screen.getByText(/Modifier/)).toBeInTheDocument();
   });
+
+  it('should render one or multiple organizations', () => {
+    const store = makeStore(getMockContext());
+    const loginInitialState = Object.assign({}, initialState);
+    loginInitialState['anonymous'] = false;
+    loginInitialState['email'] = 'admin@localhost';
+    loginInitialState['firstName'] = 'Admin';
+    loginInitialState['lastName'] = 'User';
+    store.dispatch(setLogin(loginInitialState));
+
+    render(
+      <Provider store={store}>
+        <InfoExpander
+          data={
+            {
+              createdBy: 'Creator',
+              createdDate: '1970-01-01T00:00:00.000+00:00',
+              lastModifiedBy: 'Modifier',
+              lastModifiedDate: '1970-01-02T00:00:00.000+00:00',
+              properties: {},
+              references: {
+                contributor: [
+                  {
+                    id: 'testi 1',
+                    properties: {
+                      prefLabel: [{ lang: 'en', value: 'testi 1' }],
+                    },
+                  },
+                  {
+                    id: 'testi 2',
+                    properties: {
+                      prefLabel: [{ lang: 'en', value: 'testi 2' }],
+                    },
+                  },
+                  {
+                    id: 'testi 3',
+                    properties: {
+                      prefLabel: [{ lang: 'en', value: 'testi 3' }],
+                    },
+                  },
+                ],
+                inGroup: [{ properties: { prefLabel: [] } }],
+              },
+            } as any
+          }
+        />
+      </Provider>,
+      { wrapper: themeProvider }
+    );
+
+    expect(screen.getByText('testi 1')).toBeInTheDocument();
+    expect(screen.getByText(/testi 2/)).toBeInTheDocument();
+    expect(screen.getByText('testi 3')).toBeInTheDocument();
+  });
 });

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -6,7 +6,7 @@ import {
   ExpanderTitleButton,
   VisuallyHidden,
 } from 'suomifi-ui-components';
-import { InfoExpanderWrapper } from './info-expander.styles';
+import { InfoExpanderWrapper, PropertyList } from './info-expander.styles';
 import { VocabularyInfoDTO } from '@app/common/interfaces/vocabulary.interface';
 import Separator from '@app/common/components/separator';
 import {
@@ -218,12 +218,19 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         <VisuallyHidden as="h3">
           {t('additional-technical-information', { ns: 'common' })}
         </VisuallyHidden>
-
-        <PropertyBlock
-          title={t('vocabulary-info-organization')}
-          property={data.references.contributor?.[0]?.properties.prefLabel}
-          id="organization"
-        />
+        <BasicBlock title={t('vocabulary-info-organization')} id="organization">
+          <PropertyList>
+            {data.references.contributor
+              ?.filter((c) => c && c.properties.prefLabel)
+              .map((contributor) => (
+                <li key={contributor.id}>
+                  {getPropertyValue({
+                    property: contributor?.properties.prefLabel,
+                  })}
+                </li>
+              ))}
+          </PropertyList>
+        </BasicBlock>
         <BasicBlock title={t('vocabulary-info-created-at')} id="created-at">
           <FormattedDate date={data.createdDate} />
           {data.createdBy && `, ${data.createdBy}`}

--- a/src/common/components/search-results/result-card.styles.tsx
+++ b/src/common/components/search-results/result-card.styles.tsx
@@ -19,11 +19,6 @@ export const Extra = styled(Block)`
 export const OrganizationParagraph = styled(Paragraph)`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
   font-size: 14px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
 `;
 
 export const Title = styled(Heading)`

--- a/src/common/components/search-results/result-card.styles.tsx
+++ b/src/common/components/search-results/result-card.styles.tsx
@@ -19,6 +19,11 @@ export const Extra = styled(Block)`
 export const OrganizationParagraph = styled(Paragraph)`
   color: ${(props) => props.theme.suomifi.colors.depthDark1};
   font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 `;
 
 export const Title = styled(Heading)`

--- a/src/common/components/search-results/result-card.test.tsx
+++ b/src/common/components/search-results/result-card.test.tsx
@@ -1,0 +1,69 @@
+import { themeProvider } from '@app/tests/test-utils';
+import { render, screen } from '@testing-library/react';
+import ResultCard from './result-card';
+
+describe('result-card-expander', () => {
+  it('should render component', () => {
+    const contributors = [
+      {
+        id: 'testid',
+        label: {
+          fi: 'contributor 1',
+        },
+      },
+    ];
+
+    render(
+      <ResultCard
+        description="test description"
+        title="title"
+        titleLink=""
+        type="type"
+        contributors={contributors}
+      />,
+      {
+        wrapper: themeProvider,
+      }
+    );
+
+    expect(screen.getByText('test description')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('type')).toBeInTheDocument();
+    expect(screen.getAllByText('contributor 1')[0]).toBeInTheDocument();
+  });
+
+  it('should render multiple contributors as amount', () => {
+    const contributors = [
+      {
+        id: 'testid',
+        label: {
+          fi: 'contributor 1',
+        },
+      },
+      {
+        id: 'testid2',
+        label: {
+          fi: 'contributor 2',
+        },
+      },
+    ];
+
+    render(
+      <ResultCard
+        description="test description"
+        title="title"
+        titleLink=""
+        type="type"
+        contributors={contributors}
+      />,
+      {
+        wrapper: themeProvider,
+      }
+    );
+
+    expect(screen.getByText('test description')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('type')).toBeInTheDocument();
+    expect(screen.getByText('2 tr-card-organizations')).toBeInTheDocument();
+  });
+});

--- a/src/common/components/search-results/result-card.tsx
+++ b/src/common/components/search-results/result-card.tsx
@@ -1,4 +1,7 @@
-import { InformationDomainDTO } from '@app/common/interfaces/terminology.interface';
+import {
+  ContributorsDTO,
+  InformationDomainDTO,
+} from '@app/common/interfaces/terminology.interface';
 import { translateStatus } from '@app/common/utils/translation-helpers';
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
@@ -16,7 +19,7 @@ import {
 } from './result-card.styles';
 
 interface ResultCardProps {
-  contributor?: string;
+  contributors?: ContributorsDTO[];
   description: string | JSX.Element;
   extra?: JSX.Element | (JSX.Element | undefined)[];
   icon?: BaseIconKeys;
@@ -30,7 +33,7 @@ interface ResultCardProps {
 }
 
 export default function ResultCard({
-  contributor,
+  contributors,
   description,
   extra,
   icon,
@@ -58,9 +61,9 @@ export default function ResultCard({
 
   return (
     <CardBlock padding="m" className="result-card">
-      {contributor && (
+      {contributors && contributors.length > 0 && (
         <OrganizationParagraph id="card-contributor">
-          {contributor}
+          {getLabel(contributors[0].label)} ja {contributors.length - 1} muuta
         </OrganizationParagraph>
       )}
       <Link passHref href={titleLink}>
@@ -68,7 +71,11 @@ export default function ResultCard({
           {icon && <Icon icon={icon} />}
           <Title variant="h2" id="card-title-link">
             {title}
-            <VisuallyHidden>{contributor}</VisuallyHidden>
+            <VisuallyHidden>
+              {contributors
+                ?.map((contributor) => getLabel(contributor.label))
+                .join(', ')}
+            </VisuallyHidden>
           </Title>
         </TitleLink>
       </Link>

--- a/src/common/components/search-results/result-card.tsx
+++ b/src/common/components/search-results/result-card.tsx
@@ -63,7 +63,9 @@ export default function ResultCard({
     <CardBlock padding="m" className="result-card">
       {contributors && contributors.length > 0 && (
         <OrganizationParagraph id="card-contributor">
-          {getLabel(contributors[0].label)} ja {contributors.length - 1} muuta
+          {contributors.length === 1
+            ? getLabel(contributors[0].label)
+            : `${contributors.length} ${t('card-organizations')}`}
         </OrganizationParagraph>
       )}
       <Link passHref href={titleLink}>

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -75,11 +75,7 @@ export default function SearchResults({
               return (
                 <ResultCard
                   key={terminology.id}
-                  contributor={
-                    terminology.contributors[0].label[i18n.language] ??
-                    terminology.contributors[0].label['fi'] ??
-                    ''
-                  }
+                  contributors={terminology.contributors}
                   description={getDescription(terminology)}
                   icon="registers"
                   partOf={terminology.informationDomains}


### PR DESCRIPTION
Changelog:
- result card shows either one contributor by name or amount if more than one
- info expander on terminology lists all contributors in a row
  - these are not in any specific order, the array comes from the backend
- tests
![info-expander](https://user-images.githubusercontent.com/19401683/189587168-a9663499-2f5e-4ab2-9ec1-f32743545d6d.png)
![result-card](https://user-images.githubusercontent.com/19401683/189587175-b22e4675-b8e1-4ad4-a2df-4add3af1c2d4.png)
