### PR TITLE
Fixed random removals & a bug with generating data

### DIFF
--- a/src/common/components/relational-information-block/index.tsx
+++ b/src/common/components/relational-information-block/index.tsx
@@ -172,9 +172,6 @@ function ManageRelationalInfoModal({
     setVisible(false);
     setShowChosen(false);
     setChosen([]);
-    setSelectedConcepts(
-      searchResults.filter((result) => selectedConceptIds.includes(result.id))
-    );
     setSearchResults([]);
   };
 

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -653,12 +653,6 @@ export default function generateConcept({
     ),
   ];
 
-  console.log(initialValue?.references);
-  console.log(data.terms);
-  console.log('initialTermIds', initialTermIds);
-  console.log('newTermIds', newTermIds);
-  console.log('inOtherIds', inOtherIds);
-
   let deleteVal =
     initialTermIds.length > 0
       ? initialTermIds
@@ -675,7 +669,6 @@ export default function generateConcept({
           }))
       : [];
 
-  console.log('deleteVal #1', deleteVal);
   deleteVal =
     initialInOtherIds.length > 0
       ? [
@@ -694,7 +687,6 @@ export default function generateConcept({
             })),
         ]
       : deleteVal;
-  console.log('deleteVal #2', deleteVal);
 
   return {
     delete: deleteVal,

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -628,17 +628,18 @@ export default function generateConcept({
       })
     : [];
 
-  let initialInOtherIds = initialValue
-    ? initialValue.references.exactMatch?.map((match) => match.identifier.id) ??
-      []
+  let initialInOtherIds: string[] = initialValue
+    ? initialValue.references.exactMatch
+        ?.map((match) => match.properties.targetId?.[0].value ?? '')
+        .filter((val) => val) ?? []
     : [];
 
   initialInOtherIds = initialValue
     ? [
         ...initialInOtherIds,
-        ...(initialValue.references.relatedMatch?.map(
-          (match) => match.identifier.id
-        ) ?? []),
+        ...(initialValue.references.relatedMatch
+          ?.map((match) => match.properties.targetId?.[0].value ?? '')
+          .filter((val) => val) ?? []),
       ]
     : initialInOtherIds;
 
@@ -651,6 +652,12 @@ export default function generateConcept({
       (related) => related.id
     ),
   ];
+
+  console.log(initialValue?.references);
+  console.log(data.terms);
+  console.log('initialTermIds', initialTermIds);
+  console.log('newTermIds', newTermIds);
+  console.log('inOtherIds', inOtherIds);
 
   let deleteVal =
     initialTermIds.length > 0
@@ -668,6 +675,7 @@ export default function generateConcept({
           }))
       : [];
 
+  console.log('deleteVal #1', deleteVal);
   deleteVal =
     initialInOtherIds.length > 0
       ? [
@@ -686,6 +694,7 @@ export default function generateConcept({
             })),
         ]
       : deleteVal;
+  console.log('deleteVal #2', deleteVal);
 
   return {
     delete: deleteVal,

--- a/src/modules/edit-concept/generate-form-data-test-variables.tsx
+++ b/src/modules/edit-concept/generate-form-data-test-variables.tsx
@@ -2436,7 +2436,7 @@ export const extensiveDataExpected = {
       ],
       matchInOther: [
         {
-          id: '8ee81e29-e0f1-4a23-b23b-28a976fcf87f',
+          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
           label: {
             fi: 'demo',
           },
@@ -2473,7 +2473,7 @@ export const extensiveDataExpected = {
       ],
       relatedConceptInOther: [
         {
-          id: 'a87ae2c2-3c16-494a-9f82-928fc1840a1e',
+          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
           label: {
             fi: 'demo',
           },

--- a/src/modules/edit-concept/generate-form-data.tsx
+++ b/src/modules/edit-concept/generate-form-data.tsx
@@ -207,7 +207,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.id ?? '',
+                id: r.properties.targetId?.[0].value ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => {
@@ -280,7 +280,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.id ?? '',
+                id: r.properties.targetId?.[0].value ?? '' ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => ({ [l.lang]: l.value }))

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -97,6 +97,7 @@ export default function EditConcept({
       initialValue: conceptData,
       lastModifiedBy: `${user.firstName} ${user.lastName}`,
     });
+
     setPostedData(concept);
     addConcept(concept);
     disableConfirmation();

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -97,7 +97,6 @@ export default function EditConcept({
       initialValue: conceptData,
       lastModifiedBy: `${user.firstName} ${user.lastName}`,
     });
-
     setPostedData(concept);
     addConcept(concept);
     disableConfirmation();


### PR DESCRIPTION
Changes in this PR:
- Closing relational data modal with 'Cancel' button no longer removes previous data
- Relating to this `generateFormData` was fixed to target correct ID's when adding data of relations from other terminologies