### PR TITLE
Axios response type added to excel download

### DIFF
--- a/src/common/components/info-dropdown/info-expander.tsx
+++ b/src/common/components/info-dropdown/info-expander.tsx
@@ -70,7 +70,8 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
 
   const handleDownloadClick = async () => {
     const result = await axios.get(
-      `/terminology-api/api/v1/export/${data.type.graph.id}?format=xlsx`
+      `/terminology-api/api/v1/export/${data.type.graph.id}?format=xlsx`,
+      { responseType: 'arraybuffer' }
     );
 
     if (result.status !== 200) {


### PR DESCRIPTION
Changes in this PR:
- Response type changed to array buffer in terminology download to fix bug where `.xlsx` would be corrupted