### PR TITLE
YTI-2485 fix remove related concepts

### DIFF
--- a/terminology-ui/src/modules/edit-concept/generate-concept.tsx
+++ b/terminology-ui/src/modules/edit-concept/generate-concept.tsx
@@ -219,7 +219,7 @@ export default function generateConcept({
   let externalTerms =
     data.basicInformation.relationalInfo.matchInOther?.map((match) => {
       const initialTerm = initialValue?.references.exactMatch?.find(
-        (m) => m.properties?.targetId?.[0].value === match.id
+        (m) => m.id === match.id
       );
       const id = initialTerm?.id ?? v4();
 
@@ -278,7 +278,7 @@ export default function generateConcept({
         ...data.basicInformation.relationalInfo.relatedConceptInOther.map(
           (related) => {
             const initialTerm = initialValue?.references.relatedMatch?.find(
-              (m) => m.properties?.targetId?.[0].value === related.id
+              (m) => m.id === related.id
             );
             const id = initialTerm?.id ?? v4();
 
@@ -343,7 +343,7 @@ export default function generateConcept({
         ...externalTerms,
         ...data.basicInformation.relationalInfo.closeMatch.map((match) => {
           const initialTerm = initialValue?.references.closeMatch?.find(
-            (m) => m.properties?.targetId?.[0].value === match.id
+            (m) => m.id === match.id
           );
           const id = initialTerm?.id ?? v4();
 
@@ -717,7 +717,7 @@ export default function generateConcept({
 
   let initialInOtherIds: string[] = initialValue
     ? initialValue.references.exactMatch
-        ?.map((match) => match.properties.targetId?.[0].value ?? '')
+        ?.map((match) => match.id ?? '')
         .filter((val) => val) ?? []
     : [];
 
@@ -725,7 +725,7 @@ export default function generateConcept({
     ? [
         ...initialInOtherIds,
         ...(initialValue.references.relatedMatch
-          ?.map((match) => match.properties.targetId?.[0].value ?? '')
+          ?.map((match) => match.id ?? '')
           .filter((val) => val) ?? []),
       ]
     : initialInOtherIds;
@@ -734,7 +734,7 @@ export default function generateConcept({
     ? [
         ...initialInOtherIds,
         ...(initialValue.references.closeMatch
-          ?.map((match) => match.properties.targetId?.[0].value ?? '')
+          ?.map((match) => match.id ?? '')
           .filter((val) => val) ?? []),
       ]
     : initialInOtherIds;

--- a/terminology-ui/src/modules/edit-concept/generate-form-data-test-variables.tsx
+++ b/terminology-ui/src/modules/edit-concept/generate-form-data-test-variables.tsx
@@ -2504,7 +2504,7 @@ export const extensiveDataExpected = {
       ],
       matchInOther: [
         {
-          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
+          id: '8ee81e29-e0f1-4a23-b23b-28a976fcf87f',
           label: {
             fi: 'demo',
           },
@@ -2541,7 +2541,7 @@ export const extensiveDataExpected = {
       ],
       relatedConceptInOther: [
         {
-          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
+          id: 'a87ae2c2-3c16-494a-9f82-928fc1840a1e',
           label: {
             fi: 'demo',
           },
@@ -2554,7 +2554,7 @@ export const extensiveDataExpected = {
       ],
       closeMatch: [
         {
-          id: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
+          id: 'a87ae2c2-3c16-494a-9f82-928fc1840a1f',
           label: {
             fi: 'demo',
           },

--- a/terminology-ui/src/modules/edit-concept/generate-form-data.tsx
+++ b/terminology-ui/src/modules/edit-concept/generate-form-data.tsx
@@ -208,7 +208,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.properties.targetId?.[0].value ?? '',
+                id: r.id ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => {
@@ -281,7 +281,7 @@ export default function generateFormData(
 
             {
               return {
-                id: r.properties.targetId?.[0].value ?? '',
+                id: r.id ?? '',
                 label:
                   r.properties?.prefLabel
                     ?.map((l) => ({ [l.lang]: l.value }))
@@ -302,7 +302,7 @@ export default function generateFormData(
 
             {
               return {
-                id: m.properties.targetId?.[0].value ?? '',
+                id: m.id ?? '',
                 label:
                   m.properties.prefLabel
                     ?.map((l) => ({ [l.lang]: l.value }))


### PR DESCRIPTION
Use node's id instead of targetId in concept relations. Target id refers to the concept in the other terminology, whereas node's id is used when referring concept link inside the terminology. When removing concept relation, using targetId didn't remove concept link node from the database, although the reference from the concept was removed.