### PR TITLE
Added some validation to diagram url

### DIFF
--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -108,6 +108,7 @@
   "edit-concept-error": {
     "default": "Concept has missing information",
     "diagrams": "At least one diagram is missing name and/or url",
+    "diagramsUri": "One or more diagram's url is not in valid form",
     "editorialNote": "At least one editorial note is missing a descriptive text",
     "example": "At least one example is missing a descriptive text",
     "language": "Term's language is undefined",

--- a/public/locales/fi/admin.json
+++ b/public/locales/fi/admin.json
@@ -108,6 +108,7 @@
   "edit-concept-error": {
     "default": "Käsitteen tiedoissa ilmeni puuttuvia tietoja",
     "diagrams": "Vähintään yhdeltä käsitekaaviolta puuttuu nimi ja/tai verkko-osoite",
+    "diagramsUri": "Yhdellä tai useammalla käsitekaaviolla on virheellinen verkko-osoite",
     "editorialNote": "Vähintään yhdeltä ylläpitäjän muistiipanolta puuttuu selite",
     "example": "Vähintään yhdeltä käyttöesimerkiltä puuttuu selite",
     "language": "Termin kieltä ei ole määritetty",

--- a/public/locales/sv/admin.json
+++ b/public/locales/sv/admin.json
@@ -108,6 +108,7 @@
   "edit-concept-error": {
     "default": "",
     "diagrams": "",
+    "diagramsUri": "",
     "editorialNote": "",
     "example": "",
     "language": "",

--- a/src/common/utils/to-uri.test.ts
+++ b/src/common/utils/to-uri.test.ts
@@ -1,0 +1,22 @@
+import toUri from './to-uri';
+
+describe('to-uri', () => {
+  it('should return itself if empty', () => {
+    const returned = toUri('');
+    expect(returned).toBe('');
+  });
+
+  it('should return itself when a valid uri', () => {
+    const returnedHttp = toUri('http://www.suomi.fi');
+    const returnedHttps = toUri('https://www.suomi.fi');
+
+    expect(returnedHttp).toBe('http://www.suomi.fi');
+    expect(returnedHttps).toBe('https://www.suomi.fi');
+  });
+
+  it('should add https:// in the beginning if missing', () => {
+    const returned = toUri('suomi.fi');
+
+    expect(returned).toBe('https://suomi.fi');
+  });
+});

--- a/src/common/utils/to-uri.ts
+++ b/src/common/utils/to-uri.ts
@@ -1,0 +1,13 @@
+export default function toUri(uri: string): string {
+  if (uri.length < 1) {
+    return uri;
+  }
+
+  let validUri = uri.trim().toLowerCase();
+
+  if (!validUri.startsWith('http://') && !validUri.startsWith('https://')) {
+    validUri = 'https://' + validUri;
+  }
+
+  return validUri;
+}

--- a/src/common/utils/translation-helpers.ts
+++ b/src/common/utils/translation-helpers.ts
@@ -150,6 +150,8 @@ export function translateEditConceptError(error: string, t: TFunction) {
       return t('edit-concept-error.language', { ns: 'admin' });
     case 'recommendedTermDuplicate':
       return t('edit-concept-error.recommendedTermDuplicate', { ns: 'admin' });
+    case 'diagramsUri':
+      return t('edit-concept-error.diagramsUri', { ns: 'admin' });
     default:
       return t('edit-concept-error.default', { ns: 'admin' });
   }

--- a/src/modules/edit-concept/basic-information/concept-diagrams-and-sources.tsx
+++ b/src/modules/edit-concept/basic-information/concept-diagrams-and-sources.tsx
@@ -79,7 +79,7 @@ export default function ConceptDiagramsAndSources({
                 diagrams={diagrams}
                 setDiagrams={setDiagrams}
                 handleRemove={handleRemove}
-                isError={errors.diagrams}
+                isError={errors.diagrams || errors.diagramsUri}
               />
             </BasicBlockExtraWrapper>
           }

--- a/src/modules/edit-concept/basic-information/diagrams.tsx
+++ b/src/modules/edit-concept/basic-information/diagrams.tsx
@@ -86,7 +86,11 @@ export default function Diagrams({
                 onChange={(e) =>
                   handleUpdate(diagram.id, 'url', e?.toString() ?? '')
                 }
-                status={isError && diagram.url === '' ? 'error' : 'default'}
+                status={
+                  isError && (diagram.url === '' || !diagram.url.includes('.'))
+                    ? 'error'
+                    : 'default'
+                }
               />
 
               <FullwidthTextarea

--- a/src/modules/edit-concept/generate-concept-test-expected.tsx
+++ b/src/modules/edit-concept/generate-concept-test-expected.tsx
@@ -1370,7 +1370,7 @@ export const differentTerms = {
             lang: '',
             regex: '(?s)^.*$',
             value:
-              '"{"name":"käsitekaavion nimi","url":"käsitekaavion verkko-osoite","description":"kuvaus"}"',
+              '"{"name":"käsitekaavion nimi","url":"https://käsitekaavion-verkko-osoite.fi","description":"kuvaus"}"',
           },
         ],
         historyNote: [

--- a/src/modules/edit-concept/generate-concept.test.tsx
+++ b/src/modules/edit-concept/generate-concept.test.tsx
@@ -562,7 +562,7 @@ describe('generate-concept', () => {
             {
               id: '123',
               name: 'käsitekaavion nimi',
-              url: 'käsitekaavion verkko-osoite',
+              url: 'käsitekaavion-verkko-osoite.fi',
               description: 'kuvaus',
             },
           ],

--- a/src/modules/edit-concept/generate-concept.tsx
+++ b/src/modules/edit-concept/generate-concept.tsx
@@ -1,5 +1,6 @@
 import { Concept } from '@app/common/interfaces/concept.interface';
 import { Term } from '@app/common/interfaces/term.interface';
+import toUri from '@app/common/utils/to-uri';
 import { v4 } from 'uuid';
 import { EditConceptType } from './new-concept.types';
 
@@ -463,7 +464,7 @@ export default function generateConcept({
                   lang: '',
                   regex: regex,
                   value: `"{"name":"${diagram.name ?? ''}","url":"${
-                    diagram.url ?? ''
+                    diagram.url ? toUri(diagram.url) : ''
                   }","description":"${diagram.description ?? ''}"}"`,
                 })
               )

--- a/src/modules/edit-concept/index.tsx
+++ b/src/modules/edit-concept/index.tsx
@@ -106,11 +106,19 @@ export default function EditConcept({
   const updateTerms = (terms: ConceptTermType[]) => {
     setFormData({ ...formData, terms: terms });
     enableConfirmation();
+    if (errors.total) {
+      const errors = validateForm({ ...formData, terms: terms });
+      setErrors(errors);
+    }
   };
 
   const updateBasicInformation = (basicInfo: BasicInfo) => {
     setFormData({ ...formData, basicInformation: basicInfo });
     enableConfirmation();
+    if (errors.total) {
+      const errors = validateForm({ ...formData, basicInformation: basicInfo });
+      setErrors(errors);
+    }
   };
 
   useEffect(() => {

--- a/src/modules/edit-concept/validate-form.tsx
+++ b/src/modules/edit-concept/validate-form.tsx
@@ -9,6 +9,7 @@ export interface FormError {
   source: boolean;
   status: boolean;
   diagrams: boolean;
+  diagramsUri: boolean;
   total: boolean;
 }
 
@@ -22,6 +23,7 @@ export const EmptyFormError = {
   source: false,
   status: false,
   diagrams: false,
+  diagramsUri: false,
   total: false,
 };
 
@@ -35,6 +37,7 @@ export default function validateForm(data: EditConceptType): FormError {
     source: false,
     status: false,
     diagrams: false,
+    diagramsUri: false,
     total: false,
   };
 
@@ -115,6 +118,16 @@ export default function validateForm(data: EditConceptType): FormError {
     ).length > 0
   ) {
     errors.diagrams = true;
+  }
+
+  // If there urls in diagrams that are incorrect (e.g. currently don't have any full stops (.))
+  if (
+    !errors.diagrams &&
+    data.basicInformation.diagramAndSource.diagrams.filter(
+      (diagram) => !diagram.url.includes('.')
+    ).length > 0
+  ) {
+    errors.diagramsUri = true;
   }
 
   // If the status is undefined


### PR DESCRIPTION
Changes in this PR:
- Simple validation added to diagram uri. `http://` or `https://` is added to diagram uri in payload if one is missing. This fixes the bug where incorrect uri would be made into nextjs internal link.
- Form validation expects the link to have at least one full stop (`.`) to accepts data as a proper link. This could be improved at some point.
- Form validation is called if user has tried to submit changes with an error/errors and makes changes after that until all errors are cleared. So now fixed errors in form data aren't visible after they have been fixed.