### PR TITLE
YTI-2178 Shibboleth fake login

### DIFF
--- a/terminology-ui/src/pages/api/auth/callback.ts
+++ b/terminology-ui/src/pages/api/auth/callback.ts
@@ -79,23 +79,17 @@ export default withIronSessionApiRoute(
       // Pass the cookie from the api to the client.
       // This works since the API is already in the same domain,
       // just has a more specific Path set
-      const jsessionid = (response.headers['set-cookie'] as string[]).filter(
-        (x) => x.startsWith('JSESSIONID=')
-      );
-      if (jsessionid.length > 0) {
-        res.setHeader('Set-Cookie', jsessionid);
-      } else {
-        console.warn('No JSESSIONID found in response');
-      }
+      if (response.headers['set-cookie']) {
 
-      // Collect cookies from Set-Cookie into an object.
-      // These will be saved in the session for later use.
-      (response.headers['set-cookie'] as string[])
-        .map((x) => x.split(';')[0])
-        .forEach((x) => {
-          const [key, value] = x.split('=');
-          cookies[key] = value;
-        });
+        // Collect cookies from Set-Cookie into an object.
+        // These will be saved in the session for later use.
+        (response.headers['set-cookie'] as string[])
+          .map((x) => x.split(';')[0])
+          .forEach((x) => {
+            const [key, value] = x.split('=');
+            cookies[key] = value;
+          });
+      }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         // handleAxiosError(error);

--- a/terminology-ui/src/pages/api/auth/fake-login.ts
+++ b/terminology-ui/src/pages/api/auth/fake-login.ts
@@ -10,6 +10,8 @@ export default withIronSessionApiRoute(
       return;
     }
 
+    const withAuthProxy = process.env.TERMINOLOGY_API_URL?.includes('yti-auth-proxy');
+
     let user: User | null = null;
     const cookies: { [key: string]: string } = {};
     const target = (req.query['target'] as string) ?? '/';
@@ -20,12 +22,28 @@ export default withIronSessionApiRoute(
         process.env.TERMINOLOGY_API_URL + '/api/v1/frontend/authenticated-user';
       fetchUrl += '?fake.login.mail=' + encodeURIComponent(email);
 
+      let authProxyHeaders = {};
+
+      if (withAuthProxy) {
+        const forwardedFor = req.headers['x-forwarded-for'] as string;
+        const host = req.headers['host'] as string;
+
+        authProxyHeaders = {
+          Host: host,
+          'X-Forwarded-For': forwardedFor,
+        };
+      }
+
       const response = await axios.get(fetchUrl, {
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...authProxyHeaders,
+        },
       });
 
       // should receive a fake user on success
       user = response.data;
+
       if (user && user.anonymous) {
         console.warn(
           'User from response appears to be anonymous, login may have failed'


### PR DESCRIPTION
- Add `host` and `x-forwarded-for` headers for shibboleth if using yti-auth-proxy
- Do not add `JSESSIONID` cookie to response when using eDuuni login