### PR TITLE
v2 env tag added to possible direct internal links

### DIFF
--- a/terminology-ui/src/common/components/sanitized-text-content/index.tsx
+++ b/terminology-ui/src/common/components/sanitized-text-content/index.tsx
@@ -26,12 +26,11 @@ export default function SanitizedTextContent({
       !node.getAttribute('href')?.includes('script')
     ) {
       if (internalTypes.includes(node.getAttribute('data-type') as string)) {
+        const url = node.getAttribute('href') ?? '';
         return (
           <Link
             passHref
-            href={`/terminology-api/api/v1/resolve?uri=${node.getAttribute(
-              'href'
-            )}`}
+            href={url?.includes('uri.suomi.fi') ? `${url}&env=env_v2` : url}
           >
             <SuomiInternalLink href="">{children}</SuomiInternalLink>
           </Link>


### PR DESCRIPTION
Changes in this PR:
- `env=env_v2` added as suffix to links that directly target concept's URI instead of the path