### PR TITLE
Incorrect term conjugations handling added

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -117,6 +117,7 @@
     "recommendedTerms": "Concept is missing a preferred term ",
     "source": "At least one source is missing a value",
     "status": "Concept's status is undefined",
+    "termConjugation": "One or more term has incorrect term conjugation set",
     "termPrefLabel": "At least on preferred term is missing a name",
     "termType": "Term's type is undefined"
   },

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -117,6 +117,7 @@
     "recommendedTerms": "Käsitteeltä puuttuu suositettava termi",
     "source": "Vähintään yhdeltä lähteeltä puuttuu arvo",
     "status": "Käsitteen tilaa ei ole määritetty",
+    "termConjugation": "Yhdellä tai useammalla termillä on väärin asetettu termin luku",
     "termPrefLabel": "Vähintään yhdeltä termiltä puuttuu nimi",
     "termType": "Termin tyyppiä ei ole määritetty"
   },

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -117,6 +117,7 @@
     "recommendedTerms": "",
     "source": "",
     "status": "",
+    "termConjugation": "",
     "termPrefLabel": "",
     "termType": ""
   },

--- a/src/common/utils/translation-helpers.ts
+++ b/src/common/utils/translation-helpers.ts
@@ -150,6 +150,8 @@ export function translateEditConceptError(error: string, t: TFunction) {
       return t('edit-concept-error.language', { ns: 'admin' });
     case 'recommendedTermDuplicate':
       return t('edit-concept-error.recommendedTermDuplicate', { ns: 'admin' });
+    case 'termConjugation':
+      return t('edit-concept-error.termConjugation', { ns: 'admin' });
     default:
       return t('edit-concept-error.default', { ns: 'admin' });
   }

--- a/src/modules/edit-concept/concept-terms-block/term-expander.tsx
+++ b/src/modules/edit-concept/concept-terms-block/term-expander.tsx
@@ -38,7 +38,9 @@ export default function TermExpander({
   const displayIcon =
     (errors.termPrefLabel && !term.prefLabel) ||
     (errors.editorialNote &&
-      term.editorialNote.filter((n) => !n.value || n.value === '').length > 0);
+      term.editorialNote.filter((n) => !n.value || n.value === '').length >
+        0) ||
+    errors.termConjugation;
 
   return (
     <Expander>

--- a/src/modules/edit-concept/concept-terms-block/term-form.tsx
+++ b/src/modules/edit-concept/concept-terms-block/term-form.tsx
@@ -363,6 +363,15 @@ export default function TermForm({
             handleUpdate({ key: 'termConjugation', value: e })
           }
           id={`conjugations-picker_${term.id}`}
+          status={
+            term.termConjugation &&
+            !termConjugation
+              .map((c) => c.uniqueItemId)
+              .includes(term.termConjugation) &&
+            errors.termConjugation
+              ? 'error'
+              : 'default'
+          }
         />
 
         <SingleSelect

--- a/src/modules/edit-concept/validate-form.tsx
+++ b/src/modules/edit-concept/validate-form.tsx
@@ -9,6 +9,7 @@ export interface FormError {
   source: boolean;
   status: boolean;
   diagrams: boolean;
+  termConjugation: boolean;
   total: boolean;
 }
 
@@ -22,6 +23,7 @@ export const EmptyFormError = {
   source: false,
   status: false,
   diagrams: false,
+  termConjugation: false,
   total: false,
 };
 
@@ -35,6 +37,7 @@ export default function validateForm(data: EditConceptType): FormError {
     source: false,
     status: false,
     diagrams: false,
+    termConjugation: false,
     total: false,
   };
 
@@ -124,6 +127,16 @@ export default function validateForm(data: EditConceptType): FormError {
     !data.basicInformation.status
   ) {
     errors.status = true;
+  }
+
+  // If any terms conjugation is not one of the available
+  // Currently available conjugations are 'singular' and 'plural'
+  if (
+    data.terms
+      .map((t) => t.termConjugation)
+      .filter((c) => c && !['singular', 'plural'].includes(c)).length > 0
+  ) {
+    errors.termConjugation = true;
   }
 
   // Setting total of errors if one error is found in object


### PR DESCRIPTION
Changes in this PR:
- Older terminologies might have term conjugation set to any string value. This is now taken into consideration when validating concept before payload is sent to back end. If any term has an incorrect value (e.g. not 'singular' or 'plural') set in conjugation, an error is displayed in the footer with other possible errors.