### PR TITLE
YTI-2485 fix default selection in reference concepts

### DIFF
--- a/terminology-ui/src/common/components/relational-information-block/render-concepts.tsx
+++ b/terminology-ui/src/common/components/relational-information-block/render-concepts.tsx
@@ -52,8 +52,10 @@ export default function RenderConcepts({
       setChosen(
         'terminology' in chosen
           ? (chosen as Concepts[]).filter((chose) => chose.id !== concept.id)
-          : (chosen as RelationInfoType[]).filter(
-              (chose) => chose.id !== concept.id
+          : (chosen as RelationInfoType[]).filter((chose) =>
+              chose.targetId
+                ? chose.targetId !== concept.id
+                : chose.id !== concept.id
             )
       );
     }
@@ -95,7 +97,11 @@ export default function RenderConcepts({
                       lang: i18n.language,
                     })} - ${translateStatus(concept.status ?? 'DRAFT', t)}`}
                     onClick={(e) => handleCheckbox(e, concept)}
-                    checked={chosen.some((chose) => chose.id === concept.id)}
+                    checked={chosen.some((chose) =>
+                      'targetId' in chose
+                        ? (chose as RelationInfoType).targetId === concept.id
+                        : chose.id === concept.id
+                    )}
                     className="concept-checkbox"
                     variant={isSmall ? 'large' : 'small'}
                   >

--- a/terminology-ui/src/modules/edit-concept/generate-form-data-test-variables.tsx
+++ b/terminology-ui/src/modules/edit-concept/generate-form-data-test-variables.tsx
@@ -2513,6 +2513,7 @@ export const extensiveDataExpected = {
             fi: 'testi',
             en: 'test',
           },
+          targetId: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
         },
       ],
       narrowerConcept: [
@@ -2550,6 +2551,7 @@ export const extensiveDataExpected = {
             fi: 'testi',
             en: 'test',
           },
+          targetId: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
         },
       ],
       closeMatch: [
@@ -2563,6 +2565,7 @@ export const extensiveDataExpected = {
             fi: 'testi',
             en: 'test',
           },
+          targetId: '7b179ea2-b28c-497e-9e81-6ff254235ea1',
         },
       ],
     },

--- a/terminology-ui/src/modules/edit-concept/generate-form-data.tsx
+++ b/terminology-ui/src/modules/edit-concept/generate-form-data.tsx
@@ -219,6 +219,7 @@ export default function generateFormData(
                 terminologyLabel: terminologyLabel
                   ? Object.fromEntries(terminologyLabel)
                   : {},
+                targetId: r.properties.targetId?.[0].value ?? '',
               };
             }
           }) ?? [],
@@ -290,6 +291,7 @@ export default function generateFormData(
                 terminologyLabel: terminologyLabel
                   ? Object.fromEntries(terminologyLabel)
                   : {},
+                targetId: r.properties.targetId?.[0].value ?? '',
               };
             }
           }) ?? [],
@@ -311,6 +313,7 @@ export default function generateFormData(
                 terminologyLabel: terminologyLabel
                   ? Object.fromEntries(terminologyLabel)
                   : {},
+                targetId: m.properties.targetId?.[0].value ?? '',
               };
             }
           }) ?? [],

--- a/terminology-ui/src/modules/edit-concept/new-concept.types.tsx
+++ b/terminology-ui/src/modules/edit-concept/new-concept.types.tsx
@@ -58,6 +58,7 @@ export interface RelationInfoType {
   label: { [key: string]: string };
   terminologyId: string;
   terminologyLabel: { [key: string]: string };
+  targetId?: string;
 }
 
 export interface ListType {


### PR DESCRIPTION
Add an additional proeprty `targetId` to related concept. This is used in concept search modal to determine whether the concept is selected or not and avoid duplicate selections