### PR TITLE
Tweaked concept search func when fromOther

### DIFF
--- a/src/common/components/relational-information-block/relational-modal-content.tsx
+++ b/src/common/components/relational-information-block/relational-modal-content.tsx
@@ -93,6 +93,12 @@ export default function RelationModalContent({
   const handleClearValues = () => {
     setSearchTerm('');
     setStatus(null);
+
+    if (fromOther) {
+      result.reset();
+      return;
+    }
+
     searchConcept({
       ...(fromOther
         ? { notInTerminologyId: terminologyId }


### PR DESCRIPTION
Changes in this PR:
- Previously when searching for related concepts in edit concept page that were from other terminologies, clearing search filter would immediately search for all concepts. Now when user clears the search filter the search results are cleared and a request isn't send to the back end.