### PR TITLE
YTI-2109: moved button to below expander

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -160,7 +160,6 @@
   "new-collection": "New collection",
   "new-collection-to-terminology": "New collection to terminology",
   "new-concept-title": "New Concept",
-  "new-concept-to-terminology": "New concept to terminology",
   "new-term": "New term",
   "new-term-modal-description": "All fields are required unless marked optional. It is recommended to fill in all the information.",
   "new-terminology-created": "New terminology created",
@@ -281,6 +280,5 @@
   "word-class-no-items": "No word classes available",
   "you-can-copy": "You can copy the terminology as a base for a newer version, where the original terminology will exist until the newer terminology is ready",
   "you-have-right-edit-terminology": "You have the rights to edit this terminology",
-  "you-have-right-new-collection": "You have the rights to create new collections to this terminology",
-  "you-have-right-new-concept": "You have the rights to create new concepts to this terminology"
+  "you-have-right-new-collection": "You have the rights to create new collections to this terminology"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -149,6 +149,8 @@
     "undefined": "Terminology type undefined"
   },
   "try-again": "Try again",
+  "vocabulary-collections": "Terminology collections",
+  "vocabulary-concepts": "Terminology concepts",
   "vocabulary-filter-concepts": "Concepts",
   "vocabulary-filter-filter-by-keyword": "Filter by word",
   "vocabulary-filter-filter-list": "Filter list",

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -160,7 +160,6 @@
   "new-collection": "Uusi käsitekokoelma",
   "new-collection-to-terminology": "Uusi käsitekokoelma sanastoon",
   "new-concept-title": "Uusi käsite",
-  "new-concept-to-terminology": "Uusi käsite sanastoon",
   "new-term": "Uusi termi",
   "new-term-modal-description": "Tiedot ovat pakollisia, jos niitä ei ole merkitty valinnaisiksi. Suositeltavaa on täyttää kaikki tiedot.",
   "new-terminology-created": "Uusi sanasto luotu",
@@ -281,6 +280,5 @@
   "word-class-no-items": "Sanaluokka ei saatavilla",
   "you-can-copy": "Voit kopioida sanaston pohjaksi uudelle versiolle, jolloin nykyinen sanasto säilyy olemassa kunnes uusi sanasto on valmis",
   "you-have-right-edit-terminology": "Sinulla on oikeudet muokata tätä sanastoa",
-  "you-have-right-new-collection": "Sinulla on oikeudet luoda uusia käsitekokoelmia sanastoon",
-  "you-have-right-new-concept": "Sinulla on oikeudet luoda uusia käsitteitä sanastoon"
+  "you-have-right-new-collection": "Sinulla on oikeudet luoda uusia käsitekokoelmia sanastoon"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -149,6 +149,8 @@
     "undefined": "Sanaston tyyppiä ei ole määritetty"
   },
   "try-again": "Yritä uudestaan",
+  "vocabulary-collections": "Sanaston käsitekokoelmat",
+  "vocabulary-concepts": "Sanaston käsitteet",
   "vocabulary-filter-concepts": "Käsitteet",
   "vocabulary-filter-filter-by-keyword": "Rajaa sanalla",
   "vocabulary-filter-filter-list": "Rajaa listaa",

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -160,7 +160,6 @@
   "new-collection": "",
   "new-collection-to-terminology": "",
   "new-concept-title": "",
-  "new-concept-to-terminology": "",
   "new-term": "",
   "new-term-modal-description": "",
   "new-terminology-created": "",
@@ -281,6 +280,5 @@
   "word-class-no-items": "",
   "you-can-copy": "",
   "you-have-right-edit-terminology": "",
-  "you-have-right-new-collection": "",
-  "you-have-right-new-concept": ""
+  "you-have-right-new-collection": ""
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -149,6 +149,8 @@
     "undefined": ""
   },
   "try-again": "",
+  "vocabulary-collections": "",
+  "vocabulary-concepts": "",
   "vocabulary-filter-concepts": "",
   "vocabulary-filter-filter-by-keyword": "",
   "vocabulary-filter-filter-list": "",

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -31,7 +31,6 @@ import PropertyValue from '../property-value';
 const Subscription = dynamic(
   () => import('@app/common/components/subscription/subscription')
 );
-const NewConceptModal = dynamic(() => import('../new-concept-modal'));
 const CopyTerminologyModal = dynamic(() => import('../copy-terminology-modal'));
 
 interface InfoExpanderProps {
@@ -140,18 +139,6 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
               {t('you-have-right-edit-terminology', { ns: 'admin' })}
             </BasicBlock>
           </>
-        )}
-
-        {HasPermission({
-          actions: 'CREATE_CONCEPT',
-          targetOrganization: data.references.contributor,
-        }) && (
-          <NewConceptModal
-            terminologyId={data.type.graph.id}
-            languages={
-              data.properties.language?.map(({ value }) => value) ?? []
-            }
-          />
         )}
 
         {HasPermission({

--- a/src/common/components/new-concept-modal/index.tsx
+++ b/src/common/components/new-concept-modal/index.tsx
@@ -2,9 +2,6 @@ import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import { Button } from 'suomifi-ui-components';
-import { BasicBlock } from '../block';
-import { BasicBlockExtraWrapper } from '../block/block.styles';
-import Separator from '../separator';
 
 const NewConceptModalDynamic = dynamic(() => import('./new-concept-modal'));
 
@@ -22,25 +19,14 @@ export default function NewConceptModal({
 
   return (
     <>
-      <Separator isLarge />
-
-      <BasicBlock
-        title={t('new-concept-to-terminology')}
-        extra={
-          <BasicBlockExtraWrapper>
-            <Button
-              icon="plus"
-              variant="secondary"
-              onClick={() => setVisible(true)}
-              id="new-concept-button"
-            >
-              {t('add-new-concept')}
-            </Button>
-          </BasicBlockExtraWrapper>
-        }
+      <Button
+        icon="plus"
+        variant="secondary"
+        onClick={() => setVisible(true)}
+        id="new-concept-button"
       >
-        {t('you-have-right-new-concept')}
-      </BasicBlock>
+        {t('add-new-concept')}
+      </Button>
 
       {visible && (
         <NewConceptModalDynamic

--- a/src/modules/terminology-search/terminology-search.styles.tsx
+++ b/src/modules/terminology-search/terminology-search.styles.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Block, Button } from 'suomifi-ui-components';
 
 export const FilterMobileButton = styled(Button)`
-  margin-top: 20px;
+  margin-top: ${(props) => props.theme.suomifi.spacing.xs};
 `;
 
 export const FilterTopPartBlock = styled(Block)`

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -10,11 +10,13 @@ import {
   ResultAndFilterContainer,
   ResultAndStatsWrapper,
   PaginationWrapper,
+  QuickActionsWrapper,
 } from './vocabulary.styles';
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import { FilterMobileButton } from '@app/modules/terminology-search/terminology-search.styles';
 import { useTranslation } from 'next-i18next';
 import {
+  Heading,
   Modal,
   ModalContent,
   Notification,
@@ -30,6 +32,8 @@ import Pagination from '@app/common/components/pagination/pagination';
 import filterData from '@app/common/utils/filter-data';
 import LoadIndicator from '@app/common/components/load-indicator';
 import { useRouter } from 'next/router';
+import HasPermission from '@app/common/utils/has-permission';
+import NewConceptModal from '@app/common/components/new-concept-modal';
 
 interface VocabularyProps {
   id: string;
@@ -118,15 +122,6 @@ export default function Vocabulary({ id }: VocabularyProps) {
 
       <main id="main">
         {info && <Title info={info} />}
-        {isSmall && (
-          <FilterMobileButton
-            variant="secondary"
-            fullWidth
-            onClick={() => setShowModal(!showModal)}
-          >
-            {t('vocabulary-filter-filter-list')}
-          </FilterMobileButton>
-        )}
         <ResultAndFilterContainer>
           {!isSmall ? (
             <TerminologyListFilter
@@ -153,6 +148,35 @@ export default function Vocabulary({ id }: VocabularyProps) {
             </Modal>
           )}
           <ResultAndStatsWrapper id="search-results">
+            <QuickActionsWrapper isSmall={isSmall}>
+              <Heading variant="h2" id="results-title">
+                {urlState.type === 'concept'
+                  ? t('vocabulary-concepts')
+                  : t('vocabulary-collections')}
+              </Heading>
+              {HasPermission({
+                actions: 'CREATE_CONCEPT',
+                targetOrganization: info?.references.contributor,
+              }) && (
+                <NewConceptModal
+                  terminologyId={id}
+                  languages={
+                    info?.properties.language?.map(({ value }) => value) ?? []
+                  }
+                />
+              )}
+            </QuickActionsWrapper>
+
+            {isSmall && (
+              <FilterMobileButton
+                variant="secondary"
+                fullWidth
+                onClick={() => setShowModal(!showModal)}
+              >
+                {t('vocabulary-filter-filter-list')}
+              </FilterMobileButton>
+            )}
+
             {urlState.type === 'concept' &&
               ((showLoadingConcepts && isFetchingConcepts) || conceptsError ? (
                 <LoadIndicator

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -33,7 +33,11 @@ import filterData from '@app/common/utils/filter-data';
 import LoadIndicator from '@app/common/components/load-indicator';
 import { useRouter } from 'next/router';
 import HasPermission from '@app/common/utils/has-permission';
-import NewConceptModal from '@app/common/components/new-concept-modal';
+import dynamic from 'next/dynamic';
+
+const NewConceptModal = dynamic(
+  () => import('@app/common/components/new-concept-modal')
+);
 
 interface VocabularyProps {
   id: string;

--- a/src/modules/vocabulary/vocabulary.styles.tsx
+++ b/src/modules/vocabulary/vocabulary.styles.tsx
@@ -30,3 +30,14 @@ export const PaginationWrapper = styled.div`
   flex-direction: row;
   justify-content: center;
 `;
+
+export const QuickActionsWrapper = styled.div<{ isSmall?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: ${(props) => (props.isSmall ? 'column' : 'row')};
+
+  gap: ${(props) => props.theme.suomifi.spacing.xs};
+  & :nth-child(1) {
+    flex-grow: 1;
+  }
+`;


### PR DESCRIPTION
Changelog:
 - Simplified add concept component to only have the button
 - Removed translations and added new ones
 - Moved button to the ResultCardWrapper instead of info-expander
 - Added title next to the buttons
   - Title expands by default so the buttons will be on the right side

![add-concept-new-mobile](https://user-images.githubusercontent.com/19401683/191688594-0755296c-89b0-4753-a8a9-a2f320d4562a.png)
![add-concept-new](https://user-images.githubusercontent.com/19401683/191688604-e237f76f-9e97-4213-978b-db9482f4dd4f.png)
