### PR TITLE
Improved language versioned data fetching

### DIFF
--- a/datamodel-ui/src/common/utils/get-language-version.ts
+++ b/datamodel-ui/src/common/utils/get-language-version.ts
@@ -4,7 +4,7 @@ interface getLanguageVersionProps {
   appendLocale?: boolean;
 }
 
-export default function getLanguageVersion({
+export function getLanguageVersion({
   data,
   lang,
   appendLocale = false,
@@ -24,6 +24,48 @@ export default function getLanguageVersion({
   if (Object.keys(data).length > 0) {
     const localeKey = Object.keys(data)[0];
     return appendLocale ? `${data[localeKey]} (${localeKey})` : data[localeKey];
+  }
+
+  return '';
+}
+
+interface getPropertyLanguageVersionProps {
+  data: {
+    '@language': string;
+    '@value': string;
+  }[];
+  lang: string;
+  appendLocale?: boolean;
+}
+
+export function getPropertyLanguageVersion({
+  data,
+  lang,
+  appendLocale,
+}: getPropertyLanguageVersionProps) {
+  if (!data) {
+    return '';
+  }
+
+  if (data.some((d) => d['@language'] === lang)) {
+    const retObject = data.find((d) => d['@language'] === lang);
+
+    return retObject ? retObject['@value'] : '';
+  }
+
+  if (data.some((d) => d['@language'] === 'fi')) {
+    const retObject = data.find((d) => d['@language'] === 'fi');
+    const retValue = retObject ? retObject['@value'] : '';
+
+    return appendLocale ? `${retValue} (fi)` : retValue;
+  }
+
+  if (data.length > 0) {
+    const localeKey = data[0]['@language'];
+    const retObject = data.find((d) => d['@language'] === localeKey);
+    const retValue = retObject ? retObject['@value'] : '';
+
+    return appendLocale ? `${retValue} (${localeKey})` : retValue;
   }
 
   return '';

--- a/datamodel-ui/src/common/utils/get-language-version.ts
+++ b/datamodel-ui/src/common/utils/get-language-version.ts
@@ -30,7 +30,7 @@ export function getLanguageVersion({
 }
 
 interface getPropertyLanguageVersionProps {
-  data: {
+  data?: {
     '@language': string;
     '@value': string;
   }[];

--- a/datamodel-ui/src/modules/front-page/front-page-filter.tsx
+++ b/datamodel-ui/src/modules/front-page/front-page-filter.tsx
@@ -1,5 +1,6 @@
 import { Organizations } from '@app/common/interfaces/organizations.interface';
 import { ServiceCategories } from '@app/common/interfaces/serviceCategories.interface';
+import { getPropertyLanguageVersion } from '@app/common/utils/get-language-version';
 import { useTranslation } from 'next-i18next';
 import { SingleSelectData } from 'suomifi-ui-components';
 import Filter, {
@@ -51,10 +52,11 @@ export default function FrontPageFilter({
         organizations={
           organizations?.['@graph']
             .map((org) => ({
-              labelText:
-                org.prefLabel?.filter(
-                  (l) => l['@language'] === i18n.language
-                )[0]['@value'] ?? '',
+              labelText: getPropertyLanguageVersion({
+                data: org.prefLabel,
+                lang: i18n.language,
+                appendLocale: true,
+              }),
               uniqueItemId: org['@id'],
             }))
             .sort((x, y) => x.labelText.localeCompare(y.labelText)) ?? []

--- a/datamodel-ui/src/modules/front-page/front-page-filter.tsx
+++ b/datamodel-ui/src/modules/front-page/front-page-filter.tsx
@@ -118,11 +118,11 @@ export default function FrontPageFilter({
           serviceCategories?.['@graph']
             .map((g) => ({
               id: g['@id'],
-              name: g.label
-                ? g.label.filter(
-                    (l) => (l['@language'] ?? '') === i18n.language
-                  )?.[0]?.['@value']
-                : '',
+              name: getPropertyLanguageVersion({
+                data: g.label,
+                lang: i18n.language,
+                appendLocale: true,
+              }),
             }))
             .sort((x, y) => x.name.localeCompare(y.name)) ?? []
         }

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -13,7 +13,7 @@ import SearchResults, {
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { useGetSearchModelsQuery } from '@app/common/components/searchModels/searchModels.slice';
-import getLanguageVersion from '@app/common/utils/get-language-version';
+import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import { Modal, ModalContent, SingleSelectData } from 'suomifi-ui-components';
 import useUrlState from 'yti-common-ui/utils/hooks/use-url-state';

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -13,7 +13,10 @@ import SearchResults, {
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { useGetSearchModelsQuery } from '@app/common/components/searchModels/searchModels.slice';
-import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import {
+  getLanguageVersion,
+  getPropertyLanguageVersion,
+} from '@app/common/utils/get-language-version';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import { Modal, ModalContent, SingleSelectData } from 'suomifi-ui-components';
 import useUrlState from 'yti-common-ui/utils/hooks/use-url-state';
@@ -59,24 +62,23 @@ export default function FrontPage() {
 
     return searchModels.models.map((m) => {
       const contributors: string[] = m.contributor
-        .map(
-          (c) =>
-            organizations?.['@graph']
-              .find((o) => o['@id'].replace('urn:uuid:', '') === c)
-              ?.prefLabel?.filter(
-                (l) => (l['@language'] ?? '') === i18n.language
-              )?.[0]?.['@value'] ?? ''
+        .map((c) =>
+          getPropertyLanguageVersion({
+            data: organizations?.['@graph'].find(
+              (o) => o['@id'].replace('urn:uuid:', '') === c
+            )?.prefLabel,
+            lang: i18n.language,
+          })
         )
         .filter((c) => c.length > 0);
 
       const partOf: string[] = m.isPartOf
-        .map(
-          (p) =>
-            serviceCategories?.['@graph']
-              .find((c) => c.identifier === p)
-              ?.label.filter(
-                (l) => (l['@language'] ?? '') === i18n.language
-              )?.[0]?.['@value'] ?? ''
+        .map((p) =>
+          getPropertyLanguageVersion({
+            data: serviceCategories?.['@graph'].find((c) => c.identifier === p)
+              ?.label,
+            lang: i18n.language,
+          })
         )
         .filter((p) => p.length > 0);
 


### PR DESCRIPTION
Changes in this PR:
- `getPropertyLanguageVersion()` added to get different language versioned values from a JSON-LD type property. This fixes the bug in front page when user changed language to English and some organization didn't have a name defined in that language