### PR TITLE
API call delete key is used when deleting term

### DIFF
--- a/src/common/components/modify/modify.slice.tsx
+++ b/src/common/components/modify/modify.slice.tsx
@@ -22,10 +22,7 @@ export const modifyApi = createApi({
       query: (data) => ({
         url: '/modify',
         method: 'POST',
-        data: {
-          delete: [],
-          save: data,
-        },
+        data: data,
       }),
     }),
     addCollection: builder.mutation<

--- a/src/modules/edit-concept/generate-concept-test-expected.tsx
+++ b/src/modules/edit-concept/generate-concept-test-expected.tsx
@@ -1,1483 +1,1764 @@
-export const conceptWithOneTerm = [
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '0',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'prefLabel',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      source: [],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '1',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      conceptClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      conceptScope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      definition: [],
-      editorialNote: [],
-      example: [],
-      externalLink: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      notation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      note: [],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      subjectArea: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {
-      altLabelXl: [],
-      broader: [],
-      closeMatch: [],
-      exactMatch: [],
-      hasPart: [],
-      hiddenTerm: [],
-      isPartOf: [],
-      narrower: [],
-      notRecommendedSynonym: [],
-      prefLabelXl: [
-        {
-          id: '0',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+export const conceptWithOneTerm = {
+  delete: [],
+  save: [
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '0',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
           },
-        },
-      ],
-      related: [],
-      relatedMatch: [],
-      searchTerm: [],
-    },
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'prefLabel',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        source: [],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
       },
-      id: 'Concept',
-      uri: 'http://www.w3.org/2004/02/skos/core#Concept',
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+      },
     },
-  },
-];
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '1',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptScope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        definition: [],
+        editorialNote: [],
+        example: [],
+        externalLink: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        notation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        note: [],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        subjectArea: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+      },
+      references: {
+        altLabelXl: [],
+        broader: [],
+        closeMatch: [],
+        exactMatch: [],
+        hasPart: [],
+        hiddenTerm: [],
+        isPartOf: [],
+        narrower: [],
+        notRecommendedSynonym: [],
+        prefLabelXl: [
+          {
+            id: '0',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+        related: [],
+        relatedMatch: [],
+        searchTerm: [],
+      },
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Concept',
+        uri: 'http://www.w3.org/2004/02/skos/core#Concept',
+      },
+    },
+  ],
+};
 
-export const conceptWithOneTermWithInitialData = [
-  {
-    code: 'term-1000',
-    createdBy: 'Admin User',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '789',
-    lastModifiedBy: 'Admin User',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'prefLabel',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      source: [],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {},
-    referrers: {
-      prefLabelXl: [
-        {
-          id: '123',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
+export const conceptWithOneTermWithInitialData = {
+  delete: [],
+  save: [
+    {
+      code: 'term-1000',
+      createdBy: 'Admin User',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '789',
+      lastModifiedBy: 'Admin User',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
           },
-        },
-      ],
-    },
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: '',
-    },
-    uri: 'sanastot.suomi.fi/sanasto/term-1000',
-  },
-  {
-    code: 'concept-1000',
-    createdBy: 'Admin User',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '1',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      conceptClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      conceptScope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      definition: [],
-      editorialNote: [],
-      example: [],
-      externalLink: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      notation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      note: [],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      subjectArea: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {
-      altLabelXl: [],
-      broader: [],
-      closeMatch: [],
-      exactMatch: [],
-      hasPart: [],
-      hiddenTerm: [],
-      isPartOf: [],
-      narrower: [],
-      notRecommendedSynonym: [],
-      prefLabelXl: [
-        {
-          id: '789',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: '',
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
           },
-        },
-      ],
-      related: [],
-      relatedMatch: [],
-      searchTerm: [],
-    },
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
+        ],
+        editorialNote: [],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'prefLabel',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        source: [],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
       },
-      id: 'Concept',
-      uri: '',
+      references: {},
+      referrers: {
+        prefLabelXl: [
+          {
+            id: '123',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+      },
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: '',
+      },
+      uri: 'sanastot.suomi.fi/sanasto/term-1000',
     },
-    uri: 'sanastot.suomi.fi/sanasto/concept-1000',
-  },
-];
+    {
+      code: 'concept-1000',
+      createdBy: 'Admin User',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '1',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptScope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        definition: [],
+        editorialNote: [],
+        example: [],
+        externalLink: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        notation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        note: [],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        subjectArea: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+      },
+      references: {
+        altLabelXl: [],
+        broader: [],
+        closeMatch: [],
+        exactMatch: [],
+        hasPart: [],
+        hiddenTerm: [],
+        isPartOf: [],
+        narrower: [],
+        notRecommendedSynonym: [],
+        prefLabelXl: [
+          {
+            id: '789',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: '',
+            },
+          },
+        ],
+        related: [],
+        relatedMatch: [],
+        searchTerm: [],
+      },
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Concept',
+        uri: '',
+      },
+      uri: 'sanastot.suomi.fi/sanasto/concept-1000',
+    },
+  ],
+};
 
-export const conceptWithInternalRelations = [
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '0',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'prefLabel',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      source: [],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
+export const conceptWithInternalRelations = {
+  delete: [],
+  save: [
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '0',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'prefLabel',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        source: [],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
       },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
         },
-      ],
-      conceptClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      conceptScope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      definition: [],
-      editorialNote: [],
-      example: [],
-      externalLink: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      notation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      note: [],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      subjectArea: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-    },
-    references: {
-      altLabelXl: [],
-      broader: [
-        {
-          id: '148ab016-36ee-486a-862a-87d6dde2f86f',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
-          },
-        },
-      ],
-      closeMatch: [],
-      exactMatch: [],
-      hasPart: [
-        {
-          id: '148ab016-36ee-486a-862a-87d6dde2f86f',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
-          },
-        },
-      ],
-      hiddenTerm: [],
-      isPartOf: [
-        {
-          id: '148ab016-36ee-486a-862a-87d6dde2f86f',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
-          },
-        },
-      ],
-      narrower: [
-        {
-          id: '148ab016-36ee-486a-862a-87d6dde2f86f',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
-          },
-        },
-      ],
-      notRecommendedSynonym: [],
-      prefLabelXl: [
-        {
-          id: '0',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-          },
-        },
-      ],
-      related: [
-        {
-          id: '148ab016-36ee-486a-862a-87d6dde2f86f',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Concept',
-            uri: '',
-          },
-        },
-      ],
-      relatedMatch: [],
-      searchTerm: [],
-    },
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
       },
-      id: 'Concept',
-      uri: 'http://www.w3.org/2004/02/skos/core#Concept',
     },
-  },
-];
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptScope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        definition: [],
+        editorialNote: [],
+        example: [],
+        externalLink: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        notation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        note: [],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        subjectArea: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+      },
+      references: {
+        altLabelXl: [],
+        broader: [
+          {
+            id: '148ab016-36ee-486a-862a-87d6dde2f86f',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+        closeMatch: [],
+        exactMatch: [],
+        hasPart: [
+          {
+            id: '148ab016-36ee-486a-862a-87d6dde2f86f',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+        hiddenTerm: [],
+        isPartOf: [
+          {
+            id: '148ab016-36ee-486a-862a-87d6dde2f86f',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+        narrower: [
+          {
+            id: '148ab016-36ee-486a-862a-87d6dde2f86f',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+        notRecommendedSynonym: [],
+        prefLabelXl: [
+          {
+            id: '0',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+        related: [
+          {
+            id: '148ab016-36ee-486a-862a-87d6dde2f86f',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+        relatedMatch: [],
+        searchTerm: [],
+      },
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Concept',
+        uri: 'http://www.w3.org/2004/02/skos/core#Concept',
+      },
+    },
+  ],
+};
 
-export const differentTerms = [
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '0',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'muutoshistoria',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'ylläpitäjän muistiinpano',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käytön historiatieto',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'demo',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käyttöala',
-        },
-      ],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'lähteet',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'singular',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'feminine',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '1',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'termin lisätieto',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'spoken-form',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'adjective',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '1',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'muutoshistoria',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'ylläpitäjän muistiinpano',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käytön historiatieto',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'synonyymi',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käyttöala',
-        },
-      ],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'lähteet',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'singular',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '~',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'feminine',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '1',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'termin lisätieto',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'spoken-form',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'adjective',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '2',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'muutoshistoria',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'ylläpitäjän muistiinpano',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käytön historiatieto',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'ei-suositettava synonyymi',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käyttöala',
-        },
-      ],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'lähteet',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'singular',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '~',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'feminine',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '1',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'termin lisätieto',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'spoken-form',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'adjective',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '3',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'muutoshistoria',
-        },
-      ],
-      draftComment: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      editorialNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'ylläpitäjän muistiinpano',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käytön historiatieto',
-        },
-      ],
-      prefLabel: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'hakusana',
-        },
-      ],
-      scope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käyttöala',
-        },
-      ],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'lähteet',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      termConjugation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'singular',
-        },
-      ],
-      termEquivalency: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '~',
-        },
-      ],
-      termEquivalencyRelation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      termFamily: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'feminine',
-        },
-      ],
-      termHomographNumber: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '1',
-        },
-      ],
-      termInfo: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'termin lisätieto',
-        },
-      ],
-      termStyle: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'spoken-form',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'adjective',
-        },
-      ],
-    },
-    references: {},
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
-      },
-      id: 'Term',
-      uri: 'http://www.w3.org/2008/05/skos-xl#Label',
-    },
-  },
-  {
-    createdBy: '',
-    createdDate: '1970-01-01T00:00:00.000Z',
-    id: '6e00b816-c077-4747-8597-46047005584d',
-    lastModifiedBy: '',
-    lastModifiedDate: '1970-01-01T00:00:00.000Z',
-    properties: {
-      changeNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'muutoshistoria',
-        },
-      ],
-      conceptClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käsitteen luokka',
-        },
-      ],
-      conceptScope: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      definition: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'määritelmä',
-        },
-      ],
-      editorialNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'ylläpitäjän muistiinpano',
-        },
-      ],
-      example: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'käyttöesimerkki',
-        },
-      ],
-      externalLink: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value:
-            '"{"name":"käsitekaavion nimi","url":"käsitekaavion verkko-osoite","description":"kuvaus"}"',
-        },
-      ],
-      historyNote: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'käytön historiatieto',
-        },
-      ],
-      notation: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: '',
-        },
-      ],
-      note: [
-        {
-          lang: 'fi',
-          regex: '(?s)^.*$',
-          value: 'huomautus',
-        },
-      ],
-      source: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'lähteet',
-        },
-      ],
-      status: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'DRAFT',
-        },
-      ],
-      subjectArea: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'aihealue',
-        },
-      ],
-      wordClass: [
-        {
-          lang: '',
-          regex: '(?s)^.*$',
-          value: 'adjective',
-        },
-      ],
-    },
-    references: {
-      altLabelXl: [
-        {
-          id: '1',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+export const differentTerms = {
+  delete: [],
+  save: [
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '0',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'muutoshistoria',
           },
-        },
-      ],
-      broader: [],
-      closeMatch: [],
-      exactMatch: [],
-      hasPart: [],
-      hiddenTerm: [],
-      isPartOf: [],
-      narrower: [],
-      notRecommendedSynonym: [
-        {
-          id: '2',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
           },
-        },
-      ],
-      prefLabelXl: [
-        {
-          id: '0',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+        ],
+        editorialNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'ylläpitäjän muistiinpano',
           },
-        },
-      ],
-      related: [],
-      relatedMatch: [],
-      searchTerm: [
-        {
-          id: '3',
-          type: {
-            graph: {
-              id: 'terminologyId',
-            },
-            id: 'Term',
-            uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käytön historiatieto',
           },
-        },
-      ],
-    },
-    referrers: {},
-    type: {
-      graph: {
-        id: 'terminologyId',
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'demo',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käyttöala',
+          },
+        ],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'lähteet',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'singular',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'feminine',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '1',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'termin lisätieto',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'spoken-form',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'adjective',
+          },
+        ],
       },
-      id: 'Concept',
-      uri: 'http://www.w3.org/2004/02/skos/core#Concept',
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+      },
     },
-  },
-];
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '1',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'muutoshistoria',
+          },
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'ylläpitäjän muistiinpano',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käytön historiatieto',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'synonyymi',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käyttöala',
+          },
+        ],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'lähteet',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'singular',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '~',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'feminine',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '1',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'termin lisätieto',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'spoken-form',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'adjective',
+          },
+        ],
+      },
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+      },
+    },
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '2',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'muutoshistoria',
+          },
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'ylläpitäjän muistiinpano',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käytön historiatieto',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'ei-suositettava synonyymi',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käyttöala',
+          },
+        ],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'lähteet',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'singular',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '~',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'feminine',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '1',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'termin lisätieto',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'spoken-form',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'adjective',
+          },
+        ],
+      },
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+      },
+    },
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '3',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'muutoshistoria',
+          },
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'ylläpitäjän muistiinpano',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käytön historiatieto',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'hakusana',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käyttöala',
+          },
+        ],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'lähteet',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'singular',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '~',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'feminine',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '1',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'termin lisätieto',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'spoken-form',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'adjective',
+          },
+        ],
+      },
+      references: {},
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+      },
+    },
+    {
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '6e00b816-c077-4747-8597-46047005584d',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'muutoshistoria',
+          },
+        ],
+        conceptClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käsitteen luokka',
+          },
+        ],
+        conceptScope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        definition: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'määritelmä',
+          },
+        ],
+        editorialNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'ylläpitäjän muistiinpano',
+          },
+        ],
+        example: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'käyttöesimerkki',
+          },
+        ],
+        externalLink: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value:
+              '"{"name":"käsitekaavion nimi","url":"käsitekaavion verkko-osoite","description":"kuvaus"}"',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'käytön historiatieto',
+          },
+        ],
+        notation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        note: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'huomautus',
+          },
+        ],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'lähteet',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        subjectArea: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'aihealue',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'adjective',
+          },
+        ],
+      },
+      references: {
+        altLabelXl: [
+          {
+            id: '1',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+        broader: [],
+        closeMatch: [],
+        exactMatch: [],
+        hasPart: [],
+        hiddenTerm: [],
+        isPartOf: [],
+        narrower: [],
+        notRecommendedSynonym: [
+          {
+            id: '2',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+        prefLabelXl: [
+          {
+            id: '0',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+        related: [],
+        relatedMatch: [],
+        searchTerm: [
+          {
+            id: '3',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: 'http://www.w3.org/2008/05/skos-xl#Label',
+            },
+          },
+        ],
+      },
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Concept',
+        uri: 'http://www.w3.org/2004/02/skos/core#Concept',
+      },
+    },
+  ],
+};
+
+export const removeTerm = {
+  delete: [
+    {
+      id: 'ffd68efb-d5c8-4ea2-9fb8-fa7b0b688fe9',
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: '',
+      },
+    },
+  ],
+  save: [
+    {
+      code: 'term-3',
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: '0',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        draftComment: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        editorialNote: [],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        prefLabel: [
+          {
+            lang: 'fi',
+            regex: '(?s)^.*$',
+            value: 'demo fi',
+          },
+        ],
+        scope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        source: [],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        termConjugation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalency: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termEquivalencyRelation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termFamily: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termHomographNumber: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termInfo: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        termStyle: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+      },
+      references: {},
+      referrers: {
+        prefLabelXl: [
+          {
+            id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Concept',
+              uri: '',
+            },
+          },
+        ],
+      },
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Term',
+        uri: '',
+      },
+      uri: 'http://uri.suomi.fi/terminology/212e3cf8/term-3',
+    },
+    {
+      code: 'concept-1',
+      createdBy: '',
+      createdDate: '1970-01-01T00:00:00.000Z',
+      id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+      lastModifiedBy: '',
+      lastModifiedDate: '1970-01-01T00:00:00.000Z',
+      properties: {
+        changeNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        conceptScope: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        definition: [],
+        editorialNote: [],
+        example: [],
+        externalLink: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        historyNote: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        notation: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        note: [],
+        source: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        status: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: 'DRAFT',
+          },
+        ],
+        subjectArea: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+        wordClass: [
+          {
+            lang: '',
+            regex: '(?s)^.*$',
+            value: '',
+          },
+        ],
+      },
+      references: {
+        altLabelXl: [],
+        broader: [],
+        closeMatch: [],
+        exactMatch: [],
+        hasPart: [],
+        hiddenTerm: [],
+        isPartOf: [],
+        narrower: [],
+        notRecommendedSynonym: [],
+        prefLabelXl: [
+          {
+            id: '0',
+            type: {
+              graph: {
+                id: 'terminologyId',
+              },
+              id: 'Term',
+              uri: '',
+            },
+          },
+        ],
+        related: [],
+        relatedMatch: [],
+        searchTerm: [],
+      },
+      referrers: {},
+      type: {
+        graph: {
+          id: 'terminologyId',
+        },
+        id: 'Concept',
+        uri: '',
+      },
+      uri: 'http://uri.suomi.fi/terminology/212e3cf8/concept-1',
+    },
+  ],
+};

--- a/src/modules/edit-concept/generate-concept.test.tsx
+++ b/src/modules/edit-concept/generate-concept.test.tsx
@@ -4,6 +4,7 @@ import {
   conceptWithOneTerm,
   conceptWithOneTermWithInitialData,
   differentTerms,
+  removeTerm,
 } from './generate-concept-test-expected';
 
 describe('generate-concept', () => {
@@ -65,7 +66,9 @@ describe('generate-concept', () => {
     const returned = generateConcept({
       data: input,
       terminologyId: 'terminologyId',
-    }).map((json) => {
+    });
+
+    const save = returned.save.map((json) => {
       // Replacing generated time stamps with expected values
       json.createdDate = '1970-01-01T00:00:00.000Z';
       json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
@@ -74,7 +77,7 @@ describe('generate-concept', () => {
 
     // Replacing the last object's id with expected value
     // since it's randombly generated in the function
-    returned[1].id = '1';
+    save[1].id = '1';
 
     expect(returned).toStrictEqual(conceptWithOneTerm);
   });
@@ -245,7 +248,8 @@ describe('generate-concept', () => {
         uri: 'sanastot.suomi.fi/sanasto/concept-1000',
       },
       lastModifiedBy: 'Admin User',
-    }).map((json) => {
+    });
+    const save = returned.save.map((json) => {
       // Replacing generated time stamps with expected values
       json.createdDate = '1970-01-01T00:00:00.000Z';
       json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
@@ -254,7 +258,7 @@ describe('generate-concept', () => {
 
     // Replacing the last object's id with expected value
     // since it's randombly generated in the function
-    returned[1].id = '1';
+    save[1].id = '1';
 
     expect(returned).toStrictEqual(conceptWithOneTermWithInitialData);
   });
@@ -372,7 +376,8 @@ describe('generate-concept', () => {
     const returned = generateConcept({
       data: input,
       terminologyId: 'terminologyId',
-    }).map((json) => {
+    });
+    const save = returned.save.map((json) => {
       // Replacing generated ids and time stamps with known values
       json.createdDate = '1970-01-01T00:00:00.000Z';
       json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
@@ -381,11 +386,11 @@ describe('generate-concept', () => {
     });
 
     const expected = conceptWithInternalRelations;
-    const lastObjectId = returned[1].id;
+    const lastObjectId = save[1].id;
 
     // Changing expected values last object's id to match
     // what's returned. expected-value set id randomly
-    expected[1].id = lastObjectId;
+    expected.save[1].id = lastObjectId;
 
     expect(returned).toStrictEqual(expected);
   });
@@ -592,7 +597,8 @@ describe('generate-concept', () => {
     const returned = generateConcept({
       data: input,
       terminologyId: 'terminologyId',
-    }).map((json) => {
+    });
+    const save = returned.save.map((json) => {
       // Replacing generated ids and time stamps with known values
       json.createdDate = '1970-01-01T00:00:00.000Z';
       json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
@@ -601,11 +607,297 @@ describe('generate-concept', () => {
     });
 
     const expected = differentTerms;
-    const lastObjectId = returned[4].id;
+    const lastObjectId = save[4].id;
 
     // Changing expected values last object's id to match
     // what's returned. expected-value set id randomly
-    expected[4].id = lastObjectId;
+    expected.save[4].id = lastObjectId;
+
+    expect(returned).toStrictEqual(expected);
+  });
+
+  it('should remove term properly', () => {
+    const input = {
+      terms: [
+        {
+          changeNote: '',
+          draftComment: '',
+          editorialNote: [],
+          historyNote: '',
+          id: '0',
+          language: 'fi',
+          prefLabel: 'demo fi',
+          scope: '',
+          source: [],
+          status: 'draft',
+          termConjugation: '',
+          termEquivalency: '',
+          termEquivalencyRelation: '',
+          termFamily: '',
+          termHomographNumber: '',
+          termInfo: '',
+          termStyle: '',
+          termType: 'recommended-term',
+          wordClass: '',
+        },
+      ],
+      basicInformation: {
+        definition: {},
+        example: [],
+        subject: '',
+        note: [],
+        diagramAndSource: {
+          diagrams: [],
+          sources: [],
+        },
+        orgInfo: {
+          changeHistory: '',
+          editorialNote: [],
+          etymology: '',
+        },
+        otherInfo: {
+          conceptClass: '',
+          wordClass: '',
+        },
+        relationalInfo: {
+          broaderConcept: [],
+          narrowerConcept: [],
+          relatedConcept: [],
+          isPartOfConcept: [],
+          hasPartConcept: [],
+          relatedConceptInOther: [],
+          matchInOther: [],
+        },
+      },
+    };
+
+    const returned = generateConcept({
+      data: input,
+      terminologyId: 'terminologyId',
+      initialValue: {
+        id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+        code: 'concept-1',
+        uri: 'http://uri.suomi.fi/terminology/212e3cf8/concept-1',
+        number: 0,
+        createdBy: '',
+        createdDate: '1970-01-01T00:00:00.000Z',
+        lastModifiedBy: '',
+        lastModifiedDate: '1970-01-01T00:00:00.000Z',
+        type: {
+          id: 'Concept',
+          graph: {
+            id: 'terminologyId',
+          },
+          uri: '',
+        },
+        properties: {
+          status: [
+            {
+              lang: '',
+              value: 'DRAFT',
+              regex: '(?s)^.* $',
+            },
+          ],
+        },
+        references: {
+          prefLabelXl: [
+            {
+              id: '0',
+              code: 'term-3',
+              uri: 'http://uri.suomi.fi/terminology/212e3cf8/term-3',
+              number: 0,
+              createdBy: '',
+              createdDate: '1970-01-01T00:00:00.000Z',
+              lastModifiedBy: '',
+              lastModifiedDate: '1970-01-01T00:00:00.000Z',
+              type: {
+                id: 'Term',
+                graph: {
+                  id: 'terminologyId',
+                },
+                uri: '',
+              },
+              properties: {
+                prefLabel: [
+                  {
+                    lang: 'fi',
+                    value: 'demo fi',
+                    regex: '(?s)^.* $',
+                  },
+                ],
+                status: [
+                  {
+                    lang: '',
+                    value: 'DRAFT',
+                    regex: '(?s)^.* $',
+                  },
+                ],
+              },
+              references: {},
+              referrers: {
+                prefLabelXl: [
+                  {
+                    id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+                    code: 'concept-1',
+                    uri: 'http://uri.suomi.fi/terminology/212e3cf8/concept-1',
+                    number: 0,
+                    createdDate: '1970-01-01T00:00:00.000Z',
+                    lastModifiedDate: '1970-01-01T00:00:00.000Z',
+                    type: {
+                      id: 'Concept',
+                      graph: {
+                        id: 'terminologyId',
+                      },
+                      uri: '',
+                    },
+                    properties: {
+                      status: [
+                        {
+                          lang: '',
+                          value: 'DRAFT',
+                          regex: '(?s)^.* $',
+                        },
+                      ],
+                    },
+                    references: {},
+                    referrers: {},
+                    identifier: {
+                      id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+                      type: {
+                        id: 'Concept',
+                        graph: {
+                          id: 'terminologyId',
+                        },
+                        uri: '',
+                      },
+                    },
+                  },
+                ],
+              },
+              identifier: {
+                id: 'd17ed9bb-1c1f-4b46-a63d-648130e7ba19',
+                type: {
+                  id: 'Term',
+                  graph: {
+                    id: 'terminologyId',
+                  },
+                  uri: '',
+                },
+              },
+            },
+            {
+              id: 'ffd68efb-d5c8-4ea2-9fb8-fa7b0b688fe9',
+              code: 'term-4',
+              uri: 'http://uri.suomi.fi/terminology/212e3cf8/term-4',
+              number: 0,
+              createdBy: '',
+              createdDate: '2022-09-28T07:35:08.000+00:00',
+              lastModifiedBy: '',
+              lastModifiedDate: '2022-09-28T07:35:08.000+00:00',
+              type: {
+                id: 'Term',
+                graph: {
+                  id: 'terminologyId',
+                },
+                uri: '',
+              },
+              properties: {
+                prefLabel: [
+                  {
+                    lang: 'en',
+                    value: 'demo en',
+                    regex: '(?s)^.* $',
+                  },
+                ],
+                status: [
+                  {
+                    lang: '',
+                    value: 'DRAFT',
+                    regex: '(?s)^.* $',
+                  },
+                ],
+              },
+              references: {},
+              referrers: {
+                prefLabelXl: [
+                  {
+                    id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+                    code: 'concept-1',
+                    uri: 'http://uri.suomi.fi/terminology/212e3cf8/concept-1',
+                    number: 0,
+                    createdDate: '2022-09-28T07:34:46.000+00: 00',
+                    lastModifiedDate: '2022-09-28T07:35:08.000+00: 00',
+                    type: {
+                      id: 'Concept',
+                      graph: {
+                        id: 'terminologyId',
+                      },
+                      uri: '',
+                    },
+                    properties: {
+                      status: [
+                        {
+                          lang: '',
+                          value: 'DRAFT',
+                          regex: '(?s)^.* $',
+                        },
+                      ],
+                    },
+                    references: {},
+                    referrers: {},
+                    identifier: {
+                      id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+                      type: {
+                        id: 'Concept',
+                        graph: {
+                          id: 'terminologyId',
+                        },
+                        uri: '',
+                      },
+                    },
+                  },
+                ],
+              },
+              identifier: {
+                id: 'ffd68efb-d5c8-4ea2-9fb8-fa7b0b688fe9',
+                type: {
+                  id: 'Term',
+                  graph: {
+                    id: 'terminologyId',
+                  },
+                  uri: '',
+                },
+              },
+            },
+          ],
+        },
+        referrers: {},
+        identifier: {
+          id: 'abad6405-2843-42e3-bacd-9448e34fd049',
+          type: {
+            id: 'Concept',
+            graph: {
+              id: 'terminologyId',
+            },
+            uri: '',
+          },
+        },
+      },
+    });
+    const save = returned.save.map((json) => {
+      // Replacing generated ids and time stamps with known values
+      json.createdDate = '1970-01-01T00:00:00.000Z';
+      json.lastModifiedDate = '1970-01-01T00:00:00.000Z';
+
+      return json;
+    });
+
+    const expected = removeTerm;
+    const lastObjectId = save[1].id;
+
+    // Changing expected values last object's id to match
+    // what's returned. expected-value set id randomly
+    returned.save[1].id = lastObjectId;
 
     expect(returned).toStrictEqual(expected);
   });

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -16,6 +16,7 @@ export default function generateConcept({
   initialValue,
   lastModifiedBy,
 }: generateConceptProps) {
+  console.log(initialValue);
   const regex = '(?s)^.*$';
   const now = new Date();
   let matchingIds: string[] = [];
@@ -614,7 +615,34 @@ export default function generateConcept({
     retVal[retVal.length - 1].uri = initialValue.uri ?? '';
   }
 
-  return retVal;
+  const initialTermIds =
+    initialValue &&
+    Object.keys(initialValue?.references).flatMap((key) =>
+      initialValue?.references[key as keyof Concept['references']]?.map(
+        (val) => val.id && val.id
+      )
+    );
+
+  const newTermIds = data.terms.map((term) => term.id);
+
+  const deleteVal = initialTermIds?.filter((initId) =>
+    newTermIds.some((id) => id !== initId)
+  );
+
+  return {
+    delete:
+      deleteVal?.map((d) => ({
+        id: d,
+        type: {
+          graph: {
+            id: terminologyId,
+          },
+          id: 'Term',
+          uri: '',
+        },
+      })) ?? [],
+    save: retVal,
+  };
 }
 
 function getInitialTerm(id: string, terms: Concept['references']): Term | null {

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -614,19 +614,21 @@ export default function generateConcept({
     retVal[retVal.length - 1].uri = initialValue.uri ?? '';
   }
 
-  const initialTermIds =
-    initialValue &&
-    Object.keys(initialValue?.references).flatMap((key) =>
-      initialValue?.references[key as keyof Concept['references']]?.map(
-        (val) => val.id && val.id
+  const initialTermIds: string[] = initialValue
+    ? Object.keys(initialValue?.references).flatMap(
+        (key) =>
+          initialValue?.references[key as keyof Concept['references']]?.map(
+            (val) => val.id
+          ) ?? []
       )
-    );
+    : [];
 
   const newTermIds = data.terms.map((term) => term.id);
 
-  const deleteVal = initialTermIds?.filter((initId) =>
-    newTermIds.some((id) => id !== initId)
-  );
+  const deleteVal =
+    initialTermIds.length > 0
+      ? initialTermIds?.filter((initId) => !newTermIds.includes(initId))
+      : [];
 
   return {
     delete:

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -16,7 +16,6 @@ export default function generateConcept({
   initialValue,
   lastModifiedBy,
 }: generateConceptProps) {
-  console.log(initialValue);
   const regex = '(?s)^.*$';
   const now = new Date();
   let matchingIds: string[] = [];

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -116,7 +116,7 @@ export default function EditConcept({
     if (addConceptStatus.isSuccess && postedData) {
       router.replace(
         `/terminology/${terminologyId}/concept/${
-          postedData[postedData.length - 1].id
+          postedData.save[postedData.save.length - 1].id
         }`
       );
     }


### PR DESCRIPTION
Previously data sent to API looked something like this:
`data: delete: [], save: [{ ... }]`
where `delete` key would always have an empty array. Now if a term is removed from a concept it's id and other information is added to delete array as an object.