### PR TITLE
Tweaked SearchInput and fixed desc in ResultCard

### DIFF
--- a/common-ui/components/filter/status-filter-radio.tsx
+++ b/common-ui/components/filter/status-filter-radio.tsx
@@ -25,7 +25,9 @@ export default function StatusFilterRadio({
         });
       }}
       radioButtonVariant={isModal ? 'large' : 'small'}
-      selectedItem={urlState.status.length < 1 ? 'VALID,DRAFT' : urlState.status.join(',')}
+      selectedItem={
+        urlState.status.length < 1 ? 'VALID,DRAFT' : urlState.status.join(',')
+      }
     />
   );
 }

--- a/common-ui/components/search-results/result-card.tsx
+++ b/common-ui/components/search-results/result-card.tsx
@@ -71,9 +71,13 @@ export default function ResultCard({
         {status && renderStatus()}
       </Subtitle>
       <Description id="card-description">
-        {description && description.length > 0
-          ? description
-          : noDescriptionText}
+        <SanitizedTextContent
+          text={
+            description && description.length > 0
+              ? description
+              : noDescriptionText
+          }
+        />
       </Description>
       {partOf && (
         <PartOf id="card-partof">

--- a/common-ui/components/search-results/search-count-tags.tsx
+++ b/common-ui/components/search-results/search-count-tags.tsx
@@ -101,12 +101,17 @@ export default function SearchCountTags({
   function renderStatusTags() {
     return ['valid', 'draft', 'retired', 'superseded', 'invalid']
       .map((status) => {
-        if (urlState.status.includes(status) || urlState.status.includes(status.toUpperCase())) {
+        if (
+          urlState.status.includes(status) ||
+          urlState.status.includes(status.toUpperCase())
+        ) {
           return (
             <Tag
               onRemove={() =>
                 patchUrlState({
-                  status: urlState.status.filter((s) => s !== status && s !== status.toUpperCase()),
+                  status: urlState.status.filter(
+                    (s) => s !== status && s !== status.toUpperCase()
+                  ),
                 })
               }
               key={status}

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -38,27 +38,27 @@ interface SearchResultsProps {
   tagsTitle: string;
   tagsHiddenTitle: string;
   extra?:
-  | {
-    expander: {
-      buttonLabel: string;
-      contentLabel: string;
-      deepHits: {
-        [key: string]: {
-          label: string;
-          id: string;
-          uri?: string;
-        }[];
+    | {
+        expander: {
+          buttonLabel: string;
+          contentLabel: string;
+          deepHits: {
+            [key: string]: {
+              label: string;
+              id: string;
+              uri?: string;
+            }[];
+          };
+        };
+      }
+    | {
+        other: {
+          title: string;
+          items: {
+            [key: string]: string;
+          };
+        };
       };
-    };
-  }
-  | {
-    other: {
-      title: string;
-      items: {
-        [key: string]: string;
-      };
-    };
-  };
 }
 
 export default function SearchResults({
@@ -108,21 +108,21 @@ export default function SearchResults({
                 extra &&
                 ('expander' in extra
                   ? extra.expander.deepHits[d.id] && (
-                    <ResultCardExpander
-                      buttonLabel={extra.expander.buttonLabel}
-                      contentLabel={extra.expander.contentLabel}
-                      deepHits={extra.expander.deepHits[d.id]}
-                    />
-                  )
+                      <ResultCardExpander
+                        buttonLabel={extra.expander.buttonLabel}
+                        contentLabel={extra.expander.contentLabel}
+                        deepHits={extra.expander.deepHits[d.id]}
+                      />
+                    )
                   : extra.other.items[d.id] && (
-                    <>
-                      <CardConcepts value={extra.other.title}>
-                        <SanitizedTextContent
-                          text={extra.other.items[d.id]}
-                        />
-                      </CardConcepts>
-                    </>
-                  ))
+                      <>
+                        <CardConcepts value={extra.other.title}>
+                          <SanitizedTextContent
+                            text={extra.other.items[d.id]}
+                          />
+                        </CardConcepts>
+                      </>
+                    ))
               }
             />
           );

--- a/terminology-ui/src/common/components/relational-information-block/search.tsx
+++ b/terminology-ui/src/common/components/relational-information-block/search.tsx
@@ -38,12 +38,24 @@ export default function Search({
   return (
     <SearchBlock id="search-block" $isSmall={isSmall}>
       <div>
+        {/*
+         * This component has both onSearch and onKeyPressDownCapture intentionally.
+         *
+         * onSearch does not call handleSearch() when text value is empty so
+         * onKeyPressCapture handles these situations
+         */}
         <SearchInput
           labelText={t('search-term')}
           clearButtonLabel={t('clear-button-label')}
           searchButtonLabel={t('search')}
           onChange={(value) => setSearchTerm(value as string)}
           value={searchTerm}
+          onKeyPressCapture={(e) => {
+            const inputValue = e.target as HTMLInputElement;
+            if (inputValue.value === '' && e.key === 'Enter') {
+              handleSearch();
+            }
+          }}
           onSearch={() => handleSearch()}
           maxLength={TEXT_INPUT_MAX}
           id="keyword-input"


### PR DESCRIPTION
Changes in this PR:
- Enter key press call `onSearch()` even though the value is empty in relational concepts modal
- Wrapped result card description in `<SanitizedTextContent/>` to display possible links correctly