### PR TITLE
YTI-2502: fixed hooks when opening related concept

### DIFF
--- a/terminology-ui/src/modules/concept/index.tsx
+++ b/terminology-ui/src/modules/concept/index.tsx
@@ -55,6 +55,11 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
   const { data: terminology, error: terminologyError } = useGetVocabularyQuery({
     id: terminologyId,
   });
+  //We cannot call a hook on a conditional statement so this has to be checked before rendering
+  const hasPermission = HasPermission({
+    actions: ['EDIT_CONCEPT', 'DELETE_CONCEPT'],
+    targetOrganization: terminology?.references.contributor,
+  });
   const { data: concept, error: conceptError } = useGetConceptQuery({
     terminologyId,
     conceptId,
@@ -176,10 +181,7 @@ export default function Concept({ terminologyId, conceptId }: ConceptProps) {
 
           <Separator isLarge />
 
-          {HasPermission({
-            actions: ['EDIT_CONCEPT', 'DELETE_CONCEPT'],
-            targetOrganization: terminology?.references.contributor,
-          }) && (
+          {hasPermission && (
             <>
               <BasicBlock
                 title={t('edit-collection-block-title')}


### PR DESCRIPTION
Moved hooks to prevent conditional hooks. Caused problems where conditional hooks were called when clicking a related concept link