### PR TITLE
Changed organization selector to use HasPermission()

### DIFF
--- a/public/locales/en/collection.json
+++ b/public/locales/en/collection.json
@@ -12,6 +12,8 @@
   "concept-status": "Concept status",
   "concepts-in-collection": "Concepts in collection",
   "definition": "Definition",
+  "edit-collection": "Edit collection",
+  "edit-collection-rights": "You have rights to edit this collection.",
   "enter-collection-description": "Enter a definition",
   "enter-collection-name": "Enter a name",
   "enter-search-term": "Enter search term",

--- a/public/locales/fi/collection.json
+++ b/public/locales/fi/collection.json
@@ -12,6 +12,8 @@
   "concept-status": "Käsitteen tila",
   "concepts-in-collection": "Käsitekokoelmaan kuuluvat käsitteet",
   "definition": "Määritelmä",
+  "edit-collection": "Muokkaa käsitekokoelmaa",
+  "edit-collection-rights": "Sinulla on oikeudet muokata tätä käsitekokoelmaa",
   "enter-collection-description": "Kirjoita kuvaus",
   "enter-collection-name": "Kirjoita nimi",
   "enter-search-term": "Kirjoita hakusana",

--- a/public/locales/sv/collection.json
+++ b/public/locales/sv/collection.json
@@ -12,6 +12,8 @@
   "concept-status": "",
   "concepts-in-collection": "",
   "definition": "",
+  "edit-collection": "",
+  "edit-collection-rights": "",
   "enter-collection-description": "",
   "enter-collection-name": "",
   "enter-search-term": "",

--- a/src/common/components/terminology-components/organization-selector.tsx
+++ b/src/common/components/terminology-components/organization-selector.tsx
@@ -1,7 +1,5 @@
 import { useTranslation } from 'next-i18next';
-import { useSelector } from 'react-redux';
 import { MultiSelectData, Paragraph, Text } from 'suomifi-ui-components';
-import { selectLogin } from '@app/common/components/login/login.slice';
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import { useGetOrganizationsQuery } from '@app/common/components/terminology-search/terminology-search.slice';
 import {
@@ -11,6 +9,7 @@ import {
 import { UpdateTerminology } from '@app/modules/new-terminology/update-terminology.interface';
 import { NewTerminologyInfo } from '@app/common/interfaces/new-terminology-info';
 import { useEffect, useState } from 'react';
+import HasPermission from '@app/common/utils/has-permission';
 
 export interface OrganizationSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
@@ -23,7 +22,6 @@ export default function OrganizationSelector({
   userPosted,
   initialData,
 }: OrganizationSelectorProps) {
-  const user = useSelector(selectLogin());
   const { t, i18n } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
   const { data: organizations } = useGetOrganizationsQuery(i18n.language);
@@ -40,7 +38,12 @@ export default function OrganizationSelector({
 
   const adminOrgs: MultiSelectData[] = organizations
     ?.map((org) => {
-      if (user.organizationsInRole.ADMIN.includes(org.id.toString())) {
+      if (
+        HasPermission({
+          actions: ['CREATE_TERMINOLOGY'],
+          targetOrganization: org.id.toString(),
+        })
+      ) {
         const orgName = org.properties.prefLabel.value;
 
         if (orgName) {

--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -184,7 +184,7 @@ export default function Collection({
           }) && (
             <>
               <BasicBlock
-                title="Muokkaa käsitekokoelmaa"
+                title={t('edit-collection')}
                 extra={
                   <BasicBlockExtraWrapper>
                     <Link href={`${router.asPath}/edit`}>
@@ -193,13 +193,13 @@ export default function Collection({
                         icon="edit"
                         id="edit-collection-button"
                       >
-                        Muokkaa käsitekokoelmaa
+                        {t('edit-collection')}
                       </Button>
                     </Link>
                   </BasicBlockExtraWrapper>
                 }
               >
-                Sinulla on oikeudet muokata tätä käsitekokoelmaa
+                {t('edit-collection-rights')}
               </BasicBlock>
 
               <Separator />


### PR DESCRIPTION
Changes in this PR:
- Changed `organization-selector` in new terminology creation modal to use `HasPermission()`
- Added missing translations