### PR TITLE
Email validation added

### DIFF
--- a/terminology-ui/public/locales/en/admin.json
+++ b/terminology-ui/public/locales/en/admin.json
@@ -22,6 +22,7 @@
   "alert-description-languages-undefined": "Terminology description is undefined",
   "alert-description-name-undefined": "Terminology name is undefined in",
   "alert-information-domain-undefined": "Information domains is undefined",
+  "alert-invalid-email": "Invalid email",
   "alert-no-status": "Terminology status is undefined",
   "alert-org-undefined": "Contributors is undefined",
   "alert-prefix-invalid-or-in-use": "Prefix is in invalid form or prefix is already in use",

--- a/terminology-ui/public/locales/fi/admin.json
+++ b/terminology-ui/public/locales/fi/admin.json
@@ -22,6 +22,7 @@
   "alert-description-languages-undefined": "Sanaston kieliä ei ole määritelty",
   "alert-description-name-undefined": "Sanaston nimi puuttuu kieleltä",
   "alert-information-domain-undefined": "Tietoaluetta ei ole määritelty",
+  "alert-invalid-email": "Sähköpostiosoite on virheellinen",
   "alert-no-status": "Sanaston tilaa ei ole määritetty",
   "alert-org-undefined": "Sisällöntuottajia ei ole määritelty",
   "alert-prefix-invalid-or-in-use": "Tunnus ei oikeassa muodossa tai se on jo käytössä",

--- a/terminology-ui/public/locales/sv/admin.json
+++ b/terminology-ui/public/locales/sv/admin.json
@@ -22,6 +22,7 @@
   "alert-description-languages-undefined": "",
   "alert-description-name-undefined": "",
   "alert-information-domain-undefined": "",
+  "alert-invalid-email": "",
   "alert-no-status": "",
   "alert-org-undefined": "",
   "alert-prefix-invalid-or-in-use": "",

--- a/terminology-ui/src/common/components/terminology-components/contact-info.tsx
+++ b/terminology-ui/src/common/components/terminology-components/contact-info.tsx
@@ -50,6 +50,13 @@ export default function ContactInfo({
         maxLength={EMAIL_MAX}
         id="contact-input"
         disabled={disabled}
+        status={
+          userPosted &&
+          contact !== '' &&
+          contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
+            ? 'error'
+            : 'default'
+        }
       />
     </BlankFieldset>
   );

--- a/terminology-ui/src/modules/new-terminology/info-manual.tsx
+++ b/terminology-ui/src/modules/new-terminology/info-manual.tsx
@@ -46,8 +46,11 @@ export default function InfoManual({
       valid = false;
     } else {
       Object.entries(terminologyData).forEach(([key, value]) => {
-        if (key === 'contact') {
-          return;
+        if (
+          key === 'contact' &&
+          value.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
+        ) {
+          valid = false;
         }
 
         if (!value || value.length < 1 || value[1] === false) {

--- a/terminology-ui/src/modules/new-terminology/missing-info-alert.tsx
+++ b/terminology-ui/src/modules/new-terminology/missing-info-alert.tsx
@@ -10,6 +10,7 @@ interface MissingInfoAlertProps {
 export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
   const { t } = useTranslation('admin');
   const render = renderAlert();
+
   if (!data || !render) {
     return null;
   }
@@ -23,6 +24,7 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
           renderInformationDomainAlerts(),
           renderPrefixAlerts(),
           renderStatusAlerts(),
+          renderContactAlerts(),
         ].filter((alert) => alert)}
       />
     );
@@ -38,7 +40,10 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
       data.infoDomains.length === 0 ||
       !data.prefix[0] ||
       data.prefix[1] === false ||
-      (Object.keys(data).includes('status') && !data.status)
+      (Object.keys(data).includes('status') && !data.status) ||
+      (data.contact &&
+        data.contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) ===
+          null)
     ) {
       return true;
     }
@@ -95,6 +100,17 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
   function renderStatusAlerts(): string {
     if (Object.keys(data).includes('status') && !data.status) {
       return t('alert-no-status');
+    }
+
+    return '';
+  }
+
+  function renderContactAlerts(): string {
+    if (
+      data.contact &&
+      data.contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
+    ) {
+      return t('alert-invalid-email');
     }
 
     return '';


### PR DESCRIPTION
Changes in this PR:
- Email validation added to new terminology creation modal
  - If email isn't present the fallback value is used and email is considered valid. Otherwise the input text is checked to be a valid email