### PR TITLE
Copied from information added

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -161,6 +161,7 @@
   "vocabulary-filter-visual-placeholder": "e.g. daycare, studying...",
   "vocabulary-info-collection": "Collection",
   "vocabulary-info-concept": "Concept",
+  "vocabulary-info-copied-from": "Copied from terminology",
   "vocabulary-info-created-at": "Created at",
   "vocabulary-info-description": "Description",
   "vocabulary-info-en": "English",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -161,6 +161,7 @@
   "vocabulary-filter-visual-placeholder": "Esim. päivähoito, opiskelu...",
   "vocabulary-info-collection": "Käsitekokoelma",
   "vocabulary-info-concept": "Käsite",
+  "vocabulary-info-copied-from": "Kopioitu sanastosta",
   "vocabulary-info-created-at": "Luotu",
   "vocabulary-info-description": "Kuvaus",
   "vocabulary-info-en": "englanti",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -161,6 +161,7 @@
   "vocabulary-filter-visual-placeholder": "",
   "vocabulary-info-collection": "",
   "vocabulary-info-concept": "",
+  "vocabulary-info-copied-from": "",
   "vocabulary-info-created-at": "",
   "vocabulary-info-description": "",
   "vocabulary-info-en": "",

--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -261,6 +261,14 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
           <FormattedDate date={data.createdDate} />
           {data.createdBy && `, ${data.createdBy}`}
         </BasicBlock>
+        {data.properties.origin && (
+          <BasicBlock
+            title={t('vocabulary-info-copied-from')}
+            id="copied-from-terminology"
+          >
+            {data.properties.origin[0].value}
+          </BasicBlock>
+        )}
         <BasicBlock title={t('vocabulary-info-modified-at')} id="modified-at">
           <FormattedDate date={data.lastModifiedDate} />
           {data.lastModifiedBy && `, ${data.lastModifiedBy}`}

--- a/src/common/interfaces/vocabulary.interface.ts
+++ b/src/common/interfaces/vocabulary.interface.ts
@@ -9,6 +9,7 @@ export interface VocabularyInfoDTO
     contact?: Property[];
     description?: Property[];
     language?: Property[];
+    origin?: Property[];
     prefLabel?: Property[];
     priority?: Property[];
     status?: Property[];

--- a/src/modules/edit-vocabulary/index.tsx
+++ b/src/modules/edit-vocabulary/index.tsx
@@ -59,6 +59,7 @@ export default function EditVocabulary({ terminologyId }: EditVocabularyProps) {
       lastModifiedBy: `${user.firstName} ${user.lastName}`,
       terminologyId: terminologyId,
       uri: info?.uri,
+      origin: info?.properties.origin?.[0].value,
     });
 
     if (!newData) {

--- a/src/modules/new-terminology/generate-new-terminology.tsx
+++ b/src/modules/new-terminology/generate-new-terminology.tsx
@@ -137,8 +137,6 @@ export default function generateNewTerminology({
     postData.uri = uri;
   }
 
-  console.log(postData);
-
   return postData;
 }
 

--- a/src/modules/new-terminology/generate-new-terminology.tsx
+++ b/src/modules/new-terminology/generate-new-terminology.tsx
@@ -11,6 +11,7 @@ interface GenerateNewTerminologyProps {
   lastModifiedBy?: string;
   terminologyId?: string;
   uri?: string;
+  origin?: string;
 }
 
 export default function generateNewTerminology({
@@ -22,6 +23,7 @@ export default function generateNewTerminology({
   lastModifiedBy,
   terminologyId,
   uri,
+  origin,
 }: GenerateNewTerminologyProps) {
   if (!data.contributors) {
     return;
@@ -126,7 +128,7 @@ export default function generateNewTerminology({
       {
         lang: '',
         regex: regex,
-        value: '',
+        value: origin ? origin : '',
       },
     ];
   }
@@ -134,6 +136,8 @@ export default function generateNewTerminology({
   if (uri) {
     postData.uri = uri;
   }
+
+  console.log(postData);
 
   return postData;
 }


### PR DESCRIPTION
Changes in this PR:
- Added information about which terminology a copied terminology was copied from

![image](https://user-images.githubusercontent.com/82932696/195010195-9a6d1145-17c8-4b52-95c1-ee855c459ac9.png)
