### PR TITLE
YTI-2060: added concept import modal

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -100,8 +100,8 @@
   "description": "Description",
   "diagram-name": "Diagram name",
   "diagram-url": "Diagram web address",
-  "download-failed": "Download failed",
-  "downloading-file": "Downloading file",
+  "download-failed": "Import failed",
+  "downloading-file": "Importing file",
   "edit-concept-error": {
     "default": "Concept has missing information",
     "diagrams": "At least one diagram is missing name and/or url",

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -67,6 +67,14 @@
   "concept-class": "Concept class",
   "concept-diagram-or-link": "Concept diagram or other link",
   "concept-diagrams-and-sources": "Concept diagrams and sources",
+  "concept-import": {
+    "property-missing-language-suffix": "Property key is missing language suffix",
+    "status-column-missing": "Status column is missing",
+    "term-missing-language-suffix": "Term key is missing language suffix",
+    "terminology-no-language": "Language does not exist in terminology",
+    "undefined-error": "There was an error importing the concepts",
+    "value-not-valid": "Value in cell was not valid"
+  },
   "concept-other-information": "Concept's other information",
   "concept-other-terms-description": "You can add other terms to the concept, such as a non-recommended term or synonym.",
   "concept-other-terms-title": "Other terms",
@@ -117,6 +125,9 @@
   "example-description": "Example gives information on how to use concept.",
   "example-textarea-label-text": "Example related to concept",
   "example-textarea-placeholder": "Give example",
+  "excel-column": "Column",
+  "excel-row": "Row",
+  "excel-sheet": "Sheet",
   "file-added": "File added",
   "file-upload-error": {
     "incorrect-file-type": "Incorrect file type. Allowed file type is xlsx.",
@@ -128,6 +139,8 @@
   "has-part-concept-chip-label": "Chosen has part concepts",
   "has-part-concept-decription": "Narrower concept that is part of this concept.",
   "homograph-number": "Homograph number",
+  "import-concepts": "Import concepts",
+  "import-concepts-to-terminology": "Import concepts to terminology",
   "info-domains": "Information domains",
   "info-domains-available": "Available information domains",
   "info-domains-hint": "Select information domains for the terminology. Setting information domain(s) makes terminology easier for users to find.",

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -67,6 +67,14 @@
   "concept-class": "Käsitteen luokka",
   "concept-diagram-or-link": "Käsitekaavio tai muu linkki",
   "concept-diagrams-and-sources": "Käsitekaaviot ja lähteet",
+  "concept-import": {
+    "property-missing-language-suffix": "Käsitteen tiedon avaimesta puuttuu kieli suffiksi",
+    "status-column-missing": "Tila kenttä puuttuu",
+    "term-missing-language-suffix": "Termin avaimesta puuttuu kieli suffiksi",
+    "terminology-no-language": "Sanastossa ei ole annettua kieltä",
+    "undefined-error": "Käsitteiden tuonnissa tapahtui virhe",
+    "value-not-valid": "Arvo solussa on virheellinen"
+  },
   "concept-other-information": "Käsitteen muut tiedot",
   "concept-other-terms-description": "Voit lisätä käsitteelle muita termejä, kuten ei suositettavan termin tai synonyymin.",
   "concept-other-terms-title": "Muut termit",
@@ -117,6 +125,9 @@
   "example-description": "Käyttöesimerkki on esimerkki käsitteen käytöstä.",
   "example-textarea-label-text": "Käsitteeseen liittyvä esimerkki",
   "example-textarea-placeholder": "Kirjoita esimerkki",
+  "excel-column": "Sarake",
+  "excel-row": "Rivi",
+  "excel-sheet": "Taulukko",
   "file-added": "Tiedosto lisätty",
   "file-upload-error": {
     "incorrect-file-type": "Väärä tiedostotyyppi. Sallittu tiedostotyyppi on xlsx.",
@@ -128,6 +139,8 @@
   "has-part-concept-chip-label": "Valitut koostumussuhteiset alakäsitteet",
   "has-part-concept-decription": "Käsite, joka vastaa kokonaisuuden osaa.",
   "homograph-number": "Homonyymin järjestysnumero",
+  "import-concepts": "Tuo käsitteitä",
+  "import-concepts-to-terminology": "Tuo käsitteet sanastoon",
   "info-domains": "Tietoalueet",
   "info-domains-available": "Saatavilla olevat tietoalueet",
   "info-domains-hint": "Valitse sanastolle sen sisältöä kuvaavat tietoalueet. Tietoalue auttaa sanaston löydettävyydessä.",

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -67,6 +67,14 @@
   "concept-class": "",
   "concept-diagram-or-link": "",
   "concept-diagrams-and-sources": "",
+  "concept-import": {
+    "property-missing-language-suffix": "",
+    "status-column-missing": "",
+    "term-missing-language-suffix": "",
+    "terminology-no-language": "",
+    "undefined-error": "",
+    "value-not-valid": ""
+  },
   "concept-other-information": "",
   "concept-other-terms-description": "",
   "concept-other-terms-title": "",
@@ -117,6 +125,9 @@
   "example-description": "",
   "example-textarea-label-text": "",
   "example-textarea-placeholder": "",
+  "excel-column": "",
+  "excel-row": "",
+  "excel-sheet": "",
   "file-added": "",
   "file-upload-error": {
     "incorrect-file-type": "",
@@ -128,6 +139,8 @@
   "has-part-concept-chip-label": "",
   "has-part-concept-decription": "",
   "homograph-number": "",
+  "import-concepts": "",
+  "import-concepts-to-terminology": "",
   "info-domains": "",
   "info-domains-available": "",
   "info-domains-hint": "",

--- a/src/common/components/concept-import/concept-import-modal.test.tsx
+++ b/src/common/components/concept-import/concept-import-modal.test.tsx
@@ -1,0 +1,44 @@
+import { makeStore } from '@app/store';
+import { getMockContext, themeProvider } from '@app/tests/test-utils';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import ConceptImportModal from './concept-import-modal';
+
+describe('info-file', () => {
+  let appRoot: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    appRoot = document.createElement('div');
+    appRoot.setAttribute('id', '__next');
+    document.body.appendChild(appRoot);
+  });
+
+  it('should render components', () => {
+    const store = makeStore(getMockContext());
+
+    const mockRefetch = jest.fn();
+    const mockSetVisible = jest.fn();
+
+    render(
+      <Provider store={store}>
+        <ConceptImportModal
+          visible
+          setVisible={mockSetVisible}
+          terminologyId="testID"
+          refetch={mockRefetch}
+        />
+      </Provider>,
+      {
+        wrapper: themeProvider,
+      }
+    );
+
+    expect(screen.getByText('tr-import-concepts')).toBeInTheDocument();
+
+    expect(
+      screen.getByText('tr-import-concepts-to-terminology')
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/tr-allowed-file-formats/)).toBeInTheDocument();
+  });
+});

--- a/src/common/components/concept-import/concept-import-modal.tsx
+++ b/src/common/components/concept-import/concept-import-modal.tsx
@@ -1,0 +1,97 @@
+import FileUpload from '@app/modules/new-terminology/file-upload';
+import InfoFile from '@app/modules/new-terminology/info-file';
+import { useTranslation } from 'next-i18next';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalTitle,
+} from 'suomifi-ui-components';
+import { createErrorMessage, ExcelError } from '../excel/excel.error';
+import { usePostSimpleImportExcelMutation } from '../excel/excel.slice';
+import { useBreakpoints } from '../media-query/media-query-context';
+
+interface ConceptImportModalProps {
+  terminologyId: string;
+  visible: boolean;
+  setVisible: (value: boolean) => void;
+  refetch: () => void;
+}
+
+export default function ConceptImportModal({
+  terminologyId,
+  visible,
+  setVisible,
+  refetch,
+}: ConceptImportModalProps) {
+  const { t } = useTranslation('admin');
+  const { isSmall } = useBreakpoints();
+  const [fileData, setFileData] = useState<File | null>();
+  const [isValid, setIsValid] = useState(false);
+  const [userPosted, setUserPosted] = useState(false);
+  const [startFileUpload, setStartFileUpload] = useState(false);
+  const [error, setError] = useState<ExcelError | undefined>(undefined);
+  const [postSimpleImportExcel, simpleImportExcel] =
+    usePostSimpleImportExcelMutation();
+
+  const handleClose = useCallback(() => {
+    setStartFileUpload(false);
+    setVisible(false);
+    setUserPosted(false);
+    if (simpleImportExcel.isSuccess) {
+      refetch();
+    }
+  }, [setVisible, refetch, simpleImportExcel]);
+
+  const handlePost = () => {
+    if (fileData) {
+      const formData = new FormData();
+      formData.append('file', fileData);
+      setStartFileUpload(true);
+      setUserPosted(true);
+      postSimpleImportExcel({ terminologyId: terminologyId, file: formData });
+    }
+  };
+
+  useEffect(() => {
+    if (simpleImportExcel.isError) {
+      setError(createErrorMessage(simpleImportExcel.error));
+    }
+  }, [simpleImportExcel]);
+
+  return (
+    <Modal
+      appElementId="__next"
+      visible={visible}
+      onEscKeyDown={() => handleClose()}
+      variant={!isSmall ? 'default' : 'smallScreen'}
+    >
+      <ModalContent>
+        <ModalTitle>{t('import-concepts')}</ModalTitle>
+        {!startFileUpload ? (
+          <InfoFile setFileData={setFileData} setIsValid={setIsValid} />
+        ) : (
+          <FileUpload
+            importResponseData={simpleImportExcel.data}
+            importResponseStatus={simpleImportExcel.status}
+            handlePost={handlePost}
+            handleClose={handleClose}
+            errorInfo={error}
+          />
+        )}
+      </ModalContent>
+      {!userPosted && (
+        <ModalFooter id="concept-import-modal-footer">
+          <Button disabled={!isValid} onClick={handlePost}>
+            {t('import-concepts-to-terminology')}
+          </Button>
+          <Button variant="secondary" onClick={handleClose}>
+            {t('cancel-variant')}
+          </Button>
+        </ModalFooter>
+      )}
+    </Modal>
+  );
+}

--- a/src/common/components/concept-import/concept-import-modal.tsx
+++ b/src/common/components/concept-import/concept-import-modal.tsx
@@ -68,7 +68,7 @@ export default function ConceptImportModal({
       onEscKeyDown={() => handleClose()}
       variant={!isSmall ? 'default' : 'smallScreen'}
     >
-      <ModalContent>
+      <ModalContent style={userPosted ? { paddingBottom: '18px' } : {}}>
         <ModalTitle>{t('import-concepts')}</ModalTitle>
         {!startFileUpload ? (
           <InfoFile setFileData={setFileData} setIsValid={setIsValid} />

--- a/src/common/components/concept-import/concept-import-modal.tsx
+++ b/src/common/components/concept-import/concept-import-modal.tsx
@@ -69,7 +69,9 @@ export default function ConceptImportModal({
       variant={!isSmall ? 'default' : 'smallScreen'}
     >
       <ModalContent style={userPosted ? { paddingBottom: '18px' } : {}}>
-        <ModalTitle>{t('import-concepts')}</ModalTitle>
+        <ModalTitle>
+          {!startFileUpload ? t('import-concepts') : t('downloading-file')}
+        </ModalTitle>
         {!startFileUpload ? (
           <InfoFile setFileData={setFileData} setIsValid={setIsValid} />
         ) : (

--- a/src/common/components/concept-import/index.tsx
+++ b/src/common/components/concept-import/index.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'next-i18next';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { Button } from 'suomifi-ui-components';
+
+const ConceptImportModalDynamic = dynamic(
+  () => import('./concept-import-modal')
+);
+
+interface ConceptImportProps {
+  terminologyId: string;
+  refetch: () => void;
+}
+
+export default function ConceptImportModal({
+  terminologyId,
+  refetch,
+}: ConceptImportProps) {
+  const { t } = useTranslation('admin');
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <Button
+        icon="upload"
+        variant="secondary"
+        onClick={() => setVisible(true)}
+      >
+        {t('import-concepts')}
+      </Button>
+
+      {visible && (
+        <ConceptImportModalDynamic
+          terminologyId={terminologyId}
+          visible={visible}
+          setVisible={setVisible}
+          refetch={refetch}
+        />
+      )}
+    </>
+  );
+}

--- a/src/common/components/excel/excel.error.md
+++ b/src/common/components/excel/excel.error.md
@@ -1,0 +1,7 @@
+# Purpose of this component
+
+`yti-terminology-api` returns a `ExcelImportResponseDTO` object in the REST api response for the Excel import endpoints. These can contain a `ExcelParseException`.
+
+The purpose of this component is to parse the incoming information into something we can use in this project.
+
+The error details are optional in case the excel error throws some other kind of error

--- a/src/common/components/excel/excel.error.tsx
+++ b/src/common/components/excel/excel.error.tsx
@@ -1,0 +1,47 @@
+import { AxiosBaseQueryError } from '@app/store/axios-base-query';
+import { SerializedError } from '@reduxjs/toolkit';
+
+export interface ExcelError {
+  code: string;
+  data: ExcelErrorDetails;
+}
+
+export interface ExcelErrorDetails {
+  message: string;
+  errorDetails?: {
+    sheet: string;
+    row: number;
+    column: string;
+  };
+}
+
+export const createErrorMessage = (
+  error: AxiosBaseQueryError | SerializedError | undefined
+) => {
+  if (!error) {
+    return {
+      code: 'UNKNOWN_ERROR',
+      data: { message: 'Unknown error' },
+    } as ExcelError;
+  }
+
+  // AxiosBaseQueryError
+  if ('status' in error) {
+    return {
+      code: error.status,
+      data: error.data as ExcelErrorDetails,
+    } as ExcelError;
+  }
+  // SerializedError
+  if ('code' in error) {
+    return {
+      code: error.code ?? 'UNKNOWN_ERROR',
+      data: {
+        message:
+          error.message ?? error.code
+            ? `Error code ${error.code}`
+            : 'Unknown error',
+      },
+    } as ExcelError;
+  }
+};

--- a/src/common/components/excel/excel.slice.tsx
+++ b/src/common/components/excel/excel.slice.tsx
@@ -26,8 +26,21 @@ export const excelApi = createApi({
         method: 'GET',
       }),
     }),
+    postSimpleImportExcel: builder.mutation<
+      ImportResponse,
+      { terminologyId: string; file: FormData }
+    >({
+      query: (props) => ({
+        url: `/import/simpleExcel/${props.terminologyId}`,
+        method: 'POST',
+        data: props.file,
+      }),
+    }),
   }),
 });
 
-export const { usePostImportExcelMutation, useGetImportStatusMutation } =
-  excelApi;
+export const {
+  usePostImportExcelMutation,
+  useGetImportStatusMutation,
+  usePostSimpleImportExcelMutation,
+} = excelApi;

--- a/src/common/utils/translation-helpers.ts
+++ b/src/common/utils/translation-helpers.ts
@@ -176,3 +176,22 @@ export function translateHttpError(
       return t('error-occured_unhandled-error', { ns: 'alert' });
   }
 }
+
+export function translateExcelParseError(message: string, t: TFunction) {
+  switch (message) {
+    case 'terminology-no-language':
+      return t('concept-import.terminology-no-language', { ns: 'admin' });
+    case 'term-missing-language-suffix':
+      return t('concept-import.term-missing-language-suffix', { ns: 'admin' });
+    case 'value-not-valid':
+      return t('concept-import.value-not-valid', { ns: 'admin' });
+    case 'property-missing-language-suffix':
+      return t('concept-import.property-missing-language-suffix', {
+        ns: 'admin',
+      });
+    case 'status-column-missing':
+      return t('concept-import.status-column-missing', { ns: 'admin' });
+    default:
+      return t('concept-import.undefined-error', { ns: 'admin' });
+  }
+}

--- a/src/modules/new-terminology/file-upload.tsx
+++ b/src/modules/new-terminology/file-upload.tsx
@@ -1,5 +1,7 @@
+import { ExcelError } from '@app/common/components/excel/excel.error';
 import { useGetImportStatusMutation } from '@app/common/components/excel/excel.slice';
 import { ImportResponse } from '@app/common/interfaces/excel.interface';
+import { translateExcelParseError } from '@app/common/utils/translation-helpers';
 import { useTranslation } from 'next-i18next';
 import { useEffect } from 'react';
 import { Button, InlineAlert, Text } from 'suomifi-ui-components';
@@ -15,6 +17,7 @@ interface FileUploadProps {
   importResponseStatus: string;
   handlePost: () => void;
   handleClose: () => void;
+  errorInfo?: ExcelError;
 }
 
 export default function FileUpload({
@@ -22,6 +25,7 @@ export default function FileUpload({
   importResponseStatus,
   handlePost,
   handleClose,
+  errorInfo,
 }: FileUploadProps) {
   const { t } = useTranslation('admin');
   const [fetchImportStatus, importStatus] = useGetImportStatusMutation();
@@ -44,7 +48,30 @@ export default function FileUpload({
       {importResponseStatus === 'rejected' ? (
         <>
           <InlineAlert status="error" style={{ marginBottom: '25px' }}>
-            {t('download-failed')}
+            {errorInfo ? (
+              <>
+                {translateExcelParseError(errorInfo.data.message, t)}
+                <ul>
+                  {errorInfo.data.errorDetails?.sheet && (
+                    <li>{`${t('excel-sheet')}: ${
+                      errorInfo.data.errorDetails?.sheet
+                    }`}</li>
+                  )}
+                  {errorInfo.data.errorDetails?.row && (
+                    <li>{`${t('excel-row')}: ${
+                      errorInfo.data.errorDetails?.row
+                    }`}</li>
+                  )}
+                  {errorInfo.data.errorDetails?.column && (
+                    <li>{`${t('excel-column')}: ${
+                      errorInfo.data.errorDetails?.column
+                    }`}</li>
+                  )}
+                </ul>
+              </>
+            ) : (
+              <>{t('download-failed')}</>
+            )}
           </InlineAlert>
           <ButtonBlock>
             <Button onClick={() => handlePost()}>{t('try-again')}</Button>

--- a/src/modules/new-terminology/file-upload.tsx
+++ b/src/modules/new-terminology/file-upload.tsx
@@ -57,7 +57,7 @@ export default function FileUpload({
                       errorInfo.data.errorDetails?.sheet
                     }`}</li>
                   )}
-                  {errorInfo.data.errorDetails?.row && (
+                  {errorInfo.data.errorDetails?.row != undefined && (
                     <li>{`${t('excel-row')}: ${
                       errorInfo.data.errorDetails?.row
                     }`}</li>

--- a/src/modules/new-terminology/info-file.tsx
+++ b/src/modules/new-terminology/info-file.tsx
@@ -11,12 +11,12 @@ import {
   FileWrapper,
 } from './new-terminology.styles';
 
-interface infoFileProps {
+interface InfoFileProps {
   setIsValid: (valid: boolean) => void;
   setFileData: (data: File | null) => void;
 }
 
-export default function InfoFile({ setIsValid, setFileData }: infoFileProps) {
+export default function InfoFile({ setIsValid, setFileData }: InfoFileProps) {
   const { t } = useTranslation('admin');
   const input = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);

--- a/src/modules/vocabulary/index.tsx
+++ b/src/modules/vocabulary/index.tsx
@@ -34,6 +34,7 @@ import LoadIndicator from '@app/common/components/load-indicator';
 import { useRouter } from 'next/router';
 import HasPermission from '@app/common/utils/has-permission';
 import dynamic from 'next/dynamic';
+import ConceptImportModal from '@app/common/components/concept-import';
 
 const NewConceptModal = dynamic(
   () => import('@app/common/components/new-concept-modal')
@@ -162,12 +163,18 @@ export default function Vocabulary({ id }: VocabularyProps) {
                 actions: 'CREATE_CONCEPT',
                 targetOrganization: info?.references.contributor,
               }) && (
-                <NewConceptModal
-                  terminologyId={id}
-                  languages={
-                    info?.properties.language?.map(({ value }) => value) ?? []
-                  }
-                />
+                <>
+                  <NewConceptModal
+                    terminologyId={id}
+                    languages={
+                      info?.properties.language?.map(({ value }) => value) ?? []
+                    }
+                  />
+                  <ConceptImportModal
+                    refetch={refetchConcepts}
+                    terminologyId={id}
+                  />
+                </>
               )}
             </QuickActionsWrapper>
 


### PR DESCRIPTION
Changelog:
 - Import concept button next to add concept button
 - Opens modal where you can upload a file.
 - Shows errors if there is a excel parsing error
 - tests

![concept-import-button](https://user-images.githubusercontent.com/19401683/192729563-83de32c5-8240-4d03-ac37-31361b4948e2.png)

![concept-import-modal](https://user-images.githubusercontent.com/19401683/192729613-8136f572-32c5-40a8-b9b1-82e1e51015c0.png)

![concept-import-success](https://user-images.githubusercontent.com/19401683/192732021-ad66daeb-7d2d-43f3-9c71-e87b4efafce2.png)

![concept-import-error](https://user-images.githubusercontent.com/19401683/192732047-da334cd3-d81b-4e9c-9d0c-a016507978b0.png)
