### PR TITLE
Fixed error with moving to related concept page

### DIFF
--- a/src/modules/collection/index.tsx
+++ b/src/modules/collection/index.tsx
@@ -180,36 +180,25 @@ export default function Collection({
                 extra={
                   <BasicBlockExtraWrapper>
                     <EditToolsBlock>
-                      {HasPermission({
-                        actions: 'EDIT_COLLECTION',
-                        targetOrganization: terminology?.references.contributor,
-                      }) && (
-                        <Link href={`${router.asPath}/edit`}>
-                          <Button
-                            variant="secondary"
-                            icon="edit"
-                            id="edit-collection-button"
-                          >
-                            {t('edit-collection')}
-                          </Button>
-                        </Link>
-                      )}
-                      {HasPermission({
-                        actions: 'DELETE_COLLECTION',
-                        targetOrganization: terminology?.references.contributor,
-                      }) && (
-                        <>
-                          <RemovalModal
-                            nonDescriptive={true}
-                            removalData={{
-                              type: 'collection',
-                              data: collection,
-                            }}
-                            targetId={collection?.id ?? ''}
-                            targetName={prefLabel}
-                          />
-                        </>
-                      )}
+                      <Link href={`${router.asPath}/edit`}>
+                        <Button
+                          variant="secondary"
+                          icon="edit"
+                          id="edit-collection-button"
+                        >
+                          {t('edit-collection')}
+                        </Button>
+                      </Link>
+
+                      <RemovalModal
+                        nonDescriptive={true}
+                        removalData={{
+                          type: 'collection',
+                          data: collection,
+                        }}
+                        targetId={collection?.id ?? ''}
+                        targetName={prefLabel}
+                      />
                     </EditToolsBlock>
                   </BasicBlockExtraWrapper>
                 }

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -217,33 +217,24 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
                 extra={
                   <BasicBlockExtraWrapper>
                     <EditToolsBlock>
-                      {HasPermission({
-                        actions: ['EDIT_CONCEPT'],
-                        targetOrganization: terminology?.references.contributor,
-                      }) && (
-                        <Link
-                          href={`/terminology/${terminologyId}/concept/${conceptId}/edit`}
+                      <Link
+                        href={`/terminology/${terminologyId}/concept/${conceptId}/edit`}
+                      >
+                        <Button
+                          variant="secondary"
+                          icon="edit"
+                          id="edit-concept-button"
                         >
-                          <Button
-                            variant="secondary"
-                            icon="edit"
-                            id="edit-concept-button"
-                          >
-                            {t('edit-concept')}
-                          </Button>
-                        </Link>
-                      )}
-                      {HasPermission({
-                        actions: ['DELETE_CONCEPT'],
-                        targetOrganization: terminology?.references.contributor,
-                      }) && (
-                        <RemovalModal
-                          nonDescriptive={true}
-                          removalData={{ type: 'concept', data: concept }}
-                          targetId={concept?.id ?? ''}
-                          targetName={prefLabel}
-                        />
-                      )}
+                          {t('edit-concept')}
+                        </Button>
+                      </Link>
+
+                      <RemovalModal
+                        nonDescriptive={true}
+                        removalData={{ type: 'concept', data: concept }}
+                        targetId={concept?.id ?? ''}
+                        targetName={prefLabel}
+                      />
                     </EditToolsBlock>
                   </BasicBlockExtraWrapper>
                 }


### PR DESCRIPTION
YTI-2187
Changes in this PR:
- Removed unnecessary permission check that caused an error to occur in concept page when accessing it through an internal link. This has been fixed in collection page as well.