### PR TITLE
Yti 2108 permission bugfix

### DIFF
--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -114,7 +114,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
 
         {HasPermission({
           actions: 'EDIT_TERMINOLOGY',
-          targetOrganization: data.references.contributor?.[0].id,
+          targetOrganization: data.references.contributor,
         }) && (
           <>
             <Separator isLarge />
@@ -144,7 +144,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
 
         {HasPermission({
           actions: 'CREATE_CONCEPT',
-          targetOrganization: data.references.contributor?.[0].id,
+          targetOrganization: data.references.contributor,
         }) && (
           <NewConceptModal
             terminologyId={data.type.graph.id}
@@ -156,7 +156,7 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
 
         {HasPermission({
           actions: 'CREATE_COLLECTION',
-          targetOrganization: data.references.contributor?.[0].id,
+          targetOrganization: data.references.contributor,
         }) && (
           <>
             <Separator isLarge />

--- a/src/common/utils/has-permission.tsx
+++ b/src/common/utils/has-permission.tsx
@@ -27,7 +27,7 @@ export interface hasPermissionProps {
 
 export interface checkPermissionProps {
   user: User;
-  actions: Actions | Actions[];
+  actions: Actions[];
   targetOrganization?: string;
 }
 
@@ -46,7 +46,11 @@ export default function HasPermission({
     return false;
   }
 
-  return checkPermission({ user, actions, targetOrganization });
+  return checkPermission({
+    user,
+    actions: Array.isArray(actions) ? actions : [actions],
+    targetOrganization,
+  });
 }
 
 export function checkPermission({
@@ -55,21 +59,12 @@ export function checkPermission({
   targetOrganization,
 }: checkPermissionProps) {
   const organizationsInRole = Object.keys(user.organizationsInRole);
-  const rolesInOrganizations = Object.keys(user.rolesInOrganizations);
   const rolesInTargetOrganization =
     targetOrganization && user.rolesInOrganizations[targetOrganization];
 
   // Return true if user is superuser
   if (user.superuser) {
     return true;
-  }
-
-  // Return false if user doesn't have a role in target organization
-  if (
-    targetOrganization &&
-    !rolesInOrganizations.includes(targetOrganization)
-  ) {
-    return false;
   }
 
   // Return true if target organization is undefined and user has admin role
@@ -90,9 +85,7 @@ export function checkPermission({
   if (
     !targetOrganization &&
     organizationsInRole.includes('TERMINOLOGY_EDITOR') &&
-    (Array.isArray(actions)
-      ? !actions.some((action) => action.includes('ADMIN'))
-      : !actions.includes('ADMIN'))
+    !actions.some((action) => action.includes('ADMIN'))
   ) {
     return true;
   }
@@ -101,9 +94,7 @@ export function checkPermission({
   // organization and actions don't include admin actions
   if (
     rolesInTargetOrganization?.includes('TERMINOLOGY_EDITOR') &&
-    (Array.isArray(actions)
-      ? !actions.some((action) => action.includes('ADMIN'))
-      : !actions.includes('ADMIN'))
+    !actions.some((action) => action.includes('ADMIN'))
   ) {
     return true;
   }

--- a/src/common/utils/has-permissions.test.ts
+++ b/src/common/utils/has-permissions.test.ts
@@ -36,7 +36,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
     });
     expect(rights).toBe(true);
   });
@@ -49,7 +49,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
     });
     expect(rights).toBe(true);
   });
@@ -62,7 +62,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
     });
     expect(rights).toBe(false);
   });
@@ -72,7 +72,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
       targetOrganization: 'foo',
     });
     expect(rights).toBe(true);
@@ -86,7 +86,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
       targetOrganization: 'foo',
     });
     expect(rights).toBe(true);
@@ -100,7 +100,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
       targetOrganization: 'foo',
     });
     expect(rights).toBe(false);
@@ -139,7 +139,7 @@ describe('has-permission', () => {
 
     const rights = checkPermission({
       user: user,
-      actions: 'CREATE_TERMINOLOGY',
+      actions: ['CREATE_TERMINOLOGY'],
     });
 
     expect(rights).toBe(false);
@@ -151,6 +151,36 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY', 'EDIT_TERMINOLOGY', 'DELETE_TERMINOLOGY'],
+      targetOrganization: 'foo',
+    });
+
+    expect(rights).toBe(true);
+  });
+
+  it('should have rights to edit concept', () => {
+    const user = createMockUser(
+      { foo: ['TERMINOLOGY_EDITOR'] },
+      { TERMINOLOGY_EDITOR: ['foo'] }
+    );
+
+    const rights = checkPermission({
+      user: user,
+      actions: ['EDIT_CONCEPT'],
+      targetOrganization: 'foo',
+    });
+
+    expect(rights).toBe(true);
+  });
+
+  it('should have rights to edit collection', () => {
+    const user = createMockUser(
+      { foo: ['TERMINOLOGY_EDITOR'] },
+      { TERMINOLOGY_EDITOR: ['foo'] }
+    );
+
+    const rights = checkPermission({
+      user: user,
+      actions: ['EDIT_COLLECTION'],
       targetOrganization: 'foo',
     });
 

--- a/src/common/utils/has-permissions.test.ts
+++ b/src/common/utils/has-permissions.test.ts
@@ -73,7 +73,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
     expect(rights).toBe(true);
   });
@@ -87,7 +87,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
     expect(rights).toBe(true);
   });
@@ -101,7 +101,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
     expect(rights).toBe(false);
   });
@@ -115,7 +115,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY', 'EDIT_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
     expect(rights).toBe(true);
   });
@@ -129,7 +129,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY', 'EDIT_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
     expect(rights).toBe(false);
   });
@@ -151,7 +151,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['CREATE_TERMINOLOGY', 'EDIT_TERMINOLOGY', 'DELETE_TERMINOLOGY'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
 
     expect(rights).toBe(true);
@@ -166,7 +166,7 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['EDIT_CONCEPT'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
 
     expect(rights).toBe(true);
@@ -181,9 +181,51 @@ describe('has-permission', () => {
     const rights = checkPermission({
       user: user,
       actions: ['EDIT_COLLECTION'],
-      targetOrganization: 'foo',
+      targetOrganizations: ['foo'],
     });
 
     expect(rights).toBe(true);
+  });
+
+  it('should have rights with multiple target organizations defined', () => {
+    const editorUser = createMockUser(
+      { foo: ['TERMINOLOGY_EDITOR'], temp: ['SOME_OTHER_ROLES'] },
+      { TERMINOLOGY_EDITOR: ['foo'], SOME_OTHER_ROLES: ['temp'] }
+    );
+
+    const adminUser = createMockUser(
+      { foo: ['TERMINOLOGY_EDITOR'], temp: ['ADMIN'] },
+      { TERMINOLOGY_EDITOR: ['foo'], ADMIN: ['temp'] }
+    );
+
+    const editorRights = checkPermission({
+      user: editorUser,
+      actions: ['EDIT_COLLECTION'],
+      targetOrganizations: ['foo', 'temp'],
+    });
+
+    const adminRights = checkPermission({
+      user: adminUser,
+      actions: ['EDIT_COLLECTION'],
+      targetOrganizations: ['foo', 'temp'],
+    });
+
+    expect(editorRights).toBe(true);
+    expect(adminRights).toBe(true);
+  });
+
+  it('should not have rights with multiple target organizations defined', () => {
+    const user = createMockUser(
+      { foo: ['RANDOM_ROLE'], temp: ['SOME_OTHER_ROLES'] },
+      { RANDOM_ROLE: ['foo'], SOME_OTHER_ROLES: ['temp'] }
+    );
+
+    const rights = checkPermission({
+      user: user,
+      actions: ['EDIT_COLLECTION'],
+      targetOrganizations: ['foo', 'temp'],
+    });
+
+    expect(rights).toBe(false);
   });
 });

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -180,7 +180,7 @@ export default function Collection({
 
           {HasPermission({
             actions: 'EDIT_COLLECTION',
-            targetOrganization: terminology?.references.contributor?.[0].id,
+            targetOrganization: terminology?.references.contributor,
           }) && (
             <>
               <BasicBlock

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -213,10 +213,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
           {HasPermission({
             actions: 'EDIT_CONCEPT',
-            // Added terminology object as a fallback if terminologyId isn't
-            // defined for some reason in SSR
-            targetOrganization:
-              terminologyId ?? terminology?.references.contributor?.[0].id,
+            targetOrganization: terminology?.references.contributor?.[0].id,
           }) && (
             <>
               <BasicBlock

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -213,7 +213,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
           {HasPermission({
             actions: 'EDIT_CONCEPT',
-            targetOrganization: terminology?.references.contributor?.[0].id,
+            targetOrganization: terminology?.references.contributor,
           }) && (
             <>
               <BasicBlock

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -213,7 +213,10 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
           {HasPermission({
             actions: 'EDIT_CONCEPT',
-            targetOrganization: terminologyId,
+            // Added terminology object as a fallback if terminologyId isn't
+            // defined for some reason in SSR
+            targetOrganization:
+              terminologyId ?? terminology?.references.contributor?.[0].id,
           }) && (
             <>
               <BasicBlock


### PR DESCRIPTION
Changes in this PR:
- Tweaked `hasPermission()` and added new unit tests
- Added terminology object as a fallback for `hasPermission` in concept page to ensure that terminology ID is passed to function