### PR TITLE
Fixed which error message is displayed

### DIFF
--- a/src/modules/new-terminology/info-file.tsx
+++ b/src/modules/new-terminology/info-file.tsx
@@ -84,12 +84,8 @@ export default function InfoFile({ setIsValid, setFileData }: infoFileProps) {
         setFile(selectedItems[i]);
         setAlert('none');
         break;
-      }
-
-      if (alert === 'none') {
-        // Setting alert to upload-error here because
-        // input is set to accept only .xlsx files below
-        setAlert('upload-error');
+      } else if (alert === 'none' && selectedItems[i].name.length > 0) {
+        setAlert('incorrect-file-type');
       }
     }
   };


### PR DESCRIPTION
Changes in this PR:
- If user uploaded a file via file explorer and had uploaded a file that wasn't of type xlsx, a wrong error message was displayed. Now user receives a error message that explains that given file was of a wrong kind instead a general error message