### PR TITLE
Bunch of smaller changes

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -62,6 +62,7 @@
   "navigated-to": "Navigated to",
   "navigation-close": "Close navigation",
   "navigation-open": "Open navigation",
+  "no-filters": "No filters",
   "no-languages-available": "No languages available",
   "not-recommended-synonym": "Non-recommended synonym",
   "own-information": "Own information",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -97,6 +97,7 @@
   "site-services": "Services",
   "site-title": "Interoperability platform",
   "site-to-login": "Continue to login",
+  "site-tools": "Tools",
   "skip-link-main": "Go directly to contents.",
   "skip-link-search-results": "Go directly to search results.",
   "statuses": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -62,6 +62,7 @@
   "navigated-to": "Siirrytty sivulle",
   "navigation-close": "Sulje navigaatio",
   "navigation-open": "Avaa navigaatio",
+  "no-filters": "Ei rajauksia",
   "no-languages-available": "Kieliä ei saatavilla",
   "not-recommended-synonym": "Ei suositettava synonyymi",
   "own-information": "Omat tiedot",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -97,6 +97,7 @@
   "site-services": "Palvelut",
   "site-title": "Yhteentoimivuusalusta",
   "site-to-login": "Jatka kirjautumaan",
+  "site-tools": "Työkalut",
   "skip-link-main": "Siirry suoraan sisältöön.",
   "skip-link-search-results": "Siirry suoraan hakutuloksiin.",
   "statuses": {

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -62,6 +62,7 @@
   "navigated-to": "",
   "navigation-close": "",
   "navigation-open": "",
+  "no-filters": "",
   "no-languages-available": "",
   "not-recommended-synonym": "",
   "own-information": "",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -97,6 +97,7 @@
   "site-services": "",
   "site-title": "",
   "site-to-login": "",
+  "site-tools": "",
   "skip-link-main": "",
   "skip-link-search-results": "",
   "statuses": {

--- a/src/common/components/filter/filter.styles.tsx
+++ b/src/common/components/filter/filter.styles.tsx
@@ -42,6 +42,7 @@ export const Header = styled.div`
     font-size: inherit;
     margin-top: 0;
     margin-bottom: 0;
+    text-transform: uppercase;
   }
 `;
 

--- a/src/common/components/filter/reset-all-filters-button.tsx
+++ b/src/common/components/filter/reset-all-filters-button.tsx
@@ -33,7 +33,7 @@ export default function ResetAllFiltersButton() {
       isInitial(urlState, 'domain') &&
       isInitial(urlState, 'organization') &&
       isInitial(urlState, 'status') &&
-      isInitial(urlState, 'type')
+      isInitial(urlState, 'lang')
     );
   }
 }

--- a/src/common/components/footer/footer.tsx
+++ b/src/common/components/footer/footer.tsx
@@ -26,8 +26,8 @@ export default function Footer({ feedbackSubject }: FooterProps) {
       <FooterContentWrapper id="footer">
         <Image
           src="/logo-suomi.fi.png"
-          width="254"
-          height="70"
+          width="138"
+          height="38"
           alt=""
           aria-hidden
         />

--- a/src/common/components/navigation/desktop-navigation.tsx
+++ b/src/common/components/navigation/desktop-navigation.tsx
@@ -46,7 +46,7 @@ export default function DesktopNavigation() {
         className="top-navigation-li"
       >
         <SuomiFiLink className="main" href="" onClick={handleDropdown}>
-          {t('site-services')}
+          {t('site-tools')}
           <Icon
             color={theme.suomifi.colors.highlightBase}
             icon={open ? 'chevronUp' : 'chevronDown'}

--- a/src/common/components/search-results/search-count-tags.styles.tsx
+++ b/src/common/components/search-results/search-count-tags.styles.tsx
@@ -8,6 +8,7 @@ export const ChipWrapper = styled.div`
 `;
 
 export const CountText = styled(Text)`
+  font-size: 16px;
   font-weight: 600;
 `;
 

--- a/src/common/components/search-results/search-count-tags.tsx
+++ b/src/common/components/search-results/search-count-tags.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { VisuallyHidden } from 'suomifi-ui-components';
+import { Text, VisuallyHidden } from 'suomifi-ui-components';
 import {
   GroupSearchResult,
   OrganizationSearchResult,
@@ -16,6 +16,7 @@ import {
 } from './search-count-tags.styles';
 import Tag from './tag';
 import { translateStatus } from '@app/common/utils/translation-helpers';
+import { isEqual } from 'lodash';
 
 interface SearchCountTagsProps {
   title: ReactNode;
@@ -47,12 +48,25 @@ export default function SearchCountTags({
       <ChipWrapper id="result-counts-chips">
         {renderOrganizationTag()}
         {renderQBeforeStatus && renderQTag()}
+        {renderLanguageTags()}
         {renderStatusTags()}
         {!renderQBeforeStatus && renderQTag()}
         {renderDomainTags()}
+        {renderNoActiveFilters()}
       </ChipWrapper>
     </CountWrapper>
   );
+
+  function renderNoActiveFilters() {
+    // Ignoring type here on purpose
+    if (isEqual({ ...urlState, type: '' }, { ...initialUrlState, type: '' })) {
+      return (
+        <Text style={{ fontSize: '16px', lineHeight: '0' }}>
+          {t('no-filters')}
+        </Text>
+      );
+    }
+  }
 
   function renderOrganizationTag() {
     if (urlState.organization) {
@@ -121,5 +135,22 @@ export default function SearchCountTags({
         }
       })
       .filter(Boolean);
+  }
+
+  function renderLanguageTags() {
+    if (urlState.lang) {
+      return (
+        <Tag
+          onRemove={() =>
+            patchUrlState({
+              lang: '',
+            })
+          }
+          key={urlState.lang}
+        >
+          {urlState.lang}
+        </Tag>
+      );
+    }
   }
 }

--- a/src/common/components/title/title.styles.tsx
+++ b/src/common/components/title/title.styles.tsx
@@ -33,6 +33,19 @@ export const TitleDescriptionWrapper = styled.div<{ $isSmall: boolean }>`
   align-items: baseline;
 `;
 
+export const TitleType = styled(Text)`
+  color: ${(props) => props.theme.suomifi.colors.depthDark1};
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+`;
+
+export const TitleTypeAndStatusWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+`;
+
 export const TitleWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { Heading } from 'suomifi-ui-components';
+import { Heading, Text } from 'suomifi-ui-components';
 import {
   Contributor,
   Description,
   StatusChip,
   TitleDescriptionWrapper,
+  TitleType,
+  TitleTypeAndStatusWrapper,
   TitleWrapper,
   TitleWrapperNoBreadcrumb,
 } from './title.styles';
@@ -17,7 +19,12 @@ import { useEffect } from 'react';
 import { getProperty } from '@app/common/utils/get-property';
 import { useBreakpoints } from '@app/common/components/media-query/media-query-context';
 import NewTerminology from '@app/modules/new-terminology';
-import { translateStatus } from '@app/common/utils/translation-helpers';
+import {
+  translateStatus,
+  translateTerminologyType,
+  translateTermType,
+} from '@app/common/utils/translation-helpers';
+import { Badge, BadgeBar, MainTitle } from '../title-block';
 
 interface TitleProps {
   info: string | VocabularyInfoDTO;
@@ -54,7 +61,8 @@ export default function Title({ info, noExpander }: TitleProps) {
     );
   } else {
     const status = info.properties.status?.[0].value ?? 'DRAFT';
-
+    const terminologyType =
+      info.properties.terminologyType?.[0].value ?? 'TERMINOLOGICAL_VOCABULARY';
     const contributor =
       getPropertyValue({
         property: getProperty('prefLabel', info.references.contributor),
@@ -69,12 +77,16 @@ export default function Title({ info, noExpander }: TitleProps) {
           {title}
         </Heading>
 
-        <StatusChip
-          valid={status === 'VALID' ? 'true' : undefined}
-          id="status-chip"
-        >
-          {translateStatus(status, t)}
-        </StatusChip>
+        <TitleTypeAndStatusWrapper>
+          <TitleType>{translateTerminologyType(terminologyType, t)}</TitleType>{' '}
+          &middot;
+          <StatusChip
+            valid={status === 'VALID' ? 'true' : undefined}
+            id="status-chip"
+          >
+            {translateStatus(status, t)}
+          </StatusChip>
+        </TitleTypeAndStatusWrapper>
 
         {!noExpander && <InfoExpander data={info} />}
       </TitleWrapper>

--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Heading, Text } from 'suomifi-ui-components';
+import { Heading } from 'suomifi-ui-components';
 import {
   Contributor,
   Description,
@@ -22,9 +22,7 @@ import NewTerminology from '@app/modules/new-terminology';
 import {
   translateStatus,
   translateTerminologyType,
-  translateTermType,
 } from '@app/common/utils/translation-helpers';
-import { Badge, BadgeBar, MainTitle } from '../title-block';
 
 interface TitleProps {
   info: string | VocabularyInfoDTO;

--- a/src/common/utils/hooks/use-url-state/index.ts
+++ b/src/common/utils/hooks/use-url-state/index.ts
@@ -79,7 +79,15 @@ function updateURLState(router: NextRouter, state?: UrlState): void {
       pathname: router.pathname,
       query: {
         ...otherQueryParameters,
-        ...buildUrlStatePatch({ ...initialUrlState, ...state }),
+        ...buildUrlStatePatch({
+          // ...initialUrlState,
+          ...{
+            ...initialUrlState,
+            type:
+              typeof type === 'string' ? type.toString() : initialUrlState.type,
+          },
+          ...state,
+        }),
       },
     },
     undefined,

--- a/src/common/utils/hooks/use-url-state/index.ts
+++ b/src/common/utils/hooks/use-url-state/index.ts
@@ -80,7 +80,6 @@ function updateURLState(router: NextRouter, state?: UrlState): void {
       query: {
         ...otherQueryParameters,
         ...buildUrlStatePatch({
-          // ...initialUrlState,
           ...{
             ...initialUrlState,
             type:

--- a/src/common/utils/hooks/use-url-state/use-url-state.test.ts
+++ b/src/common/utils/hooks/use-url-state/use-url-state.test.ts
@@ -74,7 +74,7 @@ describe('useUrlState', () => {
     expect(isInitial(result.current.urlState, 'page')).toBeTruthy();
   });
 
-  it('resetUrlState clears query parameters', () => {
+  it('resetUrlState clears query parameters', async () => {
     mockRouter.setCurrentUrl({
       pathname: '/',
       query: {
@@ -93,7 +93,9 @@ describe('useUrlState', () => {
 
     expect(singletonRouter).toStrictEqual(
       expect.objectContaining({
-        query: {},
+        query: {
+          type: 'type-query-param',
+        },
       })
     );
   });


### PR DESCRIPTION
Changes in this PR:
- Suomi.fi logo in the footer resized to be smaller
- Terminology type (either terminological or other terminology) is shown in terminology title next to terminology status badge
- Filtering with language adds chosen language to badges where other active filters are
- Text added to filter badge block when there are no active filters
- Fixed font styling in a few places (filter title for example)
- Displaying collections in terminology isn't considered to be a active filter value anymore e.g. resetting filter button does not appear when collections are selected. Filtering works otherwise in the same way but changing between collections and concepts is done manually by user always.