### PR TITLE
Enabled JS error tracking to matomo reports

### DIFF
--- a/src/common/components/matomo/index.tsx
+++ b/src/common/components/matomo/index.tsx
@@ -38,6 +38,7 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
     matomo('enableLinkTracking');
     matomo('setTrackerUrl', `${url}/matomo.php`);
     matomo('setSiteId', siteId);
+    matomo('enableJSErrorTracking');
   }, [siteId, url]);
 
   useEffect(() => {

--- a/src/common/components/matomo/matomo.test.tsx
+++ b/src/common/components/matomo/matomo.test.tsx
@@ -61,8 +61,8 @@ describe('matomo', () => {
 
     jest.runAllTimers();
 
-    expect(window._paq?.[6]).toStrictEqual(['setCustomUrl', '/another-page']);
-    expect(window._paq?.[8]).toStrictEqual(['trackPageView']);
+    expect(window._paq?.[7]).toStrictEqual(['setCustomUrl', '/another-page']);
+    expect(window._paq?.[9]).toStrictEqual(['trackPageView']);
   });
 
   it('should log referrer url when page changes', () => {
@@ -74,7 +74,7 @@ describe('matomo', () => {
 
     jest.runAllTimers();
 
-    expect(window._paq?.[5]).toStrictEqual(['setReferrerUrl', '/']);
+    expect(window._paq?.[6]).toStrictEqual(['setReferrerUrl', '/']);
   });
 
   it('should log new page title when page changes', () => {
@@ -86,7 +86,7 @@ describe('matomo', () => {
 
     jest.runAllTimers();
 
-    expect(window._paq?.[7]).toStrictEqual([
+    expect(window._paq?.[8]).toStrictEqual([
       'setDocumentTitle',
       'Another Page',
     ]);
@@ -100,6 +100,6 @@ describe('matomo', () => {
 
     jest.runAllTimers();
 
-    expect(window._paq).toHaveLength(5);
+    expect(window._paq).toHaveLength(6);
   });
 });


### PR DESCRIPTION
`enableJSErrorTracking` added as a new parameter for Matomo requests for logging possible errors to the service.