### PR TITLE
Changed getBlockData functionality

### DIFF
--- a/terminology-ui/src/modules/collection/index.tsx
+++ b/terminology-ui/src/modules/collection/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Button,
   Notification,
@@ -35,7 +35,7 @@ import { SubTitle, MainTitle, BadgeBar } from 'yti-common-ui/title-block';
 import HasPermission from '@app/common/utils/has-permission';
 import Link from 'next/link';
 import RemovalModal from '@app/common/components/removal-modal';
-import { useGetBlockData } from './utils';
+import { getBlockData } from './utils';
 
 interface CollectionProps {
   terminologyId: string;
@@ -69,7 +69,9 @@ export default function Collection({
     language: i18n.language,
   });
 
-  const { prefLabels, definitions } = useGetBlockData(collection);
+  const { prefLabels, definitions } = useMemo(() => {
+    return getBlockData(collection);
+  }, [collection]);
 
   useEffect(() => {
     if (collection) {

--- a/terminology-ui/src/modules/collection/utils.tsx
+++ b/terminology-ui/src/modules/collection/utils.tsx
@@ -1,35 +1,20 @@
 import { Collection } from '@app/common/interfaces/collection.interface';
-import { Property } from '@app/common/interfaces/termed-data-types.interface';
 import { compareLocales } from '@app/common/utils/compare-locals';
-import { useEffect, useState } from 'react';
 
-export function useGetBlockData(collection?: Collection) {
-  const [prefLabels, setPrefLabels] = useState<Property[] | undefined>();
-  const [definitions, setDefinitions] = useState<Property[] | undefined>();
+export function getBlockData(collection?: Collection) {
+  if (!collection) {
+    return { prefLabels: [], definitions: [] };
+  }
 
-  useEffect(() => {
-    if (!collection) {
-      setPrefLabels(undefined);
-      setDefinitions(undefined);
-      return;
-    }
+  const prefLabels =
+    collection.properties.prefLabel
+      ?.slice()
+      .sort((l1, l2) => compareLocales(l1, l2)) ?? [];
 
-    if (!prefLabels && collection.properties.prefLabel) {
-      const sortedPrefLabels = collection.properties.prefLabel
-        .slice()
-        .sort((l1, l2) => compareLocales(l1, l2));
-
-      setPrefLabels(sortedPrefLabels);
-    }
-
-    if (!definitions && collection.properties.definition) {
-      const sortedDefinitions = collection.properties.definition
-        .slice()
-        .sort((d1, d2) => compareLocales(d1, d2));
-
-      setDefinitions(sortedDefinitions);
-    }
-  }, [collection, prefLabels, definitions]);
+  const definitions =
+    collection.properties.definition
+      ?.slice()
+      .sort((d1, d2) => compareLocales(d1, d2)) ?? [];
 
   return { prefLabels, definitions };
 }

--- a/terminology-ui/src/modules/concept/index.tsx
+++ b/terminology-ui/src/modules/concept/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'next-i18next';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Button,
   ExternalLink,
@@ -40,7 +40,7 @@ import Link from 'next/link';
 import { translateStatus } from '@app/common/utils/translation-helpers';
 import isEmail from 'validator/lib/isEmail';
 import RemovalModal from '@app/common/components/removal-modal';
-import { useGetBlockData } from './utils';
+import { getBlockData } from './utils';
 
 export interface ConceptProps {
   terminologyId: string;
@@ -60,12 +60,15 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
     conceptId,
   });
 
-  const { terms, definitions, notes, examples } = useGetBlockData(concept);
+  const { terms, definitions, notes, examples } = useMemo(() => {
+    return getBlockData(t, concept);
+  }, [concept, t]);
 
   const prefLabel = getPropertyValue({
     property: getProperty('prefLabel', concept?.references.prefLabelXl),
     language: i18n.language,
   });
+
   const status =
     getPropertyValue({ property: concept?.properties.status }) || 'DRAFT';
   const email = getPropertyValue({

--- a/terminology-ui/src/modules/concept/utils.tsx
+++ b/terminology-ui/src/modules/concept/utils.tsx
@@ -35,9 +35,10 @@ export function getBlockData(t: TFunction, concept?: Concept) {
     concept.properties.note?.slice().sort((t1, t2) => compareLocales(t1, t2)) ??
     [];
 
-  const examples = concept.properties.example
-    ?.slice()
-    .sort((t1, t2) => compareLocales(t1, t2));
+  const examples =
+    concept.properties.example
+      ?.slice()
+      .sort((t1, t2) => compareLocales(t1, t2)) ?? [];
 
   return { terms, definitions, notes, examples };
 }

--- a/terminology-ui/src/modules/concept/utils.tsx
+++ b/terminology-ui/src/modules/concept/utils.tsx
@@ -1,75 +1,43 @@
 import { Concept } from '@app/common/interfaces/concept.interface';
-import { Property } from '@app/common/interfaces/termed-data-types.interface';
-import {
-  compareLocales,
-  TermBlockType,
-} from '@app/common/utils/compare-locals';
-import { useTranslation } from 'next-i18next';
-import { useEffect, useState } from 'react';
+import { compareLocales } from '@app/common/utils/compare-locals';
+import { TFunction } from 'next-i18next';
 
-export function useGetBlockData(concept?: Concept) {
-  const { t } = useTranslation('concept');
-  const [terms, setTerms] = useState<TermBlockType[] | undefined>();
-  const [definitions, setDefinitions] = useState<Property[] | undefined>();
-  const [notes, setNotes] = useState<Property[] | undefined>();
-  const [examples, setExamples] = useState<Property[] | undefined>();
+export function getBlockData(t: TFunction, concept?: Concept) {
+  if (!concept) {
+    return { terms: [], definitions: [], notes: [], examples: [] };
+  }
 
-  useEffect(() => {
-    if (!concept) {
-      setTerms(undefined);
-      setDefinitions(undefined);
-      setNotes(undefined);
-      setExamples(undefined);
-      return;
-    }
+  const terms = [
+    ...(concept.references.prefLabelXl ?? []).map((term) => ({
+      term,
+      type: t('field-terms-preferred'),
+    })),
+    ...(concept.references.altLabelXl ?? []).map((term) => ({
+      term,
+      type: t('field-terms-alternative'),
+    })),
+    ...(concept.references.notRecommendedSynonym ?? []).map((term) => ({
+      term,
+      type: t('field-terms-non-recommended'),
+    })),
+    ...(concept.references.hiddenTerm ?? []).map((term) => ({
+      term,
+      type: t('field-terms-hidden'),
+    })),
+  ].sort((t1, t2) => compareLocales(t1, t2));
 
-    if (!terms) {
-      setTerms(
-        [
-          ...(concept.references.prefLabelXl ?? []).map((term) => ({
-            term,
-            type: t('field-terms-preferred'),
-          })),
-          ...(concept.references.altLabelXl ?? []).map((term) => ({
-            term,
-            type: t('field-terms-alternative'),
-          })),
-          ...(concept.references.notRecommendedSynonym ?? []).map((term) => ({
-            term,
-            type: t('field-terms-non-recommended'),
-          })),
-          ...(concept.references.hiddenTerm ?? []).map((term) => ({
-            term,
-            type: t('field-terms-hidden'),
-          })),
-        ].sort((t1, t2) => compareLocales(t1, t2))
-      );
-    }
+  const definitions =
+    concept.properties.definition
+      ?.slice()
+      .sort((t1, t2) => compareLocales(t1, t2)) ?? [];
 
-    if (!definitions && concept.properties.definition) {
-      const sortedDefinitions = concept.properties.definition
-        .slice()
-        .sort((t1, t2) => compareLocales(t1, t2));
+  const notes =
+    concept.properties.note?.slice().sort((t1, t2) => compareLocales(t1, t2)) ??
+    [];
 
-      setDefinitions(sortedDefinitions);
-    }
-
-    if (!notes && concept.properties.note) {
-      const sortedDefinitions = concept.properties.note
-        .slice()
-        .sort((t1, t2) => compareLocales(t1, t2));
-
-      setNotes(sortedDefinitions);
-    }
-
-    if (!examples && concept.properties.example) {
-      const sortedDefinitions = concept.properties.example
-        .slice()
-        .sort((t1, t2) => compareLocales(t1, t2));
-
-      setExamples(sortedDefinitions);
-    }
-  }, [concept, terms, definitions, notes, examples, t]);
+  const examples = concept.properties.example
+    ?.slice()
+    .sort((t1, t2) => compareLocales(t1, t2));
 
   return { terms, definitions, notes, examples };
 }


### PR DESCRIPTION
Changes in this PR:
- Changed to `useGetBlockData()` to `getBlockData()` and `useMemo()` solution to fix concept and collection information loading in production builds