### PR TITLE
YTI-2531: datamodel file name and added filetype to chrome

### DIFF
--- a/datamodel-ui/src/modules/as-file-modal/index.tsx
+++ b/datamodel-ui/src/modules/as-file-modal/index.tsx
@@ -19,9 +19,14 @@ import {
 interface AsFileModalProps {
   type: 'show' | 'download';
   modelId: string;
+  filename?: string;
 }
 
-export default function AsFileModal({ type, modelId }: AsFileModalProps) {
+export default function AsFileModal({
+  type,
+  modelId,
+  filename,
+}: AsFileModalProps) {
   const { t } = useTranslation('common');
   const { isSmall } = useBreakpoints();
   const [visible, setVisible] = useState(false);
@@ -110,7 +115,7 @@ export default function AsFileModal({ type, modelId }: AsFileModalProps) {
 
         <ButtonFooter>
           <Link
-            href={`/api/getModelAsFile?modelId=${modelId}&fileType=${chosenFileType}`}
+            href={`/api/getModelAsFile?modelId=${modelId}&fileType=${chosenFileType}&filename=${filename}`}
             passHref
           >
             <SuomiLink href="">

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -166,7 +166,14 @@ export default function ModelInfoView() {
                   </Button>
                 )}
                 <AsFileModal type="show" modelId={modelId} />
-                <AsFileModal type="download" modelId={modelId} />
+                <AsFileModal
+                  type="download"
+                  modelId={modelId}
+                  filename={getLanguageVersion({
+                    data: modelInfo.label,
+                    lang: i18n.language,
+                  })}
+                />
                 {hasPermission && (
                   <>
                     <Button variant="secondaryNoBorder">

--- a/datamodel-ui/src/pages/api/getModelAsFile.ts
+++ b/datamodel-ui/src/pages/api/getModelAsFile.ts
@@ -7,18 +7,22 @@ export default withIronSessionApiRoute(
     const target = (req.query['modelId'] as string) ?? '/';
     const fileType = (req.query['fileType'] as string) ?? 'LD-JSON';
     const isRaw = (req.query['raw'] as string) ?? 'false';
+    let filename = (req.query['filename'] as string) ?? 'datamodel';
 
     let mimeType: string;
     switch (fileType) {
       case 'RDF':
         mimeType = 'application/rdf+xml';
+        filename += '.rdf';
         break;
       case 'Turtle':
         mimeType = 'text/turtle';
+        filename += '.ttl';
         break;
       case 'LD+JSON':
       default:
         mimeType = 'application/ld+json';
+        filename += '.jsonld';
     }
 
     const { status, data: response } = await axios.get(
@@ -36,7 +40,10 @@ export default withIronSessionApiRoute(
       res.setHeader('Content-Type', 'text/plain; charset=UTF-8');
     } else {
       res.setHeader('Content-Type', mimeType);
-      res.setHeader('Content-Disposition', 'attachment');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${filename}"`
+      );
     }
     res.status(status);
     response.pipe(res);


### PR DESCRIPTION
Changelog:
- File name is sent through as current language label
- added file type to filename since chrome doesn't play nice with the Content-Type header