### PR TITLE
Opening falsely ID'd concept/collection bugfix

### DIFF
--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -95,6 +95,15 @@ export const getServerSideProps = createCommonGetServerSideProps(
       language: locale,
     });
 
+    if (!collectionData) {
+      return {
+        redirect: {
+          destination: '/401',
+          permanent: false,
+        },
+      };
+    }
+
     const collectionTitle = getPropertyValue({
       property: collectionData?.properties.prefLabel,
       language: locale,

--- a/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
+++ b/src/pages/terminology/[terminologyId]/collection/[collectionId].tsx
@@ -98,7 +98,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     if (!collectionData) {
       return {
         redirect: {
-          destination: '/401',
+          destination: '/404',
           permanent: false,
         },
       };

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -55,7 +55,7 @@ export default function ConceptPage(props: ConceptPageProps) {
 }
 
 export const getServerSideProps = createCommonGetServerSideProps(
-  async ({ store, params, locale }: LocalHandlerParams) => {
+  async ({ store, params, locale, res }: LocalHandlerParams) => {
     if (!params) {
       throw new Error('Missing parameters for page');
     }
@@ -88,6 +88,15 @@ export const getServerSideProps = createCommonGetServerSideProps(
       reduxKey: 'conceptAPI',
       functionKey: 'getConcept',
     });
+
+    if (!conceptData) {
+      return {
+        redirect: {
+          destination: '/401',
+          permanent: false,
+        },
+      };
+    }
 
     const vocabularyTitle = getPropertyValue({
       property: vocabularyData?.properties?.prefLabel,

--- a/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
+++ b/src/pages/terminology/[terminologyId]/concept/[conceptId].tsx
@@ -92,7 +92,7 @@ export const getServerSideProps = createCommonGetServerSideProps(
     if (!conceptData) {
       return {
         redirect: {
-          destination: '/401',
+          destination: '/404',
           permanent: false,
         },
       };


### PR DESCRIPTION
Changes in this PR:
- If a concept or collection page is loaded that doesn't have a valid ID, redirect user to /404. This has happened with some concept links where concept is from other terminology and a bug related to that. These broken ID links shouldn't appear after that PR (https://github.com/VRK-YTI/yti-terminology-ui/pull/283) has been merged but this is PR ensures that there are no breaking errors.