### PR TITLE
Added missing contact info and changed email title

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,6 +10,7 @@
   "concept-label-undefined": "Concept label is undefined",
   "concepts": "Concepts",
   "confirm-page-leave": "Are you sure you want to leave the page? Changes you made won't be saved.",
+  "contact": "Contact",
   "datamodel-title": "Data Vocabularies",
   "display-by-language": "Display by language",
   "email-subscription": "Email subscription",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -10,6 +10,7 @@
   "concept-label-undefined": "Käsitteen nimeä ei ole määritetty",
   "concepts": "Käsitteet",
   "confirm-page-leave": "Haluatko varmasti poistua sivulta? Tekemiäsi muutoksia ei tallenneta.",
+  "contact": "Yhteydenotto",
   "datamodel-title": "Tietomallit",
   "display-by-language": "Näytä sisältö kielellä",
   "email-subscription": "Ilmoitukset",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -10,6 +10,7 @@
   "concept-label-undefined": "",
   "concepts": "",
   "confirm-page-leave": "",
+  "contact": "",
   "datamodel-title": "",
   "display-by-language": "",
   "email-subscription": "",

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -46,6 +46,8 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
     return null;
   }
 
+  const contact = getPropertyValue({ property: data.properties.contact });
+
   return (
     <InfoExpanderWrapper id="info-expander">
       <ExpanderTitleButton asHeading="h2">
@@ -93,21 +95,19 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           )}
         </BasicBlock>
 
-        {data.properties.contact?.[0]?.value && (
+        {contact && (
           <BasicBlock title={t('contact')}>
             <ExternalLink
-              href={`mailto:${data.properties.contact[0].value}?subject=${t(
+              href={`mailto:${contact}?subject=${t(
                 'feedback-vocabulary'
               )} - ${getPropertyValue({
                 property: data.properties.prefLabel,
                 language: i18n.language,
               })}`}
-              labelNewWindow={`${t('site-open-new-email')} ${
-                data.properties.contact[0].value
-              }`}
+              labelNewWindow={`${t('site-open-new-email')} ${contact}`}
               style={{ fontSize: '16px' }}
             >
-              {data.properties.contact?.[0].value}
+              {contact}
             </ExternalLink>
           </BasicBlock>
         )}

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   ExpanderContent,
   ExpanderTitleButton,
+  ExternalLink,
   VisuallyHidden,
 } from 'suomifi-ui-components';
 import { InfoExpanderWrapper, PropertyList } from './info-expander.styles';
@@ -91,6 +92,25 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
             t
           )}
         </BasicBlock>
+
+        {data.properties.contact?.[0]?.value && (
+          <BasicBlock title={t('contact')}>
+            <ExternalLink
+              href={`mailto:${data.properties.contact[0].value}?subject=${t(
+                'feedback-vocabulary'
+              )} - ${getPropertyValue({
+                property: data.properties.prefLabel,
+                language: i18n.language,
+              })}`}
+              labelNewWindow={`${t('site-open-new-email')} ${
+                data.properties.contact[0].value
+              }`}
+              style={{ fontSize: '16px' }}
+            >
+              {data.properties.contact?.[0].value}
+            </ExternalLink>
+          </BasicBlock>
+        )}
 
         {HasPermission({
           actions: 'EDIT_TERMINOLOGY',

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -269,10 +269,12 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
               <ExternalLink
                 href={`mailto:${
                   isEmail(email) ? email : 'yhteentoimivuus@dvv.fi'
-                }?subject=${conceptId}`}
-                labelNewWindow={t('site-open-link-new-window', {
+                }?subject=${t('feedback-concept', {
                   ns: 'common',
-                })}
+                })} - ${prefLabel}`}
+                labelNewWindow={`${t('site-open-new-email', {
+                  ns: 'common',
+                })} ${isEmail(email) ? email : 'yhteentoimivuus@dvv.fi'}`}
               >
                 {t('feedback-action')}
               </ExternalLink>


### PR DESCRIPTION
Changes in this PR:
- Added missing contact information to terminology expander
![image](https://user-images.githubusercontent.com/82932696/189815353-e30fb7ac-53be-473c-9063-089d194098f0.png)
- Updated email title from concept ID to more descriptive one