### PR TITLE
YTI-2130 use relative links in search results

### DIFF
--- a/src/common/components/search-results/result-card-expander.tsx
+++ b/src/common/components/search-results/result-card-expander.tsx
@@ -18,12 +18,14 @@ interface ResultCardExpanderProps {
   deepHits: DeepHitsDTO[];
   buttonLabel: string;
   contentLabel: string;
+  terminologyId: string;
 }
 
 export default function ResultCardExpander({
   deepHits,
   buttonLabel,
   contentLabel,
+  terminologyId,
 }: ResultCardExpanderProps) {
   const { t, i18n } = useTranslation();
   const suffix =
@@ -42,7 +44,7 @@ export default function ResultCardExpander({
       </ExpanderTitleButton>
       <ExpanderContent>
         <ExpanderContentTitle variant="h4">{contentLabel}</ExpanderContentTitle>
-        <HitsWrapper>{renderHitsInContent()}</HitsWrapper>
+        <HitsWrapper>{renderHitsInContent(terminologyId)}</HitsWrapper>
       </ExpanderContent>
     </Expander>
   );
@@ -92,12 +94,16 @@ export default function ResultCardExpander({
     });
   }
 
-  function renderHitsInContent() {
+  function renderHitsInContent(terminologyId: string) {
     return deepHits.map((deepHit, hitIdx) =>
       deepHit.topHits.map((hit, idx) => {
         if (hit.uri) {
           return (
-            <Link key={`${hitIdx}-${idx}`} href={hit.uri} passHref>
+            <Link
+              key={`${hitIdx}-${idx}`}
+              href={`/terminology/${terminologyId}/concept/${hit.id}`}
+              passHref
+            >
               <SuomiFiLink href="">
                 <SanitizedTextContent text={getText(hit.label)} />
               </SuomiFiLink>

--- a/src/common/components/search-results/search-results.tsx
+++ b/src/common/components/search-results/search-results.tsx
@@ -92,6 +92,7 @@ export default function SearchResults({
                         deepHits={data.deepHits[terminology.id]}
                         buttonLabel={t('results-with-query-from-terminology')}
                         contentLabel={t('concepts')}
+                        terminologyId={terminology.id}
                       />
                     )
                   }


### PR DESCRIPTION
It doesn't make sense to use uri.suomi.fi links in internal links. Use relative links instead, e.g. `/terminology/:terminologyId/concept/:conceptId`