### PR TITLE
YTI-2242: Enable husky and set it up for all monorepo projects

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,13 @@
 #!/usr/bin/env sh
-#. "$(dirname -- "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
-#npm run lint-staged
+cd terminology-ui
+npm run lint-staged
+
+cd ..
+cd datamodel-ui
+npm run lint-staged
+
+cd ..
+cd common-ui
+npm run lint-staged

--- a/common-ui/.lintstagedrc.js
+++ b/common-ui/.lintstagedrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // prettier
+  '**/*.{ts,tsx,js,jsx,md,json,scss,css}': `prettier --check`,
+};

--- a/common-ui/package.json
+++ b/common-ui/package.json
@@ -20,13 +20,15 @@
     "@types/react-dom": "18.0.6",
     "react-modal": "^3.15.1",
     "react-scripts": "5.0.1",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "lint-staged": "^13.0.3"
   },
   "scripts": {
     "build": "react-scripts build",
     "test": "TZ=UTC jest --watch",
     "eject": "react-scripts eject",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "lint-staged": "lint-staged"
   },
   "dependencies": {
     "usehooks-ts": "^2.9.1"

--- a/datamodel-ui/.lintstagedrc.js
+++ b/datamodel-ui/.lintstagedrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // next lint (eslint)
+  '**/*.{js,jsx,ts,tsx}': (filenames) => [
+    `next lint --file ${filenames.join(' --file ')}`,
+  ],
+
+  // prettier
+  '**/*.{ts,tsx,js,jsx,md,json,scss,css}': `prettier --check`,
+};

--- a/datamodel-ui/package.json
+++ b/datamodel-ui/package.json
@@ -11,7 +11,8 @@
     "test": "TZ=UTC jest",
     "test:watch": "TZ=UTC jest --watch",
     "test:ci": "TZ=UTC jest --ci --runInBand --coverage",
-    "test:ci:no-coverage": "TZ=UTC jest --ci --runInBand"
+    "test:ci:no-coverage": "TZ=UTC jest --ci --runInBand",
+    "lint-staged": "lint-staged"
   },
   "dependencies": {
     "@fontsource/source-sans-pro": "^4.5.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
         "common-ui",
         "datamodel-ui",
         "terminology-ui"
-      ]
+      ],
+      "devDependencies": {
+        "husky": "^8.0.0"
+      }
     },
     "common-ui": {
       "name": "yti-common-ui",
@@ -23,6 +26,7 @@
         "@types/node": "^16.11.6",
         "@types/react": "17.0.30",
         "@types/react-dom": "18.0.6",
+        "lint-staged": "^13.0.3",
         "react-modal": "^3.15.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.7.2"
@@ -10465,6 +10469,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {
@@ -28400,6 +28419,12 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "husky": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "dev": true
+    },
     "i18next": {
       "version": "21.10.0",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
@@ -35837,6 +35862,7 @@
         "@types/node": "^16.11.6",
         "@types/react": "17.0.30",
         "@types/react-dom": "18.0.6",
+        "lint-staged": "^13.0.3",
         "react-modal": "^3.15.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "yhteentoimiva-monorepo",
   "private": true,
+  "scripts": {
+    "prepare": "husky install"
+  },
   "workspaces": [
     "common-ui",
     "datamodel-ui",
     "terminology-ui"
-  ]
+  ],
+  "devDependencies": {
+    "husky": "^8.0.0"
+  }
 }


### PR DESCRIPTION
Changelog:
 - husky install onto monorepo base
 - lint-staged into all project folders (terminology-ui already added from before)
 - next lint and prettier on datamodel (terminology already had)
 - prettier on common-ui (next lint requires pages folder, is it possible to ignore this issue somehow?)
 - added all project folders into husky pre-commit