### PR TITLE
Added minor bug fixes

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -297,7 +297,7 @@
   "term-type-error-msg": "Term type has to be defined",
   "term-type-label": "Term type",
   "term-word-class": "Term word class",
-  "term-word-class-hint-text": "Marked if the term is from a different word category than terms in other languages.",
+  "term-word-class-hint-text": "Marked only if the term is not a noun.",
   "term-x-new-type": "Term \"{{term}}\" new type",
   "terminological-vocabulary": "Terminological vocabulary",
   "terminology-description": "Description (optional)",

--- a/public/locales/en/alert.json
+++ b/public/locales/en/alert.json
@@ -3,14 +3,15 @@
   "error-occured": "An error occurred",
   "error-occured_access-request": "An error occurred with access request service",
   "error-occured_counts": "An error occurred while getting counts for statuses and information domains",
+  "error-occured_download-excel": "An error occured with downloading terminology",
   "error-occured_groups": "An error occurred while getting information domains",
   "error-occured_organization": "An error occurred while getting organizations",
   "error-occured_subscription": "An error occurred with subscription service",
   "error-occured_terminology-search": "An error occurred while searching for terminologies",
   "error-occured_unhandled-error": "An unknown error occurred",
   "error-occurred_internal-server": "An error occurred, please try again later",
-  "error-occurred_remove-collection": "",
-  "error-occurred_remove-concept": "",
+  "error-occurred_remove-collection": "An error occured while removing collection",
+  "error-occurred_remove-concept": "An error occured while removing concept",
   "error-occurred_remove-terminology": "An error occured while removing terminology",
   "error-occurred_session": "An error occured with the session, try logging in again"
 }

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -297,7 +297,7 @@
   "term-type-error-msg": "Termin tyyppi tulee olla valittu",
   "term-type-label": "Termin tyyppi",
   "term-word-class": "Termin sanaluokka",
-  "term-word-class-hint-text": "Merkitään jos termi on eri sanaluokasta kuin muunkieliset termit.",
+  "term-word-class-hint-text": "Merkitään vain, jos termin sanaluokka on muu kuin substantiivi.",
   "term-x-new-type": "Termin \"{{term}}\" uusi tyyppi",
   "terminological-vocabulary": "Terminologinen sanasto",
   "terminology-description": "Kuvaus (valinnainen)",

--- a/public/locales/fi/alert.json
+++ b/public/locales/fi/alert.json
@@ -3,6 +3,7 @@
   "error-occured": "Tapahtui virhe",
   "error-occured_access-request": "Käyttöoikeuksien pyynnössä ilmeni ongelma",
   "error-occured_counts": "Tilojen ja tietoalueiden lukumäärien haussa ilmeni ongelma",
+  "error-occured_download-excel": "Sanaston latauksessa ilmeni ongelma",
   "error-occured_groups": "Tietoalueiden haussa ilmeni ongelma",
   "error-occured_organization": "Organisaatioiden haussa ilmeni ongelma",
   "error-occured_subscription": "Sähköpostitilauksen toiminnassa ilmeni ongelma",

--- a/public/locales/sv/alert.json
+++ b/public/locales/sv/alert.json
@@ -3,6 +3,7 @@
   "error-occured": "",
   "error-occured_access-request": "",
   "error-occured_counts": "",
+  "error-occured_download-excel": "",
   "error-occured_groups": "",
   "error-occured_organization": "",
   "error-occured_subscription": "",

--- a/src/common/components/removal-modal/index.tsx
+++ b/src/common/components/removal-modal/index.tsx
@@ -277,6 +277,9 @@ export default function RemovalModal({
       return (
         <>
           <Button onClick={() => handleClick()}>{t('try-again')}</Button>
+          <Button variant="secondary" onClick={() => setVisible(false)}>
+            {t('cancel-variant')}
+          </Button>
         </>
       );
     }

--- a/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
+++ b/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
@@ -8,6 +8,7 @@ import {
   Heading,
   Icon,
   RadioButtonGroup,
+  SingleSelect,
   Text,
   Textarea,
 } from 'suomifi-ui-components';
@@ -91,8 +92,7 @@ export const TermEquivalencyBlock = styled(Block)`
 export const RadioButtonGroupSpaced = styled(RadioButtonGroup)<{
   $isInvalid?: boolean;
 }>`
-  margin: ${(props) => props.theme.suomifi.spacing.m} 0;
-  max-width: 290px;
+  margin: ${(props) => props.theme.suomifi.spacing.m} 0 0 0;
 
   .fi-hint-text {
     font-weight: 600;
@@ -147,4 +147,8 @@ export const TermFormBottomBlock = styled(Block)`
 export const TermFormRemoveButton = styled(Button)`
   height: min-content;
   white-space: nowrap;
+`;
+
+export const LanguageSingleSelect = styled(SingleSelect)`
+  margin-top: ${(props) => props.theme.suomifi.spacing.s};
 `;

--- a/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
+++ b/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
@@ -28,6 +28,7 @@ import {
   CheckboxBlock,
   DropdownBlock,
   GrammaticalBlock,
+  LanguageSingleSelect,
   MediumHeading,
   ModalDescription,
   RadioButtonGroupSpaced,
@@ -171,41 +172,7 @@ export default function NewTermModal({
           />
         )}
 
-        <RadioButtonGroupSpaced
-          labelText={t('term-type')}
-          name="term-type-radio-button-group"
-          onChange={(e) => handleUpdate({ key: 'termType', value: e })}
-          groupHintText={
-            invalidData.termType ? t('term-type-error-msg') : undefined
-          }
-          $isInvalid={
-            invalidData.termType || invalidData.recommendedTermDuplicate
-          }
-        >
-          <RadioButton
-            value="recommended-term"
-            hintText={t('recommended-term-description')}
-          >
-            {t('recommended-term', { ns: 'common' })}
-          </RadioButton>
-          <RadioButton value="synonym" hintText={t('synonym-description')}>
-            {t('synonym')}
-          </RadioButton>
-          <RadioButton
-            value="not-recommended-synonym"
-            hintText={t('not-recommended-term-description')}
-          >
-            {t('not-recommended-synonym')}
-          </RadioButton>
-          <RadioButton
-            value="search-term"
-            hintText={t('search-term-description')}
-          >
-            {t('search-term')}
-          </RadioButton>
-        </RadioButtonGroupSpaced>
-
-        <SingleSelect
+        <LanguageSingleSelect
           ariaOptionsAvailableText={t('available-languages')}
           clearButtonLabel=""
           items={languages.map((language) => ({
@@ -226,6 +193,41 @@ export default function NewTermModal({
               : undefined
           }
         />
+
+        <RadioButtonGroupSpaced
+          labelText={t('term-type')}
+          name="term-type-radio-button-group"
+          onChange={(e) => handleUpdate({ key: 'termType', value: e })}
+          groupHintText={
+            invalidData.termType ? t('term-type-error-msg') : undefined
+          }
+          $isInvalid={
+            invalidData.termType || invalidData.recommendedTermDuplicate
+          }
+        >
+          <RadioButton
+            value="recommended-term"
+            hintText={t('recommended-term-description')}
+            disabled={prefLabelInLangExists(termData, recommendedTermLangs)}
+          >
+            {t('recommended-term', { ns: 'common' })}
+          </RadioButton>
+          <RadioButton value="synonym" hintText={t('synonym-description')}>
+            {t('synonym')}
+          </RadioButton>
+          <RadioButton
+            value="not-recommended-synonym"
+            hintText={t('not-recommended-term-description')}
+          >
+            {t('not-recommended-synonym')}
+          </RadioButton>
+          <RadioButton
+            value="search-term"
+            hintText={t('search-term-description')}
+          >
+            {t('search-term')}
+          </RadioButton>
+        </RadioButtonGroupSpaced>
 
         <DropdownBlock
           labelText={t('term-status-label')}
@@ -473,4 +475,17 @@ function validateFormData(
   }
 
   return invalidData;
+}
+
+function prefLabelInLangExists(
+  data: ConceptTermType,
+  recommendedTermLangs: string[]
+) {
+  if (
+    recommendedTermLangs?.length > 0 &&
+    recommendedTermLangs.includes(data.language)
+  ) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
Changes in this PR:
- Downloading terminology as excel won't open new window to download
- Moved terms language picker upper in the form
- Fixed translations

If a recommended term has already been set with a language, user cannot choose to set the term as a recommended term
![image](https://user-images.githubusercontent.com/82932696/195826587-28b5d4af-1e43-46f6-b08d-edfe4be254cc.png)
