### PR TITLE
YTI-2338: Search term hidden from term listing

### DIFF
--- a/terminology-ui/src/modules/concept/index.tsx
+++ b/terminology-ui/src/modules/concept/index.tsx
@@ -120,10 +120,6 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
               term,
               type: t('field-terms-non-recommended'),
             })),
-            ...(concept.references.searchTerm ?? []).map((term) => ({
-              term,
-              type: t('field-terms-search-term'),
-            })),
             ...(concept.references.hiddenTerm ?? []).map((term) => ({
               term,
               type: t('field-terms-hidden'),


### PR DESCRIPTION
Changelog:
- Search term not shown in concepts page. 
- Still shown when editing