### PR TITLE
Removed word class option from concept information

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -317,9 +317,5 @@
   "type-change-alert-warning": "Recommended term type cannot be changed because no other recommended terms have been defined. Add a new recommended term or change an already existing term to recommended term.",
   "url-preview": "URL preview",
   "which-input": "How do you want to add new information?",
-  "word-class": "Word class",
-  "word-class-available": "Available word classes",
-  "word-class-hint": "Toggle only if word class is either an adjective or a verb",
-  "word-class-no-items": "No word classes available",
   "you-can-copy": "You can copy the terminology as a base for a newer version, where the original terminology will exist until the newer terminology is ready"
 }

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -317,9 +317,5 @@
   "type-change-alert-warning": "Suositettavan termin tyyppiä ei voi muuttaa, koska muita suositettavia termejä ei ole määritetty. Lisää uusi suositettava termi tai muuta olemassa oleva termi suositettavaksi termiksi.",
   "url-preview": "Url:n esikatselu",
   "which-input": "Miten lisäät tietoja?",
-  "word-class": "Sanaluokka",
-  "word-class-available": "Saatavilla olevat sanaluokat",
-  "word-class-hint": "Merkitään vain jos sanaluokka on adjektiivi tai verbi",
-  "word-class-no-items": "Sanaluokka ei saatavilla",
   "you-can-copy": "Voit kopioida sanaston pohjaksi uudelle versiolle, jolloin nykyinen sanasto säilyy olemassa kunnes uusi sanasto on valmis"
 }

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -317,9 +317,5 @@
   "type-change-alert-warning": "",
   "url-preview": "",
   "which-input": "",
-  "word-class": "",
-  "word-class-available": "",
-  "word-class-hint": "",
-  "word-class-no-items": "",
   "you-can-copy": ""
 }

--- a/src/modules/edit-concept/basic-information/other-information.tsx
+++ b/src/modules/edit-concept/basic-information/other-information.tsx
@@ -1,12 +1,7 @@
 import { TEXT_INPUT_MAX } from '@app/common/utils/constants';
-import { translateWordClass } from '@app/common/utils/translation-helpers';
 import { useTranslation } from 'next-i18next';
 import { useState } from 'react';
-import {
-  ExpanderTitleButton,
-  SingleSelect,
-  TextInput,
-} from 'suomifi-ui-components';
+import { ExpanderTitleButton, TextInput } from 'suomifi-ui-components';
 import { BasicInfoUpdate } from './concept-basic-information';
 import {
   ConceptExpander,
@@ -31,35 +26,16 @@ export default function OtherInformation({
   const [conceptClass, setConceptClass] = useState<string | undefined>(
     initialValues?.conceptClass
   );
-  const [wordClass, setWordClass] = useState<typeof partOfSpeech[0] | null>(
-    initialValues?.wordClass
-      ? {
-          uniqueItemId: initialValues.wordClass,
-          labelText: translateWordClass(initialValues.wordClass, t),
-        }
-      : null
-  );
 
   const handleChange = () => {
     update({
       key: infoKey,
       value: {
         conceptClass: conceptClass,
-        wordClass: wordClass?.uniqueItemId ?? '',
+        wordClass: '',
       },
     });
   };
-
-  const partOfSpeech = [
-    {
-      uniqueItemId: 'adjective',
-      labelText: t('word-class.adjective', { ns: 'common' }),
-    },
-    {
-      uniqueItemId: 'verb',
-      labelText: t('word-class.verb', { ns: 'common' }),
-    },
-  ];
 
   return (
     <ConceptExpander id="other-information-expander">
@@ -75,20 +51,6 @@ export default function OtherInformation({
           onBlur={() => handleChange()}
           maxLength={TEXT_INPUT_MAX}
           id="concept-class-input"
-        />
-
-        <SingleSelect
-          labelText={t('word-class')}
-          optionalText={t('optional')}
-          hintText={t('word-class-hint')}
-          clearButtonLabel={t('clear-button-label')}
-          ariaOptionsAvailableText={t('word-class-available')}
-          items={partOfSpeech}
-          selectedItem={wordClass ?? undefined}
-          noItemsText={t('word-class-no-items')}
-          onItemSelectionChange={(e) => setWordClass(e)}
-          onBlur={() => handleChange()}
-          id="word-class-picker"
         />
       </ExpanderContentFitted>
     </ConceptExpander>

--- a/src/modules/edit-concept/generate-concept-test-expected.tsx
+++ b/src/modules/edit-concept/generate-concept-test-expected.tsx
@@ -1419,7 +1419,7 @@ export const differentTerms = {
           {
             lang: '',
             regex: '(?s)^.*$',
-            value: 'adjective',
+            value: '',
           },
         ],
       },

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -513,7 +513,7 @@ export default function generateConcept({
           {
             lang: '',
             regex: regex,
-            value: data.basicInformation.otherInfo.wordClass ?? '',
+            value: '',
           },
         ],
       },

--- a/src/modules/edit-concept/generate-form-data-test-variables.tsx
+++ b/src/modules/edit-concept/generate-form-data-test-variables.tsx
@@ -2317,7 +2317,7 @@ export const extensiveDataExpected = {
       termInfo: 'termin lisätieto',
       termStyle: 'puhekieli',
       termType: 'synonym',
-      wordClass: 'adjektiivi',
+      wordClass: '',
     },
     {
       changeNote: 'muutoshistoria',
@@ -2350,7 +2350,7 @@ export const extensiveDataExpected = {
       termInfo: 'termin lisätieto',
       termStyle: 'puhekieli',
       termType: 'search-term',
-      wordClass: 'adjektiivi',
+      wordClass: '',
     },
     {
       changeNote: 'muutoshistoria',
@@ -2383,7 +2383,7 @@ export const extensiveDataExpected = {
       termInfo: 'termin lisätieto',
       termStyle: 'spoken-form',
       termType: 'recommended-term',
-      wordClass: 'adjective',
+      wordClass: '',
     },
     {
       changeNote: 'muutoshistoria',
@@ -2416,7 +2416,7 @@ export const extensiveDataExpected = {
       termInfo: 'termin lisätieto',
       termStyle: 'puhekieli',
       termType: 'not-recommended-synonym',
-      wordClass: 'adjektiivi',
+      wordClass: '',
     },
   ],
   basicInformation: {

--- a/src/modules/edit-concept/generate-form-data.tsx
+++ b/src/modules/edit-concept/generate-form-data.tsx
@@ -385,7 +385,7 @@ export default function generateFormData(
             termInfo: r.properties.termInfo?.[0].value ?? '',
             termStyle: r.properties.termStyle?.[0].value ?? '',
             termType: termType,
-            wordClass: r.properties.wordClass?.[0].value ?? '',
+            wordClass: '',
           };
         }
       )


### PR DESCRIPTION
Changes in this PR:
- Word class block in concept basic information has been removed due to it being marked as unused.