### PR TITLE
YTI-2403 change url to beta site

### DIFF
--- a/terminology-ui/src/modules/terminology-search/index.tsx
+++ b/terminology-ui/src/modules/terminology-search/index.tsx
@@ -194,7 +194,7 @@ export default function TerminologySearch() {
             </TitleDescriptionWrapper>
             <Paragraph>
               {t('move-to-former')}{' '}
-              <Link href="https://sanastot.suomi.fi/" passHref>
+              <Link href="https://sanastot.beta.yti.cloud.dvv.fi/" passHref>
                 <SuomiFiLink href="">{t('to-terminology-tool')}</SuomiFiLink>
               </Link>
               .


### PR DESCRIPTION
For swapping sanastot.beta and sanastot.suomi.fi, change link to the old version to point to beta site