### PR TITLE
Added variant if deepHit doesn't have uri defined

### DIFF
--- a/src/common/components/search-results/result-card-expander.tsx
+++ b/src/common/components/search-results/result-card-expander.tsx
@@ -93,17 +93,21 @@ export default function ResultCardExpander({
   }
 
   function renderHitsInContent() {
-    return deepHits.map((deepHit, hitIdx) => {
-      return deepHit.topHits.map((hit, idx) => {
-        return (
-          <Link key={`${hitIdx}-${idx}`} href={hit.uri} passHref>
-            <SuomiFiLink href="">
-              <SanitizedTextContent text={getText(hit.label)} />
-            </SuomiFiLink>
-          </Link>
-        );
-      });
-    });
+    return deepHits.map((deepHit, hitIdx) =>
+      deepHit.topHits.map((hit, idx) => {
+        if (hit.uri) {
+          return (
+            <Link key={`${hitIdx}-${idx}`} href={hit.uri} passHref>
+              <SuomiFiLink href="">
+                <SanitizedTextContent text={getText(hit.label)} />
+              </SuomiFiLink>
+            </Link>
+          );
+        } else {
+          return <SanitizedTextContent text={getText(hit.label)} />;
+        }
+      })
+    );
   }
 
   function getText(label: { [key: string]: string }) {


### PR DESCRIPTION
Changes in this PR:
- If deepHits-object doesn't have a uri defined, don't wrap it in a `Link`