### PR TITLE
Yti 2076 error modal exitonly

### DIFF
--- a/public/locales/en/alert.json
+++ b/public/locales/en/alert.json
@@ -4,6 +4,7 @@
   "error-occured_access-request": "An error occurred with access request service",
   "error-occured_counts": "An error occurred while getting counts for statuses and information domains",
   "error-occured_groups": "An error occurred while getting information domains",
+  "error-occured_internal-server": "An error occurred within the webpage, please try again",
   "error-occured_organization": "An error occurred while getting organizations",
   "error-occured_subscription": "An error occurred with subscription service",
   "error-occured_terminology-search": "An error occurred while searching for terminologies",

--- a/public/locales/en/alert.json
+++ b/public/locales/en/alert.json
@@ -4,10 +4,10 @@
   "error-occured_access-request": "An error occurred with access request service",
   "error-occured_counts": "An error occurred while getting counts for statuses and information domains",
   "error-occured_groups": "An error occurred while getting information domains",
-  "error-occured_internal-server": "An error occurred within the webpage, please try again",
   "error-occured_organization": "An error occurred while getting organizations",
   "error-occured_subscription": "An error occurred with subscription service",
   "error-occured_terminology-search": "An error occurred while searching for terminologies",
   "error-occured_unhandled-error": "An unknown error occurred",
+  "error-occurred_internal-server": "An error occurred, please try again later",
   "error-occurred_session": "An error occured with the session, try logging in again"
 }

--- a/public/locales/fi/alert.json
+++ b/public/locales/fi/alert.json
@@ -4,6 +4,7 @@
   "error-occured_access-request": "Käyttöoikeuksien pyynnössä ilmeni ongelma",
   "error-occured_counts": "Tilojen ja tietoalueiden lukumäärien haussa ilmeni ongelma",
   "error-occured_groups": "Tietoalueiden haussa ilmeni ongelma",
+  "error-occured_internal-server": "Sivustolla ilmeni ongelma, kokeile uudelleen",
   "error-occured_organization": "Organisaatioiden haussa ilmeni ongelma",
   "error-occured_subscription": "Sähköpostitilauksen toiminnassa ilmeni ongelma",
   "error-occured_terminology-search": "Sanastojen listauksen haussa ilmeni ongelma",

--- a/public/locales/fi/alert.json
+++ b/public/locales/fi/alert.json
@@ -4,10 +4,10 @@
   "error-occured_access-request": "Käyttöoikeuksien pyynnössä ilmeni ongelma",
   "error-occured_counts": "Tilojen ja tietoalueiden lukumäärien haussa ilmeni ongelma",
   "error-occured_groups": "Tietoalueiden haussa ilmeni ongelma",
-  "error-occured_internal-server": "Sivustolla ilmeni ongelma, kokeile uudelleen",
   "error-occured_organization": "Organisaatioiden haussa ilmeni ongelma",
   "error-occured_subscription": "Sähköpostitilauksen toiminnassa ilmeni ongelma",
   "error-occured_terminology-search": "Sanastojen listauksen haussa ilmeni ongelma",
   "error-occured_unhandled-error": "Tapahtui odottamaton virhe",
+  "error-occurred_internal-server": "Tapahtui virhe, kokeile uudelleen myöhemmin",
   "error-occurred_session": "Istunnossa ilmeni ongelma, kokeile kirjautua uudelleen"
 }

--- a/public/locales/sv/alert.json
+++ b/public/locales/sv/alert.json
@@ -4,10 +4,10 @@
   "error-occured_access-request": "",
   "error-occured_counts": "",
   "error-occured_groups": "",
-  "error-occured_internal-server": "",
   "error-occured_organization": "",
   "error-occured_subscription": "",
   "error-occured_terminology-search": "",
   "error-occured_unhandled-error": "",
+  "error-occurred_internal-server": "",
   "error-occurred_session": ""
 }

--- a/public/locales/sv/alert.json
+++ b/public/locales/sv/alert.json
@@ -4,8 +4,10 @@
   "error-occured_access-request": "",
   "error-occured_counts": "",
   "error-occured_groups": "",
+  "error-occured_internal-server": "",
   "error-occured_organization": "",
   "error-occured_subscription": "",
   "error-occured_terminology-search": "",
+  "error-occured_unhandled-error": "",
   "error-occurred_session": ""
 }

--- a/src/common/components/terminology-components/contact-info.tsx
+++ b/src/common/components/terminology-components/contact-info.tsx
@@ -14,12 +14,14 @@ interface ContactInfoProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
   defaultValue?: string;
+  disabled?: boolean;
 }
 
 export default function ContactInfo({
   update,
   userPosted,
   defaultValue,
+  disabled,
 }: ContactInfoProps) {
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -47,6 +49,7 @@ export default function ContactInfo({
         defaultValue={contact}
         maxLength={EMAIL_MAX}
         id="contact-input"
+        disabled={disabled}
       />
     </BlankFieldset>
   );

--- a/src/common/components/terminology-components/information-domains-selector.tsx
+++ b/src/common/components/terminology-components/information-domains-selector.tsx
@@ -14,12 +14,14 @@ interface InformationDomainsSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
   initialData?: NewTerminologyInfo;
+  disabled?: boolean;
 }
 
 export default function InformationDomainsSelector({
   update,
   userPosted,
   initialData,
+  disabled,
 }: InformationDomainsSelectorProps) {
   const { t, i18n } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -77,6 +79,7 @@ export default function InformationDomainsSelector({
         }
         defaultSelectedItems={selectedInfoDomains}
         id="information-domain-selector"
+        disabled={disabled}
       />
     </BlankFieldset>
   );

--- a/src/common/components/terminology-components/language-block.tsx
+++ b/src/common/components/terminology-components/language-block.tsx
@@ -16,6 +16,7 @@ interface LanguageBlockProps {
   userPosted: boolean;
   id: string;
   initialData?: TerminologyName;
+  disabled?: boolean;
 }
 
 export default function LanguageBlock({
@@ -25,6 +26,7 @@ export default function LanguageBlock({
   userPosted,
   id,
   initialData,
+  disabled,
 }: LanguageBlockProps) {
   const { t } = useTranslation('admin');
   const [name, setName] = useState(initialData ? initialData.name : '');
@@ -54,6 +56,7 @@ export default function LanguageBlock({
         defaultValue={name}
         maxLength={TEXT_INPUT_MAX}
         className="terminology-name-input"
+        disabled={disabled}
       />
       <TextareaSmBot
         labelText={t('terminology-description')}
@@ -64,6 +67,7 @@ export default function LanguageBlock({
         maxLength={TEXT_AREA_MAX}
         defaultValue={description}
         className="terminology-description-input"
+        disabled={disabled}
       />
     </LangBlock>
   );

--- a/src/common/components/terminology-components/language-selector.tsx
+++ b/src/common/components/terminology-components/language-selector.tsx
@@ -21,12 +21,14 @@ export interface LanguageSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
   initialData?: NewTerminologyInfo;
+  disabled?: boolean;
 }
 
 export default function LanguageSelector({
   update,
   userPosted,
   initialData,
+  disabled,
 }: LanguageSelectorProps) {
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -170,6 +172,7 @@ export default function LanguageSelector({
         }
         defaultSelectedItems={selectedLanguages}
         id="language-selector"
+        disabled={disabled}
       />
 
       {selectedLanguages.map((language, idx) => (
@@ -185,6 +188,7 @@ export default function LanguageSelector({
             )[0]
           }
           key={`${language}-${idx}`}
+          disabled={disabled}
         />
       ))}
     </BlankFieldset>

--- a/src/common/components/terminology-components/organization-selector.tsx
+++ b/src/common/components/terminology-components/organization-selector.tsx
@@ -16,12 +16,14 @@ export interface OrganizationSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
   initialData?: NewTerminologyInfo;
+  disabled?: boolean;
 }
 
 export default function OrganizationSelector({
   update,
   userPosted,
   initialData,
+  disabled,
 }: OrganizationSelectorProps) {
   const user = useSelector(selectLogin());
   const { t, i18n } = useTranslation('admin');
@@ -90,6 +92,7 @@ export default function OrganizationSelector({
           ariaChipActionLabel={t('aria-chip-action-label')}
           ariaSelectedAmountText={t('chosen-organizations')}
           ariaOptionChipRemovedText={t('organization-removed')}
+          disabled={disabled}
         />
       ) : (
         <>

--- a/src/common/components/terminology-components/prefix.tsx
+++ b/src/common/components/terminology-components/prefix.tsx
@@ -15,9 +15,10 @@ import { TEXT_INPUT_MAX } from '@app/common/utils/constants';
 export interface PrefixProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
+  disabled?: boolean;
 }
 
-export default function Prefix({ update, userPosted }: PrefixProps) {
+export default function Prefix({ update, userPosted, disabled }: PrefixProps) {
   const URI = 'http://uri.suomi.fi/';
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -90,10 +91,18 @@ export default function Prefix({ update, userPosted }: PrefixProps) {
         }}
         id="prefix-input-type-selector"
       >
-        <RadioButton value="automatic" id="prefix-input-automatic">
+        <RadioButton
+          value="automatic"
+          id="prefix-input-automatic"
+          disabled={disabled}
+        >
           {t('automatic-prefix')}
         </RadioButton>
-        <RadioButton value="manual" id="prefix-input-manual">
+        <RadioButton
+          value="manual"
+          id="prefix-input-manual"
+          disabled={disabled}
+        >
           {t('manual-prefix')}
         </RadioButton>
       </RadioButtonGroupSmBot>
@@ -115,6 +124,7 @@ export default function Prefix({ update, userPosted }: PrefixProps) {
           }
           maxLength={TEXT_INPUT_MAX}
           id="prefix-text-input"
+          disabled={disabled}
         />
       )}
       <Paragraph>

--- a/src/common/components/terminology-components/type-selector.tsx
+++ b/src/common/components/terminology-components/type-selector.tsx
@@ -10,11 +10,13 @@ import { useBreakpoints } from '../media-query/media-query-context';
 export interface TypeSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
   defaultValue?: string;
+  disabled?: boolean;
 }
 
 export default function TypeSelector({
   update,
   defaultValue,
+  disabled,
 }: TypeSelectorProps) {
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -36,6 +38,7 @@ export default function TypeSelector({
           value="TERMINOLOGICAL_VOCABULARY"
           id="type-terminological"
           variant={isSmall ? 'large' : 'small'}
+          disabled={disabled}
         >
           {t('terminological-vocabulary')}
         </RadioButton>
@@ -43,6 +46,7 @@ export default function TypeSelector({
           value="OTHER_VOCABULARY"
           id="type-other"
           variant={isSmall ? 'large' : 'small'}
+          disabled={disabled}
         >
           {t('other-vocabulary')}
         </RadioButton>

--- a/src/common/utils/translation-helpers.ts
+++ b/src/common/utils/translation-helpers.ts
@@ -171,7 +171,7 @@ export function translateHttpError(
     case 401:
       return t('error-occurred_session', { ns: 'alert' });
     case 500:
-      return t('error-occured_internal-server', { ns: 'alert' });
+      return t('error-occurred_internal-server', { ns: 'alert' });
     default:
       return t('error-occured_unhandled-error', { ns: 'alert' });
   }

--- a/src/common/utils/translation-helpers.ts
+++ b/src/common/utils/translation-helpers.ts
@@ -162,3 +162,17 @@ export function translateFileUploadError(
       return;
   }
 }
+
+export function translateHttpError(
+  status: number | 'GENERIC_ERROR',
+  t: TFunction
+) {
+  switch (status) {
+    case 401:
+      return t('error-occurred_session', { ns: 'alert' });
+    case 500:
+      return t('error-occured_internal-server', { ns: 'alert' });
+    default:
+      return t('error-occured_unhandled-error', { ns: 'alert' });
+  }
+}

--- a/src/modules/new-terminology/info-manual.tsx
+++ b/src/modules/new-terminology/info-manual.tsx
@@ -19,6 +19,7 @@ interface InfoManualProps {
   userPosted: boolean;
   initialData?: NewTerminologyInfo;
   onChange: () => void;
+  disabled?: boolean;
 }
 
 export default function InfoManual({
@@ -27,6 +28,7 @@ export default function InfoManual({
   userPosted,
   initialData,
   onChange,
+  disabled,
 }: InfoManualProps) {
   const { t } = useTranslation('admin');
   const [terminologyData, setTerminologyData] = useState<NewTerminologyInfo>(
@@ -67,6 +69,7 @@ export default function InfoManual({
     <form>
       <TallerSeparator />
       <LanguageSelector
+        disabled={disabled}
         update={handleUpdate}
         userPosted={userPosted}
         initialData={terminologyData}
@@ -76,11 +79,16 @@ export default function InfoManual({
         <Text variant="bold">{t('terminology-other-information')}</Text>
       </Paragraph>
       <OrganizationSelector
+        disabled={disabled}
         update={handleUpdate}
         userPosted={userPosted}
         initialData={initialData}
       />
-      <TypeSelector update={handleUpdate} defaultValue={initialData?.type} />
+      <TypeSelector
+        disabled={disabled}
+        update={handleUpdate}
+        defaultValue={initialData?.type}
+      />
 
       {initialData && (
         <StatusSelector
@@ -91,15 +99,23 @@ export default function InfoManual({
       )}
 
       <InformationDomainsSelector
+        disabled={disabled}
         update={handleUpdate}
         userPosted={userPosted}
         initialData={initialData}
       />
 
-      {!initialData && <Prefix update={handleUpdate} userPosted={userPosted} />}
+      {!initialData && (
+        <Prefix
+          disabled={disabled}
+          update={handleUpdate}
+          userPosted={userPosted}
+        />
+      )}
 
       <TallerSeparator />
       <ContactInfo
+        disabled={disabled}
         update={handleUpdate}
         userPosted={userPosted}
         defaultValue={initialData?.contact}

--- a/src/modules/new-terminology/status-selector.tsx
+++ b/src/modules/new-terminology/status-selector.tsx
@@ -10,12 +10,14 @@ export interface StatusSelectorProps {
   update: ({ key, data }: UpdateTerminology) => void;
   userPosted: boolean;
   defaultValue?: string;
+  disabled?: boolean;
 }
 
 export default function StatusSelector({
   update,
   userPosted,
   defaultValue,
+  disabled,
 }: StatusSelectorProps) {
   const { t } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -75,6 +77,7 @@ export default function StatusSelector({
         status={userPosted && isError ? 'error' : 'default'}
         onItemSelectionChange={(e) => handleChange(e)}
         $isSmall={isSmall}
+        disabled={disabled}
       />
     </BlankFieldset>
   );


### PR DESCRIPTION
Changelog:
- Added the ability to disable all add terminology modal form fields
- Disable all add terminology modal form fields if there is an API call error
- Show errors on the bottom of the modal instead of behind the modal.
- Added translations to translation helper for HTTP codes


![image](https://user-images.githubusercontent.com/19401683/191423434-9c4f8644-dce5-4500-b077-2051a9a7a04b.png)
