### PR TITLE
Fixed bug with prefix checking

### DIFF
--- a/src/common/components/vocabulary/vocabulary.slice.tsx
+++ b/src/common/components/vocabulary/vocabulary.slice.tsx
@@ -94,7 +94,7 @@ export const vocabularyApi = createApi({
     //     method: 'DELETE',
     //   }),
     // }),
-    getIfNamespaceInUse: builder.query<boolean, string>({
+    getIfNamespaceInUse: builder.mutation<boolean, string>({
       query: (prefix) => ({
         url: `/namespaceInUse?prefix=${prefix}`,
         method: 'GET',
@@ -116,7 +116,7 @@ export const {
   usePostNewVocabularyMutation,
   usePostCreateVersionMutation,
   // useDeleteVocabularyMutation,
-  useGetIfNamespaceInUseQuery,
+  useGetIfNamespaceInUseMutation,
   useGetVocabulariesQuery,
   util: { getRunningOperationPromises },
 } = vocabularyApi;


### PR DESCRIPTION
Changes in this PR:
- Switched `getIfNameSpaceInUse` to be a mutation instead of a query. Prefix is now checked correctly after user has input value for custom prefix.