### PR TITLE
Fixed render errors

### DIFF
--- a/common-ui/components/sanitized-text-content/index.tsx
+++ b/common-ui/components/sanitized-text-content/index.tsx
@@ -26,12 +26,11 @@ export default function SanitizedTextContent({
       !node.getAttribute('href')?.includes('script')
     ) {
       if (internalTypes.includes(node.getAttribute('data-type') as string)) {
+        const url = node.getAttribute('href') ?? '';
         return (
           <Link
             passHref
-            href={`/terminology-api/api/v1/resolve?uri=${node.getAttribute(
-              'href'
-            )}`}
+            href={url?.includes('uri.suomi.fi') ? `${url}&env=env_v2` : url}
           >
             <SuomiInternalLink href="">{children}</SuomiInternalLink>
           </Link>

--- a/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
+++ b/terminology-ui/src/common/components/info-dropdown/info-expander.tsx
@@ -40,6 +40,7 @@ import { useStoreDispatch } from '@app/store';
 import { setAlert } from '../alert/alert.slice';
 import UpdateWithFileModal from '../update-with-file-modal';
 import StatusMassEdit from '../status-mass-edit';
+import isEmail from 'validator/lib/isEmail';
 
 const Subscription = dynamic(
   () => import('@app/common/components/subscription/subscription')
@@ -158,9 +159,9 @@ export default function InfoExpander({ data }: InfoExpanderProps) {
         {contact && (
           <BasicBlock title={t('contact')}>
             <ExternalLink
-              href={`mailto:${contact}?subject=${t(
-                'feedback-vocabulary'
-              )} - ${getPropertyValue({
+              href={`mailto:${
+                isEmail(contact) ? contact : 'yhteentoimivuus@dvv.fi'
+              }?subject=${t('feedback-vocabulary')} - ${getPropertyValue({
                 property: data.properties.prefLabel,
                 language: i18n.language,
               })}`}

--- a/terminology-ui/src/common/components/terminology-components/contact-info.tsx
+++ b/terminology-ui/src/common/components/terminology-components/contact-info.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'next-i18next';
 import { UpdateTerminology } from '@app/modules/new-terminology/update-terminology.interface';
 import { EMAIL_MAX } from '@app/common/utils/constants';
 import { useState } from 'react';
+import isEmail from 'validator/lib/isEmail';
 
 interface ContactInfoProps {
   update: ({ key, data }: UpdateTerminology) => void;
@@ -51,9 +52,7 @@ export default function ContactInfo({
         id="contact-input"
         disabled={disabled}
         status={
-          userPosted &&
-          contact !== '' &&
-          contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
+          userPosted && contact !== '' && !isEmail(contact)
             ? 'error'
             : 'default'
         }

--- a/terminology-ui/src/common/utils/has-permission.tsx
+++ b/terminology-ui/src/common/utils/has-permission.tsx
@@ -1,4 +1,5 @@
 import { useStoreDispatch } from '@app/store';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectAdminControls } from '../components/admin-controls/admin-controls.slice';
 import {
@@ -46,13 +47,15 @@ export default function HasPermission({
   const user = useSelector(selectLogin());
   const isAdminControlsDisabled = useSelector(selectAdminControls());
 
-  if (
-    authenticatedUser &&
-    (authenticatedUser.anonymous !== user.anonymous ||
-      authenticatedUser.username !== user.username)
-  ) {
-    dispatch(setLogin(authenticatedUser));
-  }
+  useEffect(() => {
+    if (
+      authenticatedUser &&
+      (authenticatedUser.anonymous !== user.anonymous ||
+        authenticatedUser.username !== user.username)
+    ) {
+      dispatch(setLogin(authenticatedUser));
+    }
+  }, [authenticatedUser, dispatch, user]);
 
   if (isAdminControlsDisabled) {
     return false;

--- a/terminology-ui/src/modules/new-terminology/info-manual.tsx
+++ b/terminology-ui/src/modules/new-terminology/info-manual.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'next-i18next';
 import { TerminologyDataInitialState } from './terminology-initial-state';
 import { UpdateTerminology } from './update-terminology.interface';
 import StatusSelector from './status-selector';
+import isEmail from 'validator/lib/isEmail';
 
 interface InfoManualProps {
   setIsValid: (valid: boolean) => void;
@@ -46,10 +47,7 @@ export default function InfoManual({
       valid = false;
     } else {
       Object.entries(terminologyData).forEach(([key, value]) => {
-        if (
-          key === 'contact' &&
-          value.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
-        ) {
+        if (key === 'contact' && !isEmail(value)) {
           valid = false;
         }
 

--- a/terminology-ui/src/modules/new-terminology/missing-info-alert.tsx
+++ b/terminology-ui/src/modules/new-terminology/missing-info-alert.tsx
@@ -2,6 +2,7 @@ import FormFooterAlert from '@app/common/components/form-footer-alert';
 import { NewTerminologyInfo } from '@app/common/interfaces/new-terminology-info';
 import { translateLanguage } from '@app/common/utils/translation-helpers';
 import { useTranslation } from 'next-i18next';
+import isEmail from 'validator/lib/isEmail';
 
 interface MissingInfoAlertProps {
   data: NewTerminologyInfo;
@@ -41,9 +42,7 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
       !data.prefix[0] ||
       data.prefix[1] === false ||
       (Object.keys(data).includes('status') && !data.status) ||
-      (data.contact &&
-        data.contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) ===
-          null)
+      (data.contact && !isEmail(data.contact))
     ) {
       return true;
     }
@@ -106,10 +105,7 @@ export default function MissingInfoAlert({ data }: MissingInfoAlertProps) {
   }
 
   function renderContactAlerts(): string {
-    if (
-      data.contact &&
-      data.contact.match(/^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/) === null
-    ) {
+    if (data.contact && !isEmail(data.contact)) {
       return t('alert-invalid-email');
     }
 


### PR DESCRIPTION
Changes in this PR:
- Wrapped dispatch call inside `HasPermission()` useEffect to fix render errors
- Added env tag to sanitized text like in #324 to common-ui as well. `SanitizedTextContent` could be removed in the future
- Replaced custom regex in new terminology form email validation and added a fallback email if contact information of a terminology/concept is in incorrect form