### PR TITLE
Concept link initialization bugfix

### DIFF
--- a/src/common/components/relational-information-block/relational-modal-content.tsx
+++ b/src/common/components/relational-information-block/relational-modal-content.tsx
@@ -135,7 +135,7 @@ export default function RelationModalContent({
     if (result.isSuccess) {
       setSearchResults(result.data.concepts);
       setTotalResults(result.data.totalHitCount);
-      if (!initialized && !fromOther) {
+      if (!initialized) {
         setChosen(
           result.data.concepts.filter((c) =>
             initialChosenConcepts.includes(c.id)

--- a/src/common/components/relational-information-block/relational-modal-content.tsx
+++ b/src/common/components/relational-information-block/relational-modal-content.tsx
@@ -1,5 +1,6 @@
 import { Concepts } from '@app/common/interfaces/concepts.interface';
 import useMountEffect from '@app/common/utils/hooks/use-mount-effect';
+import { RelationInfoType } from '@app/modules/edit-concept/new-concept.types';
 import { useTranslation } from 'next-i18next';
 import { createRef, useEffect, useState } from 'react';
 import { SingleSelectData } from 'suomifi-ui-components';
@@ -11,8 +12,8 @@ import Search from './search';
 
 interface RelationModalContentProps {
   fromOther?: boolean;
-  chosen: Concepts[];
-  setChosen: (value: Concepts[]) => void;
+  chosen: Concepts[] | RelationInfoType[];
+  setChosen: (value: Concepts[] | RelationInfoType[]) => void;
   searchResults: Concepts[];
   setSearchResults: (value: Concepts[]) => void;
   terminologyId: string;

--- a/src/common/components/relational-information-block/render-chosen.tsx
+++ b/src/common/components/relational-information-block/render-chosen.tsx
@@ -1,12 +1,13 @@
 import { Concepts } from '@app/common/interfaces/concepts.interface';
+import { RelationInfoType } from '@app/modules/edit-concept/new-concept.types';
 import { useTranslation } from 'next-i18next';
 import { Chip, Label } from 'suomifi-ui-components';
 import PropertyValue from '../property-value';
 import { ChipBlock } from './relation-information-block.styles';
 
 interface RenderChosenProps {
-  chosen: Concepts[];
-  setChosen: (value: Concepts[]) => void;
+  chosen: Concepts[] | RelationInfoType[];
+  setChosen: (value: Concepts[] | RelationInfoType[]) => void;
   setShowChosen: (value: boolean) => void;
   chipLabel: string;
 }
@@ -18,8 +19,11 @@ export default function RenderChosen({
   chipLabel,
 }: RenderChosenProps) {
   const { t } = useTranslation('admin');
-  const handleChipRemove = (chose: Concepts) => {
-    const updatedChosen = chosen.filter((c) => c.id !== chose.id);
+  const handleChipRemove = (chose: Concepts | RelationInfoType) => {
+    const updatedChosen =
+      'terminology' in chosen
+        ? (chosen as Concepts[]).filter((c) => c.id !== chose.id)
+        : (chosen as RelationInfoType[]).filter((c) => c.id !== chose.id);
     setChosen(updatedChosen);
 
     if (updatedChosen.length < 1) {

--- a/src/common/components/relational-information-block/render-concepts.tsx
+++ b/src/common/components/relational-information-block/render-concepts.tsx
@@ -13,11 +13,12 @@ import { translateStatus } from '@app/common/utils/translation-helpers';
 import { useBreakpoints } from '../media-query/media-query-context';
 import { useEffect, useState } from 'react';
 import RenderExpanderContent from './render-expander-content';
+import { RelationInfoType } from '@app/modules/edit-concept/new-concept.types';
 
 interface RenderConceptsProps {
   concepts?: Concepts[];
-  chosen: Concepts[];
-  setChosen: (value: Concepts[]) => void;
+  chosen: Concepts[] | RelationInfoType[];
+  setChosen: (value: Concepts[] | RelationInfoType[]) => void;
 }
 
 export default function RenderConcepts({
@@ -35,11 +36,24 @@ export default function RenderConcepts({
     setExpandersOpen(concepts?.map((c) => [c.id, false]));
   }, [concepts]);
 
-  const handleCheckbox = (e: { checkboxState: boolean }, concept: Concepts) => {
+  const handleCheckbox = (
+    e: { checkboxState: boolean },
+    concept: Concepts | RelationInfoType
+  ) => {
     if (e.checkboxState) {
-      setChosen([...chosen, concept]);
+      setChosen(
+        'terminology' in concept
+          ? [...(chosen as Concepts[]), concept]
+          : [...(chosen as RelationInfoType[]), concept]
+      );
     } else {
-      setChosen(chosen.filter((chose) => chose.id !== concept.id));
+      setChosen(
+        'terminology' in chosen
+          ? (chosen as Concepts[]).filter((chose) => chose.id !== concept.id)
+          : (chosen as RelationInfoType[]).filter(
+              (chose) => chose.id !== concept.id
+            )
+      );
     }
   };
 

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -693,13 +693,19 @@ export default function generateConcept({
   const initialTermIds: string[] = initialValue
     ? Object.keys(initialValue?.references).flatMap((key) => {
         if (
-          key === 'exactMatch' ||
-          key === 'relatedMatch' ||
-          key === 'closeMatch'
+          [
+            'broader',
+            'closeMatch',
+            'exactMatch',
+            'hasPart',
+            'isPartOf',
+            'narrower',
+            'related',
+            'relatedMatch',
+          ].includes(key)
         ) {
           return [];
         }
-
         return (
           initialValue?.references[key as keyof Concept['references']]?.map(
             (val) => val.id
@@ -710,7 +716,7 @@ export default function generateConcept({
 
   let initialInOtherIds: string[] = initialValue
     ? initialValue.references.exactMatch
-        ?.map((match) => match.id ?? '')
+        ?.map((match) => match.properties.targetId?.[0].value ?? '')
         .filter((val) => val) ?? []
     : [];
 
@@ -718,7 +724,7 @@ export default function generateConcept({
     ? [
         ...initialInOtherIds,
         ...(initialValue.references.relatedMatch
-          ?.map((match) => match.id ?? '')
+          ?.map((match) => match.properties.targetId?.[0].value ?? '')
           .filter((val) => val) ?? []),
       ]
     : initialInOtherIds;
@@ -727,7 +733,7 @@ export default function generateConcept({
     ? [
         ...initialInOtherIds,
         ...(initialValue.references.closeMatch
-          ?.map((match) => match.id ?? '')
+          ?.map((match) => match.properties.targetId?.[0].value ?? '')
           .filter((val) => val) ?? []),
       ]
     : initialInOtherIds;

--- a/src/modules/edit-concept/generate-form-data-test-variables.tsx
+++ b/src/modules/edit-concept/generate-form-data-test-variables.tsx
@@ -2504,7 +2504,7 @@ export const extensiveDataExpected = {
       ],
       matchInOther: [
         {
-          id: '8ee81e29-e0f1-4a23-b23b-28a976fcf87f',
+          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
           label: {
             fi: 'demo',
           },
@@ -2541,7 +2541,7 @@ export const extensiveDataExpected = {
       ],
       relatedConceptInOther: [
         {
-          id: 'a87ae2c2-3c16-494a-9f82-928fc1840a1e',
+          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
           label: {
             fi: 'demo',
           },
@@ -2554,7 +2554,7 @@ export const extensiveDataExpected = {
       ],
       closeMatch: [
         {
-          id: 'a87ae2c2-3c16-494a-9f82-928fc1840a1f',
+          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
           label: {
             fi: 'demo',
           },

--- a/src/modules/edit-concept/generate-form-data.tsx
+++ b/src/modules/edit-concept/generate-form-data.tsx
@@ -208,7 +208,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.id ?? '',
+                id: r.properties.targetId?.[0].value ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => {
@@ -281,7 +281,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.id ?? '',
+                id: r.properties.targetId?.[0].value ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => ({ [l.lang]: l.value }))
@@ -302,7 +302,7 @@ export default function generateFormData(
 
             {
               return {
-                id: m.id ?? '',
+                id: m.properties.targetId?.[0].value ?? '',
                 label:
                   m.properties.prefLabel
                     ?.map((l) => ({ [l.lang]: l.value }))


### PR DESCRIPTION
Changes in this PR:
- Initial relational concepts from other terminologies are now displayed when opening modal. Previously information of these concepts was partly initialized _only_ after a call to backend was made. Now information of these concepts are built entirely from initial data received at page load.  
- Tweaked `generateConcept()` (again) to remove unnecessary terms appearing under delete key and target correct IDs. These were incorrectly tagged terms appearing in relational concepts that are from same terminology as edited concept.