### PR TITLE
YTI-2210: relational concepts stay checked

### DIFF
--- a/terminology-ui/src/common/components/relational-information-block/relational-modal-content.tsx
+++ b/terminology-ui/src/common/components/relational-information-block/relational-modal-content.tsx
@@ -43,7 +43,6 @@ export default function RelationModalContent({
   >();
   const [totalResults, setTotalResults] = useState(0);
   const [currPage, setCurrPage] = useState(1);
-  const [initialized, setInitialized] = useState(false);
   const modalRef = createRef<HTMLDivElement>();
 
   const statuses: StatusesType[] = [
@@ -136,23 +135,13 @@ export default function RelationModalContent({
     if (result.isSuccess) {
       setSearchResults(result.data.concepts);
       setTotalResults(result.data.totalHitCount);
-      if (!initialized) {
-        setChosen(
-          result.data.concepts.filter((c) =>
-            initialChosenConcepts.includes(c.id)
-          )
-        );
-        setInitialized(true);
-      }
     }
   }, [
     setSearchResults,
     setTotalResults,
-    setChosen,
     fromOther,
     result,
     initialChosenConcepts,
-    initialized,
   ]);
 
   useMountEffect(handleSearch, fromOther);


### PR DESCRIPTION
Changelog: 
 - don't set selectedConcepts when doing a first search.
 - selectedConcepts stay the same and the UI knows to check the checkboxes anyway