### PR TITLE
YTI-2196: remove contributor from terminology and concept

### DIFF
--- a/src/common/components/title/title.tsx
+++ b/src/common/components/title/title.tsx
@@ -61,16 +61,9 @@ export default function Title({ info, noExpander }: TitleProps) {
     const status = info.properties.status?.[0].value ?? 'DRAFT';
     const terminologyType =
       info.properties.terminologyType?.[0].value ?? 'TERMINOLOGICAL_VOCABULARY';
-    const contributor =
-      getPropertyValue({
-        property: getProperty('prefLabel', info.references.contributor),
-        language: i18n.language,
-      }) ?? '';
 
     return (
       <TitleWrapper id="page-title-block">
-        <Contributor id="contributor">{contributor}</Contributor>
-
         <Heading variant="h1" tabIndex={-1} id="page-title">
           {title}
         </Heading>

--- a/src/modules/concept/index.tsx
+++ b/src/modules/concept/index.tsx
@@ -141,14 +141,6 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
       <PageContent $breakpoint={breakpoint}>
         <MainContent id="main">
-          <SubTitle>
-            <PropertyValue
-              property={getProperty(
-                'prefLabel',
-                terminology?.references.contributor
-              )}
-            />
-          </SubTitle>
           <MainTitle>{prefLabel}</MainTitle>
           <BadgeBar>
             {t('heading')}


### PR DESCRIPTION
Removed the top bar contributor from both terminology and concept page as its shown afterwards and didnt show all contributors

![concept--no-cont](https://user-images.githubusercontent.com/19401683/198506403-cbe941c6-84bd-4779-8f64-60d1e2594ae8.png)
![terminology-no-cont](https://user-images.githubusercontent.com/19401683/198506423-b9d0dad0-4601-45b8-aceb-847abca6f72f.png)
