### PR TITLE
Pass Shibboleth session cookie to API calls in SSR

### DIFF
--- a/terminology-ui/src/pages/api/auth/logout.ts
+++ b/terminology-ui/src/pages/api/auth/logout.ts
@@ -5,11 +5,16 @@ export default withIronSessionApiRoute(
   async function logout(req, res) {
     const target = (req.query['target'] as string) ?? '/';
 
-    // invalidate cookie
-    res.setHeader(
-      'Set-Cookie',
-      'JSESSIONID=deleted; path=/terminology-api; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-    );
+    // invalidate:
+    // * JSESSIONID
+    // * all Shibboleth session cookies
+    res.setHeader('Set-Cookie', [
+      'JSESSIONID=deleted; path=/terminology-api; expires=Thu, 01 Jan 1970 00:00:00 GMT',
+      ...Object.entries(req.cookies)
+        .filter(([k, _]) => k.startsWith('_shibsession_'))
+        .map(([k, _]) =>
+          `${k}=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`),
+    ]);
 
     req.session.destroy();
     res.redirect(target);

--- a/terminology-ui/src/store/api-base-query.ts
+++ b/terminology-ui/src/store/api-base-query.ts
@@ -26,9 +26,49 @@ export const getTerminologyApiBaseQuery = (
         }
       }
 
+      // Additionally, if the browser provided us with _shibsession_..., pass
+      // it to the request as well. This helps with cases where JSESSIONID
+      // isn't enough for the spring API.
+      if ('req' in ctx && ctx.req && 'cookies' in ctx.req) {
+        const shibCookies = Object
+          .keys(ctx.req.cookies)
+          .filter((x) => x.startsWith('_shibsession'));
+
+        for (const key of shibCookies) {
+          const val = ctx.req.cookies[key];
+          if (val !== undefined) {
+            cookies[key] = val;
+          }
+        }
+      }
+
       let headers: AxiosRequestHeaders = {
         'content-type': 'application/json',
       };
+
+      // X-Forwarded-For needs to match client requests or Shibboleth will
+      // invalidate the session
+      if ('req' in ctx &&
+        ctx.req && 'headers' in ctx.req &&
+        ctx.req.headers['x-forwarded-for'] !== undefined
+      ) {
+        const hdr = Array.isArray(ctx.req.headers['x-forwarded-for']) ?
+          ctx.req.headers['x-forwarded-for'][0] :
+          ctx.req.headers['x-forwarded-for'];
+        headers['X-Forwarded-For'] = hdr;
+      }
+
+      // Host needs to match client requests or Shibboleth will
+      // invalidate the session
+      if ('req' in ctx &&
+        ctx.req && 'headers' in ctx.req &&
+        ctx.req.headers['host'] !== undefined
+      ) {
+        const hdr = Array.isArray(ctx.req.headers['host']) ?
+          ctx.req.headers['host'][0] :
+          ctx.req.headers['host'];
+        headers['Host'] = hdr;
+      }
 
       // prepare cookie header; this should only happen in SSR, since ctx.req
       // is empty on browser

--- a/terminology-ui/src/tests/login.test.ts
+++ b/terminology-ui/src/tests/login.test.ts
@@ -59,6 +59,7 @@ describe('api endpoint - login', () => {
   it('callback on success', async () => {
     const targetPath = '/testable-target-path';
 
+    // simulate arrival to callback.ts from Shibboleth
     const req = createRequest<ApiRequest>({
       method: 'GET',
       query: {
@@ -69,16 +70,20 @@ describe('api endpoint - login', () => {
         'X-Forwarded-For': '127.0.0.42',
       },
       cookies: {
+        // shibsession like it would've been set by /Shibboleth.sso/SAML2/POST
         _shibsession_123: 'foo',
       },
     });
     const res = createResponse<ApiResponse>();
 
+    // callback will call authenticated-user for user details
     mock
       .onGet(
         'http://auth-proxy.invalid/terminology-api/api/v1/frontend/authenticated-user'
       )
-      .reply(200, fakeUser, { 'set-cookie': ['JSESSIONID=foo'] });
+      .reply(200, fakeUser, {
+        'set-cookie': [ 'JSESSIONID=foo' ]
+      });
 
     await callback(req, res);
 
@@ -91,6 +96,7 @@ describe('api endpoint - login', () => {
     const jsessionid = setCookies.find((x: string) =>
       x.startsWith('JSESSIONID=')
     );
+
     expect(jsessionid).toBeDefined();
     expect(jsessionid).toBe('JSESSIONID=foo');
 


### PR DESCRIPTION
This is to work around an issue where JSESSIONID is sometimes not enough.
