### PR TITLE
useBreakpoints() errors fixed

### DIFF
--- a/common-ui/components/media-query/index.tsx
+++ b/common-ui/components/media-query/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useMediaQuery } from 'usehooks-ts';
 import { CommonContext } from '../common-context-provider';
 
@@ -29,9 +29,19 @@ export interface UseBreakpointsResult {
 
 export function useBreakpoints(): UseBreakpointsResult {
   const { isSSRMobile } = useContext(CommonContext);
-  const matchSmall = useMediaQuery(mediaQueries.s);
-  const matchMedium = useMediaQuery(mediaQueries.m);
-  const matchLarge = useMediaQuery(mediaQueries.l);
+  const [matchSmall, setMatchSmall] = useState<boolean>(false);
+  const [matchMedium, setMatchMedium] = useState<boolean>(false);
+  const [matchLarge, setMatchLarge] = useState<boolean>(true);
+
+  const s = useMediaQuery(mediaQueries.s);
+  const m = useMediaQuery(mediaQueries.m);
+  const l = useMediaQuery(mediaQueries.l);
+
+  useEffect(() => {
+    setMatchSmall(s);
+    setMatchMedium(m);
+    setMatchLarge(l);
+  }, [s, m, l]);
 
   const isSmall = global['matchMedia'] ? matchSmall : isSSRMobile;
   const isMedium = global['matchMedia'] ? matchMedium : false;

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -187,7 +187,7 @@ export default function FrontPage() {
             </ModalContent>
           </Modal>
         )}
-        <ResultAndStatsWrapper id="search-results">
+        <ResultAndStatsWrapper id="search-results-wrapper">
           <SearchResults
             data={data}
             organizations={organizations}


### PR DESCRIPTION
Changes in this PR:
- `useBreakpoints()` tweaked to fix hydration errors. Now by default server renders page for large window if mobile device isn't detected. Added `useEffect()` handles view in client if the user is accessing pages in a smaller window.
- Changed div id to be unique