### PR TITLE
Yti 2200 edit homograph

### DIFF
--- a/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
+++ b/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
@@ -11,6 +11,7 @@ import {
   SingleSelect,
   Text,
   Textarea,
+  TextInput,
 } from 'suomifi-ui-components';
 
 export const LargeHeading = styled(Heading)`
@@ -150,5 +151,9 @@ export const TermFormRemoveButton = styled(Button)`
 `;
 
 export const LanguageSingleSelect = styled(SingleSelect)`
+  margin-top: ${(props) => props.theme.suomifi.spacing.s};
+`;
+
+export const HomographTextInput = styled(TextInput)`
   margin-top: ${(props) => props.theme.suomifi.spacing.s};
 `;

--- a/src/modules/edit-concept/concept-terms-block/index.tsx
+++ b/src/modules/edit-concept/concept-terms-block/index.tsx
@@ -51,6 +51,7 @@ export default function ConceptTermsBlock({
 
   const handleUpdate = ({ termId, key, value }: ConceptTermUpdateProps) => {
     let updatedTerm = terms.filter((term) => term.id === termId)[0];
+
     updatedTerm = {
       ...updatedTerm,
       [key]: typeof value === 'string' ? value.trim() : value,
@@ -137,7 +138,11 @@ export default function ConceptTermsBlock({
               {terms
                 .filter((term) => term.termType === 'recommended-term')
                 .map((term) => (
-                  <TermExpander key={term.id} term={term} errors={errors}>
+                  <TermExpander
+                    key={`recommended-term-${term.id}`}
+                    term={term}
+                    errors={errors}
+                  >
                     <TermForm
                       term={term}
                       update={handleUpdate}
@@ -181,24 +186,26 @@ export default function ConceptTermsBlock({
             )}
             {terms.filter((term) => term.termType !== 'recommended-term')
               .length > 0 && (
-              <>
-                <OtherTermsExpanderGroup openAllText="" closeAllText="">
-                  {terms
-                    .filter((term) => term.termType !== 'recommended-term')
-                    .map((term) => (
-                      <TermExpander key={term.id} term={term} errors={errors}>
-                        <TermForm
-                          term={term}
-                          update={handleUpdate}
-                          currentTerms={terms}
-                          handleSwitchTerms={handleSwitchTerms}
-                          errors={errors}
-                          handleRemoveTerm={handleRemoveTerm}
-                        />
-                      </TermExpander>
-                    ))}
-                </OtherTermsExpanderGroup>
-              </>
+              <OtherTermsExpanderGroup openAllText="" closeAllText="">
+                {terms
+                  .filter((term) => term.termType !== 'recommended-term')
+                  .map((term) => (
+                    <TermExpander
+                      key={`other-term-${term.id}`}
+                      term={term}
+                      errors={errors}
+                    >
+                      <TermForm
+                        term={term}
+                        update={handleUpdate}
+                        currentTerms={terms}
+                        handleSwitchTerms={handleSwitchTerms}
+                        errors={errors}
+                        handleRemoveTerm={handleRemoveTerm}
+                      />
+                    </TermExpander>
+                  ))}
+              </OtherTermsExpanderGroup>
             )}
           </BasicBlockExtraWrapper>
         }

--- a/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
+++ b/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
@@ -28,6 +28,7 @@ import {
   CheckboxBlock,
   DropdownBlock,
   GrammaticalBlock,
+  HomographTextInput,
   LanguageSingleSelect,
   MediumHeading,
   ModalDescription,
@@ -158,7 +159,7 @@ export default function NewTermModal({
         </CheckboxBlock>
 
         {isHomographic && (
-          <TextInput
+          <HomographTextInput
             labelText={t('homograph-number')}
             type="number"
             defaultValue={termData.termHomographNumber}

--- a/src/modules/edit-concept/concept-terms-block/term-form.tsx
+++ b/src/modules/edit-concept/concept-terms-block/term-form.tsx
@@ -24,6 +24,7 @@ import {
   CheckboxBlock,
   DropdownBlock,
   GrammaticalBlock,
+  HomographTextInput,
   MediumHeading,
   TermFormBottomBlock,
   TermFormRemoveButton,
@@ -158,21 +159,19 @@ export default function TermForm({
       </CheckboxBlock>
 
       {isHomographic && (
-        <BasicBlock title={t('homograph-number')}>
-          <TextInput
-            labelText=""
-            type="number"
-            defaultValue={term.termHomographNumber}
-            onChange={(e) =>
-              handleUpdate({
-                key: 'termHomographNumber',
-                value: e?.toString() ?? '',
-              })
-            }
-            min={0}
-            id="homograph-number-input"
-          />
-        </BasicBlock>
+        <HomographTextInput
+          labelText={t('homograph-number')}
+          type="number"
+          defaultValue={term.termHomographNumber}
+          onChange={(e) =>
+            handleUpdate({
+              key: 'termHomographNumber',
+              value: e?.toString() ?? '',
+            })
+          }
+          min={0}
+          id="homograph-number-input"
+        />
       )}
 
       <BasicBlock title={t('language')}>

--- a/src/modules/edit-concept/concept-terms-block/term-form.tsx
+++ b/src/modules/edit-concept/concept-terms-block/term-form.tsx
@@ -134,7 +134,7 @@ export default function TermForm({
             handleUpdate({ key: 'prefLabel', value: e.target.value })
           }
           maxLength={TEXT_INPUT_MAX}
-          id="term-name-input"
+          id={`term-name-input_${term.id}`}
           status={
             errors.termPrefLabel && prefLabel === '' ? 'error' : 'default'
           }
@@ -152,7 +152,7 @@ export default function TermForm({
       <CheckboxBlock
         defaultChecked={term.termHomographNumber ? true : false}
         onClick={() => handleIsHomographic()}
-        id="homograph-checkbox"
+        id={`homograph-checkbox_${term.id}`}
         variant={isSmall ? 'large' : 'small'}
       >
         {t('term-is-homograph-label')}
@@ -170,7 +170,7 @@ export default function TermForm({
             })
           }
           min={0}
-          id="homograph-number-input"
+          id={`homograph-number-input_${term.id}`}
         />
       )}
 
@@ -184,7 +184,7 @@ export default function TermForm({
             <Button
               variant="secondary"
               onClick={() => setModalVisible(true)}
-              id="change-type-button"
+              id={`change-type-button_${term.id}`}
             >
               {t('change-term-type')}
             </Button>
@@ -207,7 +207,7 @@ export default function TermForm({
         labelText={t('term-status-label')}
         defaultValue={term.status}
         onChange={(e) => handleUpdate({ key: 'status', value: e })}
-        id="status-picker"
+        id={`status-picker_${term.id}`}
         $isSmall={isSmall}
       >
         <DropdownItem value="DRAFT">
@@ -239,7 +239,7 @@ export default function TermForm({
         defaultValue={term.termInfo}
         onBlur={(e) => handleUpdate({ key: 'termInfo', value: e.target.value })}
         maxLength={TEXT_AREA_MAX}
-        id="info-input"
+        id={`info-input_${term.id}`}
       />
       <WiderTextareaBlock
         labelText={t('term-scope-label')}
@@ -248,7 +248,7 @@ export default function TermForm({
         visualPlaceholder={t('term-scope-placeholder')}
         defaultValue={term.scope}
         onBlur={(e) => handleUpdate({ key: 'scope', value: e.target.value })}
-        id="scope-input"
+        id={`scope-input_${term.id}`}
         maxLength={TEXT_AREA_MAX}
       />
 
@@ -277,7 +277,7 @@ export default function TermForm({
         onBlur={(e) =>
           handleUpdate({ key: 'changeNote', value: e.target.value })
         }
-        id="change-note-input"
+        id={`change-note-input_${term.id}`}
         maxLength={TEXT_AREA_MAX}
       />
       <WiderTextareaBlock
@@ -290,7 +290,7 @@ export default function TermForm({
           handleUpdate({ key: 'historyNote', value: e.target.value })
         }
         maxLength={TEXT_AREA_MAX}
-        id="history-note-input"
+        id={`history-note-input_${term.id}`}
       />
 
       <ListBlock
@@ -339,7 +339,7 @@ export default function TermForm({
               : undefined
           }
           onItemSelect={(e) => handleUpdate({ key: 'termFamily', value: e })}
-          id="family-picker"
+          id={`family-picker_${term.id}`}
         />
 
         <SingleSelect
@@ -362,7 +362,7 @@ export default function TermForm({
           onItemSelect={(e) =>
             handleUpdate({ key: 'termConjugation', value: e })
           }
-          id="conjugations-picker"
+          id={`conjugations-picker_${term.id}`}
         />
 
         <SingleSelect
@@ -384,7 +384,7 @@ export default function TermForm({
               : undefined
           }
           onItemSelect={(e) => handleUpdate({ key: 'wordClass', value: e })}
-          id="word-class-picker"
+          id={`word-class-picker_${term.id}`}
         />
         {handleRemoveTerm && isSmall && (
           <TermFormBottomBlock>


### PR DESCRIPTION
Changes in this PR:
- Homographic number in other terms had a bug where users couldn't change the value or remove the homographic number tag. This was caused by an error where duplicate id's caused the update to only target the first preferred term. This was fixed by making id's truly unique.
- Fixed styling with homographic number input