### PR TITLE
YTI-2433: changed to get org and service categories (groups) from datamodel

### DIFF
--- a/datamodel-ui/src/common/interfaces/model.interface.ts
+++ b/datamodel-ui/src/common/interfaces/model.interface.ts
@@ -7,8 +7,8 @@ export interface ModelType {
   label: { [key: string]: string };
   description: { [key: string]: string };
   languages: string[];
-  organizations: string[];
-  groups: string[];
+  organizations: Organization[];
+  groups: Group[];
   contact: string;
   internalNamespaces: [];
   externalNamespaces: [];
@@ -18,16 +18,14 @@ export interface ModelType {
 
 export interface Group {
   id: string;
-  type: string;
   identifier: string;
-  label: LangObject[];
+  label: { [key: string]: string };
 }
 
 export interface Organization {
   id: string;
-  type: string;
-  parentOrganization: string;
-  prefLabel: LangObject[];
+  parentOrganization?: string;
+  label: { [key: string]: string };
 }
 
 // Note: This might need a more descriptive name

--- a/datamodel-ui/src/common/utils/get-value.ts
+++ b/datamodel-ui/src/common/utils/get-value.ts
@@ -1,13 +1,12 @@
 import { MultiSelectData } from 'suomifi-ui-components';
 import {
   DataVocabulary,
+  Group,
   LangObject,
   ModelType,
   ReferenceData,
   Terminology,
 } from '../interfaces/model.interface';
-import { Organization } from '../interfaces/organizations.interface';
-import { ServiceCategory } from '../interfaces/service-categories.interface';
 import { Status } from '../interfaces/status.interface';
 import { Type } from '../interfaces/type.interface';
 import { getLanguageVersion } from './get-language-version';
@@ -123,53 +122,38 @@ export function getDocumentation(data?: ModelType): string {
   return '';
 }
 
-export function getGroup(data?: ModelType, lang?: string): string[] {
+export function getGroup(data?: ModelType, lang?: string): Group[] {
   return data?.groups ?? [];
 }
 
-export function getOrganizations(
-  data?: ModelType,
-  organizations?: Organization[],
-  lang?: string
-): string[] {
-  if (!data) {
+export function getOrganizations(data: ModelType, lang?: string): string[] {
+  if (!data || !data.organizations) {
     return [];
   }
 
-  if (!organizations) {
-    return data.organizations;
-  }
-
-  return data.organizations.map((id) =>
-    getLanguageVersion({
-      data: organizations.find((org) => org.id === id)?.label,
+  return data.organizations.map((org) => {
+    return getLanguageVersion({
+      data: org.label,
       lang: lang ?? 'fi',
-    })
-  );
+    });
+  });
 }
 
 export function getOrganizationsWithId(
   data?: ModelType,
-  organizations?: Organization[],
   lang?: string
 ): MultiSelectData[] {
-  if (!data) {
+  console.log(data);
+  if (!data || !data.organizations) {
     return [];
   }
 
-  if (!organizations) {
-    return data.organizations.map((org) => ({
-      labelText: org,
-      uniqueItemId: org,
-    }));
-  }
-
-  return data.organizations.map((id) => ({
+  return data.organizations.map((org) => ({
     labelText: getLanguageVersion({
-      data: organizations.find((org) => org.id === id)?.label,
+      data: org.label,
       lang: lang ?? 'fi',
     }),
-    uniqueItemId: id,
+    uniqueItemId: org.id,
   }));
 }
 
@@ -184,23 +168,15 @@ export function getLink(
   return [];
 }
 
-export function getIsPartOf(
-  data?: ModelType,
-  serviceGroups?: ServiceCategory[],
-  lang?: string
-): string[] {
+export function getIsPartOf(data?: ModelType, lang?: string): string[] {
   if (!data || !data.groups) {
     return [];
   }
 
-  if (!serviceGroups) {
-    return data.groups;
-  }
-
   return data.groups
-    .map((id) =>
+    .map((group) =>
       getLanguageVersion({
-        data: serviceGroups.find((group) => group.identifier === id)?.label,
+        data: group.label,
         lang: lang ?? 'fi',
       })
     )
@@ -209,26 +185,15 @@ export function getIsPartOf(
 
 export function getIsPartOfWithId(
   data?: ModelType,
-  serviceGroups?: ServiceCategory[],
   lang?: string
 ): MultiSelectData[] {
   if (!data || !data.groups) {
     return [];
   }
 
-  if (!serviceGroups) {
-    return data.groups.map((group) => ({
-      labelText: group,
-      uniqueItemId: group,
-    }));
-  }
-
-  return data.groups.map((id) => ({
-    labelText: getLanguageVersion({
-      data: serviceGroups.find((group) => group.identifier === id)?.label,
-      lang: lang ?? 'fi',
-    }),
-    uniqueItemId: id,
+  return data.groups.map((group) => ({
+    labelText: getLanguageVersion({ data: group.label, lang: lang ?? 'fi' }),
+    uniqueItemId: group.identifier,
   }));
 }
 

--- a/datamodel-ui/src/modules/model/model-edit-view.tsx
+++ b/datamodel-ui/src/modules/model/model-edit-view.tsx
@@ -1,8 +1,6 @@
 import { usePostModelMutation } from '@app/common/components/model/model.slice';
 import { ModelFormType } from '@app/common/interfaces/model-form.interface';
 import { ModelType } from '@app/common/interfaces/model.interface';
-import { Organization } from '@app/common/interfaces/organizations.interface';
-import { ServiceCategory } from '@app/common/interfaces/service-categories.interface';
 import {
   getIsPartOfWithId,
   getOrganizationsWithId,
@@ -24,16 +22,12 @@ import { FormUpdateErrors, validateFormUpdate } from './validate-form-update';
 
 interface ModelEditViewProps {
   model: ModelType;
-  organizations: Organization[];
-  serviceCategories: ServiceCategory[];
   setShow: (value: boolean) => void;
   handleSuccess: () => void;
 }
 
 export default function ModelEditView({
   model,
-  organizations,
-  serviceCategories,
   setShow,
   handleSuccess,
 }: ModelEditViewProps) {
@@ -56,11 +50,9 @@ export default function ModelEditView({
           '',
         selected: true,
       })) ?? [],
-    organizations:
-      getOrganizationsWithId(model, organizations, i18n.language) ?? [],
+    organizations: getOrganizationsWithId(model, i18n.language) ?? [],
     prefix: model.prefix ?? '',
-    serviceCategories:
-      getIsPartOfWithId(model, serviceCategories, i18n.language) ?? [],
+    serviceCategories: getIsPartOfWithId(model, i18n.language) ?? [],
     status: model.status ?? 'DRAFT',
     type: model.type ?? 'PROFILE',
   });

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -34,8 +34,6 @@ import { translateLanguage } from '@app/common/utils/translation-helpers';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import Separator from 'yti-common-ui/separator';
 import FormattedDate from 'yti-common-ui/formatted-date';
-import { useGetServiceCategoriesQuery } from '@app/common/components/service-categories/service-categories.slice';
-import { useGetOrganizationsQuery } from '@app/common/components/organizations/organizations.slice';
 import { ModelFormType } from '@app/common/interfaces/model-form.interface';
 import ModelEditView from './model-edit-view';
 import AsFileModal from '../as-file-modal';
@@ -55,12 +53,6 @@ export default function ModelInfoView() {
   const [headerHeight, setHeaderHeight] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
   const { data: modelInfo, refetch } = useGetModelQuery(modelId);
-  const { data: serviceCategories } = useGetServiceCategoriesQuery(
-    i18n.language ?? 'fi'
-  );
-  const { data: organizations } = useGetOrganizationsQuery(
-    i18n.language ?? 'fi'
-  );
 
   const data = useMemo(() => {
     if (!modelInfo) {
@@ -72,20 +64,20 @@ export default function ModelInfoView() {
       description: getComments(modelInfo),
       prefix: getBaseModelPrefix(modelInfo),
       uri: getUri(modelInfo),
-      isPartOf: getIsPartOf(modelInfo, serviceCategories, i18n.language),
+      isPartOf: getIsPartOf(modelInfo, i18n.language),
       languages: getLanguages(modelInfo),
       terminologies: getTerminology(modelInfo, i18n.language),
       referenceData: getReferenceData(modelInfo, i18n.language),
       dataVocabularies: getDataVocabularies(modelInfo, i18n.language),
       links: getLink(modelInfo),
-      organizations: getOrganizations(modelInfo, organizations, i18n.language),
+      organizations: getOrganizations(modelInfo, i18n.language),
       contact: getContact(modelInfo),
       created: getCreated(modelInfo),
     };
-  }, [modelInfo, i18n.language, organizations, serviceCategories]);
+  }, [modelInfo, i18n.language]);
 
   useEffect(() => {
-    if (modelInfo && serviceCategories && organizations) {
+    if (modelInfo) {
       setFormData({
         contact: '',
         languages:
@@ -101,16 +93,14 @@ export default function ModelInfoView() {
               )?.[1] ?? '',
             selected: true,
           })) ?? [],
-        organizations:
-          getOrganizationsWithId(modelInfo, organizations, i18n.language) ?? [],
+        organizations: getOrganizationsWithId(modelInfo, i18n.language) ?? [],
         prefix: modelInfo?.prefix ?? '',
-        serviceCategories:
-          getIsPartOfWithId(modelInfo, serviceCategories, i18n.language) ?? [],
+        serviceCategories: getIsPartOfWithId(modelInfo, i18n.language) ?? [],
         status: modelInfo?.status ?? 'DRAFT',
         type: modelInfo?.type ?? 'PROFILE',
       });
     }
-  }, [modelInfo, serviceCategories, organizations, t, i18n.language]);
+  }, [modelInfo, t, i18n.language]);
 
   const handleSuccess = () => {
     refetch();
@@ -132,12 +122,10 @@ export default function ModelInfoView() {
     return <DrawerContent />;
   }
 
-  if (showEditView && formData && organizations && serviceCategories) {
+  if (showEditView && formData) {
     return (
       <ModelEditView
         model={modelInfo}
-        organizations={organizations}
-        serviceCategories={serviceCategories}
         setShow={setShowEditView}
         handleSuccess={handleSuccess}
       />


### PR DESCRIPTION
Changelog: 
- orgs and servicecategories gotten from datamodel instead of getting them separately and mapping the label

NOTE:
Requires: https://github.com/VRK-YTI/yti-datamodel-api/pull/101