### PR TITLE
Term equivalency visible in term edit

### DIFF
--- a/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
+++ b/src/modules/edit-concept/concept-terms-block/concept-terms-block.styles.tsx
@@ -87,6 +87,10 @@ export const TermEquivalencyBlock = styled(Block)`
       font-weight: 400;
     }
   }
+
+  > span {
+    margin-bottom: ${(props) => props.theme.suomifi.spacing.xs};
+  }
 `;
 
 export const RadioButtonGroupSpaced = styled(RadioButtonGroup)<{

--- a/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
+++ b/src/modules/edit-concept/concept-terms-block/new-term-modal.tsx
@@ -286,6 +286,7 @@ export default function NewTermModal({
           <span>{t('term-equivalency-description')}</span>
           <Dropdown
             labelText=""
+            labelMode="hidden"
             defaultValue="undefined"
             onChange={(e) => handleUpdate({ key: 'termEquivalency', value: e })}
           >

--- a/src/modules/edit-concept/concept-terms-block/term-form.tsx
+++ b/src/modules/edit-concept/concept-terms-block/term-form.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'next-i18next';
 import { useState } from 'react';
 import {
   Button,
+  Dropdown,
   DropdownItem,
   SingleSelect,
   TextInput,
@@ -25,6 +26,7 @@ import {
   DropdownBlock,
   GrammaticalBlock,
   MediumHeading,
+  TermEquivalencyBlock,
   TermFormBottomBlock,
   TermFormRemoveButton,
   TermFormTopBlock,
@@ -252,6 +254,25 @@ export default function TermForm({
         id="scope-input"
         maxLength={TEXT_AREA_MAX}
       />
+
+      <TermEquivalencyBlock>
+        <label>
+          {t('term-equivalency')}
+          <span> ({t('optional')})</span>
+        </label>
+        <span>{t('term-equivalency-description')}</span>
+        <Dropdown
+          labelText=""
+          labelMode="hidden"
+          defaultValue={term.termEquivalency}
+          onChange={(e) => handleUpdate({ key: 'termEquivalency', value: e })}
+        >
+          <DropdownItem value="undefined">{t('no-selection')}</DropdownItem>
+          <DropdownItem value="<">{'<'}</DropdownItem>
+          <DropdownItem value=">">{'>'}</DropdownItem>
+          <DropdownItem value="~">{t('almost-the-same-as')} (~)</DropdownItem>
+        </Dropdown>
+      </TermEquivalencyBlock>
 
       <ListBlock
         update={handleUpdate}


### PR DESCRIPTION
Changes in this PR:
- Term equivalency added to be visible and editable in term expander in concept edit page