### PR TITLE
Datamodel yti 2565 resource render

### DIFF
--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -6,6 +6,9 @@ export interface VisualizationType {
     x: number;
     y: number;
   };
-  attributes: [];
+  attributes: {
+    identifier: string;
+    label: { [key: string]: string };
+  }[];
   associations: [];
 }

--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -10,5 +10,9 @@ export interface VisualizationType {
     identifier: string;
     label: { [key: string]: string };
   }[];
-  associations: [];
+  associations: {
+    identifier: string;
+    label: { [key: string]: string };
+    path: string[];
+  }[];
 }

--- a/datamodel-ui/src/modules/graph/edge-corner.tsx
+++ b/datamodel-ui/src/modules/graph/edge-corner.tsx
@@ -1,0 +1,10 @@
+import { Handle, Position } from 'reactflow';
+
+export default function EdgeCorner({ id }: { id: string }) {
+  return (
+    <div id="corner">
+      <Handle type="target" position={Position.Top} id={id} />
+      <Handle type="source" position={Position.Top} id={id} />
+    </div>
+  );
+}

--- a/datamodel-ui/src/modules/graph/graph.styles.tsx
+++ b/datamodel-ui/src/modules/graph/graph.styles.tsx
@@ -23,4 +23,34 @@ export const ModelFlow = styled(ReactFlow)`
     margin: 0;
     z-index: 4;
   }
+
+  [data-id^="corner-"] {
+    padding: 0;
+    margin: 0;
+    width: 20px;
+    height: 20px;
+    z-index: 1 !important;
+    margin-left: 10px;
+    margin-top: -10px;
+    border: 1px solid transparent;
+
+    box-shadow: none !important;
+    background: none;
+
+    .react-flow__handle {
+      min-width: 0 !important;
+      min-height: 0 !important;
+      width: 0;
+      height: 0;
+      border: 0;
+      top: 0;
+      bottom 0;
+    }
+
+    &:hover {
+      background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
+      border-radius: 50%;
+      border: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
+    }
+  }
 `;

--- a/datamodel-ui/src/modules/graph/graph.styles.tsx
+++ b/datamodel-ui/src/modules/graph/graph.styles.tsx
@@ -24,7 +24,7 @@ export const ModelFlow = styled(ReactFlow)`
     z-index: 4;
   }
 
-  [data-id^="corner-"] {
+  [data-id^="#corner-"] {
     padding: 0;
     margin: 0;
     width: 20px;

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -55,7 +55,6 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
   const { data, isSuccess } = useGetVisualizationQuery(modelId);
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-  const [startNodeId, setStartNodeId] = useState<string | undefined>();
   const [cleanUnusedCorners, setCleanUnusedCorners] = useState(false);
 
   const deleteEdgeById = useCallback(
@@ -145,53 +144,6 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
     [dispatch, globalSelected.id]
   );
 
-  // const onConnectEnd = useCallback(
-  //   (e) => {
-  //     if (!startNodeId) {
-  //       return;
-  //     }
-
-  //     if (e.target.className === 'react-flow__pane') {
-  //       if (!reactFlowWrapper.current) {
-  //         return;
-  //       }
-
-  //       const { top, left } = reactFlowWrapper.current.getBoundingClientRect();
-
-  //       // We need to subtract 26 from x position to get correct location
-  //       // 26 is calculated by so:
-  //       // ( Drawer width + half of the cornerEdge width ) / 2
-  //       // = (42 + 5) / 2
-
-  //       setNodes((nodes) => [
-  //         ...nodes,
-  //         {
-  //           id: `corner-${edgePart}`,
-  //           position: project({ x: e.clientX - left - 26, y: e.clientY - top }),
-  //           data: {},
-  //           type: 'cornerEdge',
-  //         }
-  //       ]);
-
-  //       setEdges((edges) => [
-  //         ...edges,
-  //         { id: `${startNodeId}-corner-${edgePart}`, source: startNodeId, target: `corner-${edgePart}`, type: 'straight' }
-  //       ]);
-
-  //       setEdgePart((part) => part + 1);
-  //     } else {
-  //       setEdgePart(0);
-  //     }
-
-  //     setStartNodeId(undefined);
-  //   },
-  //   [startNodeId, edgePart, setEdges, setNodes, project]
-  // );
-
-  const onConnectStart = useCallback((e, params) => {
-    setStartNodeId(params.nodeId);
-  }, []);
-
   const onConnect = useCallback(
     (params) => {
       setEdges((edges) =>
@@ -253,8 +205,6 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
         edgeTypes={edgeTypes}
         onNodeClick={onNodeClick}
         onEdgeClick={onEdgeClick}
-        // onConnectEnd={onConnectEnd}
-        // onConnectStart={onConnectStart}
         fitView
       >
         {children}

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -16,6 +16,7 @@ import {
   createNewAssociationEdge,
   createNewCornerEdge,
   createNewCornerNode,
+  generateInitialEdges,
   getUnusedCornerIds,
   handleEdgeDelete,
 } from './utils';
@@ -211,8 +212,19 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
   useEffect(() => {
     if (isSuccess) {
       setNodes(convertToNodes(data, i18n.language));
+      setEdges(
+        generateInitialEdges(data, deleteEdgeById, splitEdge, i18n.language)
+      );
     }
-  }, [data, isSuccess, setNodes, i18n.language]);
+  }, [
+    data,
+    isSuccess,
+    setNodes,
+    setEdges,
+    deleteEdgeById,
+    splitEdge,
+    i18n.language,
+  ]);
 
   useEffect(() => {
     const cleanCorners = () => {
@@ -228,9 +240,6 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
       setCleanUnusedCorners(false);
     }
   }, [cleanUnusedCorners, edges, nodes, setNodes]);
-
-  console.log('nodes', nodes);
-  console.log('edges', edges);
 
   return (
     <div ref={reactFlowWrapper} style={{ height: '100%', width: '100%' }}>

--- a/datamodel-ui/src/modules/graph/labeled-edge.tsx
+++ b/datamodel-ui/src/modules/graph/labeled-edge.tsx
@@ -33,7 +33,7 @@ export default function LabeledEdge({
     targetY,
   });
 
-  const onDeleteClick = (e: MouseEvent<HTMLButtonElement>, id: string) => {
+  const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     data.handleDelete(id);
     if (globalSelected.id === id) {
@@ -65,7 +65,7 @@ export default function LabeledEdge({
         >
           <div>{label}</div>
           {selected && (
-            <DeleteEdgeButton onClick={(e) => onDeleteClick(e, id)}>
+            <DeleteEdgeButton onClick={(e) => onDeleteClick(e)}>
               ×
             </DeleteEdgeButton>
           )}

--- a/datamodel-ui/src/modules/graph/labeled-edge.tsx
+++ b/datamodel-ui/src/modules/graph/labeled-edge.tsx
@@ -11,7 +11,7 @@ import { DeleteEdgeButton, EdgeContent } from './edge.styles';
 import { useSelector } from 'react-redux';
 import { useStoreDispatch } from '@app/store';
 
-export default function Edge({
+export default function LabeledEdge({
   id,
   data,
   source,
@@ -41,6 +41,11 @@ export default function Edge({
     }
   };
 
+  const onSplitClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    data.splitEdge(source, target, e.clientX, e.clientY);
+  };
+
   return (
     <>
       <path
@@ -64,6 +69,9 @@ export default function Edge({
               ×
             </DeleteEdgeButton>
           )}
+          <div>
+            <button onClick={(e) => onSplitClick(e)}>split</button>
+          </div>
         </EdgeContent>
       </EdgeLabelRenderer>
     </>

--- a/datamodel-ui/src/modules/graph/labeled-edge.tsx
+++ b/datamodel-ui/src/modules/graph/labeled-edge.tsx
@@ -35,7 +35,7 @@ export default function LabeledEdge({
 
   const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    data.handleDelete(id, source, target);
+    data.handleDelete(id);
     if (globalSelected.id === id) {
       dispatch(setSelected('', 'associations'));
     }

--- a/datamodel-ui/src/modules/graph/labeled-edge.tsx
+++ b/datamodel-ui/src/modules/graph/labeled-edge.tsx
@@ -35,7 +35,7 @@ export default function LabeledEdge({
 
   const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    data.handleDelete(id);
+    data.handleDelete(id, source, target);
     if (globalSelected.id === id) {
       dispatch(setSelected('', 'associations'));
     }

--- a/datamodel-ui/src/modules/graph/node.tsx
+++ b/datamodel-ui/src/modules/graph/node.tsx
@@ -26,23 +26,8 @@ export default function ClassNode({ id, data }: ClassNodeProps) {
   const dispatch = useStoreDispatch();
   const globalSelected = useSelector(selectSelected());
   const globalHover = useSelector(selectHovered());
-  const [showAtttributes, setShowAttributes] = useState(true);
+  const [showAttributes, setShowAttributes] = useState(true);
   const [hover, setHover] = useState(false);
-
-  const mockAttributes = [
-    {
-      identifier: `${id}-attr-1`,
-      label: 'Attribute #1',
-    },
-    {
-      identifier: `${id}-attr-2`,
-      label: 'Attribute #2',
-    },
-    {
-      identifier: `${id}-attr-3`,
-      label: 'Attribute #3',
-    },
-  ];
 
   return (
     <ClassNodeDiv
@@ -58,23 +43,24 @@ export default function ClassNode({ id, data }: ClassNodeProps) {
       <Handle type="target" position={Position.Top} id={id} />
       <div className="node-title">
         <div>{data.label}</div>
-        <button onClick={() => setShowAttributes(!showAtttributes)}>
+        <button onClick={() => setShowAttributes(!showAttributes)}>
           <Icon
-            icon={showAtttributes ? 'chevronUp' : 'chevronDown'}
+            icon={showAttributes ? 'chevronUp' : 'chevronDown'}
             variant="secondaryNoBorder"
           />
         </button>
       </div>
       <Handle type="source" position={Position.Bottom} id={id} />
 
-      {showAtttributes &&
-        mockAttributes.map((child) => (
+      {showAttributes &&
+        data.resources &&
+        data.resources.map((r) => (
           <Attribute
-            key={`${id}-child-${child.identifier}`}
+            key={`${id}-child-${r.identifier}`}
             className="node-resource"
-            onClick={() => dispatch(setSelected('', 'attributes'))}
+            onClick={() => dispatch(setSelected(r.identifier, 'attributes'))}
           >
-            {child.label}
+            {r.label}
           </Attribute>
         ))}
     </ClassNodeDiv>

--- a/datamodel-ui/src/modules/graph/node.tsx
+++ b/datamodel-ui/src/modules/graph/node.tsx
@@ -1,12 +1,14 @@
 import {
   selectHovered,
   selectSelected,
+  setSelected,
 } from '@app/common/components/model/model.slice';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Handle, Position } from 'reactflow';
 import { Icon } from 'suomifi-ui-components';
 import { Attribute, ClassNodeDiv } from './node.styles';
+import { useStoreDispatch } from '@app/store';
 
 interface ClassNodeProps {
   id: string;
@@ -21,6 +23,7 @@ interface ClassNodeProps {
 }
 
 export default function ClassNode({ id, data }: ClassNodeProps) {
+  const dispatch = useStoreDispatch();
   const globalSelected = useSelector(selectSelected());
   const globalHover = useSelector(selectHovered());
   const [showAtttributes, setShowAttributes] = useState(true);
@@ -69,6 +72,7 @@ export default function ClassNode({ id, data }: ClassNodeProps) {
           <Attribute
             key={`${id}-child-${child.identifier}`}
             className="node-resource"
+            onClick={() => dispatch(setSelected('', 'attributes'))}
           >
             {child.label}
           </Attribute>

--- a/datamodel-ui/src/modules/graph/splittable-edge.tsx
+++ b/datamodel-ui/src/modules/graph/splittable-edge.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable jsx-a11y/mouse-events-have-key-events */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import { MouseEvent } from 'react';
+import { EdgeProps, getStraightPath } from 'reactflow';
+import styled from 'styled-components';
+
+const EdgeContent = styled.div`
+  background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
+  border: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
+  border-radius: 5px;
+  display: flex;
+  padding: 2px;
+  width: min-content;
+
+  button {
+    border: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
+    border-radius: 50%;
+    background: none;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+  }
+
+  button:first-child {
+    margin-right: 3px;
+  }
+`;
+
+export default function SplittableEdge({
+  id,
+  data,
+  source,
+  sourceX,
+  sourceY,
+  target,
+  targetX,
+  targetY,
+  label,
+  markerEnd,
+  selected,
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getStraightPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  });
+
+  const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    data.handleDelete(id);
+  };
+
+  const onSplitClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    data.splitEdge(source, target, e.clientX, e.clientY);
+  };
+
+  return (
+    <>
+      <path id={id} className="react-flow__edge-path" d={edgePath} />
+      {selected && (
+        <foreignObject
+          width={49}
+          height={26.5}
+          x={labelX - 49 / 2}
+          y={labelY - 26.5 / 2}
+          className="edgebutton-foreignobject"
+          requiredExtensions="http://www.w3.org/1999/xhtml"
+        >
+          <EdgeContent>
+            <button onClick={(e) => onSplitClick(e)}>/</button>
+            <button onClick={(e) => onDeleteClick(e)}>×</button>
+          </EdgeContent>
+        </foreignObject>
+      )}
+    </>
+  );
+}

--- a/datamodel-ui/src/modules/graph/splittable-edge.tsx
+++ b/datamodel-ui/src/modules/graph/splittable-edge.tsx
@@ -49,7 +49,7 @@ export default function SplittableEdge({
 
   const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    data.handleDelete(id);
+    data.handleDelete(id, source, target);
   };
 
   const onSplitClick = (e: MouseEvent<HTMLButtonElement>) => {

--- a/datamodel-ui/src/modules/graph/splittable-edge.tsx
+++ b/datamodel-ui/src/modules/graph/splittable-edge.tsx
@@ -49,7 +49,7 @@ export default function SplittableEdge({
 
   const onDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    data.handleDelete(id, source, target);
+    data.handleDelete(id);
   };
 
   const onSplitClick = (e: MouseEvent<HTMLButtonElement>) => {

--- a/datamodel-ui/src/modules/graph/util.test.data.ts
+++ b/datamodel-ui/src/modules/graph/util.test.data.ts
@@ -1,0 +1,272 @@
+import { VisualizationType } from '@app/common/interfaces/visualization.interface';
+import { Edge, MarkerType } from 'reactflow';
+
+export const visualizationTypeArray: VisualizationType[] = [
+  {
+    identifier: '1',
+    label: {
+      fi: 'label-1-fi',
+      en: 'label-1-en',
+    },
+    parentClasses: [],
+    position: {
+      x: 0,
+      y: 0,
+    },
+    attributes: [],
+    associations: [],
+  },
+  {
+    identifier: '2',
+    label: {
+      en: 'label-2-en',
+    },
+    parentClasses: [],
+    position: {
+      x: 0,
+      y: 0,
+    },
+    attributes: [],
+    associations: [],
+  },
+  {
+    identifier: '3',
+    label: {
+      fi: 'label-3-fi',
+      en: 'label-3-en',
+      sv: 'label-3-sv',
+    },
+    parentClasses: [],
+    position: {
+      x: 0,
+      y: 0,
+    },
+    attributes: [],
+    associations: [],
+  },
+];
+
+export const twoEdgesOneSplit: Edge[] = [
+  {
+    source: 'class-1',
+    sourceHandle: 'class-1',
+    target: 'class-3',
+    targetHandle: 'class-3',
+    type: 'associationEdge',
+    markerEnd: {
+      type: 'arrowclosed' as MarkerType,
+      height: 30,
+      width: 30,
+    },
+    label: 'Association',
+    data: {},
+    id: 'reactflow__edge-class-1-class-3',
+  },
+  {
+    source: 'corner-12312312',
+    sourceHandle: 'corner-12312312',
+    target: 'class-3',
+    targetHandle: 'class-3',
+    type: 'associationEdge',
+    markerEnd: {
+      type: 'arrowclosed' as MarkerType,
+      height: 30,
+      width: 30,
+    },
+    label: 'Assosiaatio',
+    data: {},
+    id: 'reactflow__edge-corner-12312312-class-3',
+  },
+  {
+    source: 'class-2',
+    sourceHandle: 'class-2',
+    target: 'corner-12312312',
+    targetHandle: 'corner-12312312',
+    type: 'defaultEdge',
+    data: {},
+    id: 'reactflow__edge-class-2-#corner-corner-12312312',
+  },
+];
+
+export const threeEdgesOneMultipleSplit: Edge[] = [
+  {
+    source: 'class-1',
+    sourceHandle: 'class-1',
+    target: 'class-4',
+    targetHandle: 'class-4',
+    type: 'associationEdge',
+    markerEnd: {
+      type: 'arrowclosed' as MarkerType,
+      height: 30,
+      width: 30,
+    },
+    label: 'Association',
+    data: {},
+    id: 'reactflow__edge-class-1-class-4',
+  },
+  {
+    source: 'class-2',
+    sourceHandle: 'class-2',
+    target: 'class-4',
+    targetHandle: 'class-4',
+    type: 'associationEdge',
+    markerEnd: {
+      type: 'arrowclosed' as MarkerType,
+      height: 30,
+      width: 30,
+    },
+    label: 'Association',
+    data: {},
+    id: 'reactflow__edge-class-2-class-4',
+  },
+  {
+    source: 'corner-4',
+    sourceHandle: 'corner-4',
+    target: 'class-4',
+    targetHandle: 'class-4',
+    type: 'associationEdge',
+    markerEnd: {
+      type: 'arrowclosed' as MarkerType,
+      height: 30,
+      width: 30,
+    },
+    label: 'Assosiaatio',
+    data: {},
+    id: 'reactflow__edge-corner-4-class-4',
+  },
+  {
+    source: 'corner-3',
+    sourceHandle: 'corner-3',
+    target: 'corner-4',
+    targetHandle: 'corner-4',
+    type: 'defaultEdge',
+    data: {},
+    id: 'reactflow__edge-corner-3-#corner-corner-4',
+  },
+  {
+    source: 'corner-2',
+    sourceHandle: 'corner-2',
+    target: 'corner-3',
+    targetHandle: 'corner-3',
+    type: 'defaultEdge',
+    data: {},
+    id: 'reactflow__edge-corner-2-#corner-corner-3',
+  },
+  {
+    source: 'corner-1',
+    sourceHandle: 'corner-1',
+    target: 'corner-2',
+    targetHandle: 'corner-2',
+    type: 'defaultEdge',
+    data: {},
+    id: 'reactflow__edge-corner-1-#corner-corner-2',
+  },
+  {
+    source: 'class-3',
+    sourceHandle: 'class-3',
+    target: 'corner-1',
+    targetHandle: 'corner-1',
+    type: 'defaultEdge',
+    data: {},
+    id: 'reactflow__edge-class-3-#corner-corner-1',
+  },
+];
+
+// Convert test expected results
+export const convertedExpected = [
+  {
+    id: '1',
+    position: {
+      x: 0,
+      y: 0,
+    },
+    data: {
+      identifier: '1',
+      label: 'label-1-fi',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+  {
+    id: '2',
+    position: {
+      x: 0,
+      y: 200,
+    },
+    data: {
+      identifier: '2',
+      label: 'label-2-en (en)',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+  {
+    id: '3',
+    position: {
+      x: 0,
+      y: 400,
+    },
+    data: {
+      identifier: '3',
+      label: 'label-3-fi',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+];
+
+export const convertedLangVersionedExpected = [
+  {
+    id: '1',
+    position: {
+      x: 0,
+      y: 0,
+    },
+    data: {
+      identifier: '1',
+      label: 'label-1-en',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+  {
+    id: '2',
+    position: {
+      x: 0,
+      y: 200,
+    },
+    data: {
+      identifier: '2',
+      label: 'label-2-en',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+  {
+    id: '3',
+    position: {
+      x: 0,
+      y: 400,
+    },
+    data: {
+      identifier: '3',
+      label: 'label-3-en',
+      resources: [],
+    },
+    type: 'classNode',
+  },
+];
+
+// Connected edges expected results
+export const connectedEdgesRemoved: string[] = [
+  'reactflow__edge-corner-12312312-class-3',
+  'reactflow__edge-class-2-#corner-corner-12312312',
+];
+
+export const connectedEdgesRemovedMultiple: string[] = [
+  'reactflow__edge-corner-4-class-4',
+  'reactflow__edge-corner-3-#corner-corner-4',
+  'reactflow__edge-corner-2-#corner-corner-3',
+  'reactflow__edge-corner-1-#corner-corner-2',
+  'reactflow__edge-class-3-#corner-corner-1',
+];

--- a/datamodel-ui/src/modules/graph/util.test.data.ts
+++ b/datamodel-ui/src/modules/graph/util.test.data.ts
@@ -14,7 +14,16 @@ export const visualizationTypeArray: VisualizationType[] = [
       y: 0,
     },
     attributes: [],
-    associations: [],
+    associations: [
+      {
+        identifier: 'association-1',
+        label: {
+          fi: 'assoc-1-fi',
+          en: 'assoc-1-en',
+        },
+        path: ['2'],
+      },
+    ],
   },
   {
     identifier: '2',
@@ -27,7 +36,15 @@ export const visualizationTypeArray: VisualizationType[] = [
       y: 0,
     },
     attributes: [],
-    associations: [],
+    associations: [
+      {
+        identifier: 'association-2',
+        label: {
+          en: 'assoc-2-en',
+        },
+        path: ['3'],
+      },
+    ],
   },
   {
     identifier: '3',
@@ -41,7 +58,16 @@ export const visualizationTypeArray: VisualizationType[] = [
       x: 0,
       y: 0,
     },
-    attributes: [],
+    attributes: [
+      {
+        identifier: '3-1',
+        label: {
+          fi: 'attr-1-fi',
+          en: 'attr-1-en',
+          sv: 'attr-1-sv',
+        },
+      },
+    ],
     associations: [],
   },
 ];
@@ -209,7 +235,12 @@ export const convertedExpected = [
     data: {
       identifier: '3',
       label: 'label-3-fi',
-      resources: [],
+      resources: [
+        {
+          identifier: '3-1',
+          label: 'attr-1-fi',
+        },
+      ],
     },
     type: 'classNode',
   },
@@ -251,7 +282,12 @@ export const convertedLangVersionedExpected = [
     data: {
       identifier: '3',
       label: 'label-3-en',
-      resources: [],
+      resources: [
+        {
+          identifier: '3-1',
+          label: 'attr-1-en',
+        },
+      ],
     },
     type: 'classNode',
   },
@@ -270,3 +306,45 @@ export const connectedEdgesRemovedMultiple: string[] = [
   'reactflow__edge-corner-1-#corner-corner-2',
   'reactflow__edge-class-3-#corner-corner-1',
 ];
+
+// Initial edges results
+export function initialEdges(handleDelete: jest.Mock, splitEdge: jest.Mock) {
+  return [
+    {
+      source: '1',
+      sourceHandle: '1',
+      target: '2',
+      targetHandle: '2',
+      type: 'associationEdge',
+      markerEnd: {
+        type: 'arrowclosed' as MarkerType,
+        height: 30,
+        width: 30,
+      },
+      label: 'assoc-1-fi',
+      data: {
+        handleDelete: handleDelete,
+        splitEdge: splitEdge,
+      },
+      id: 'reactflow__edge-1-2',
+    },
+    {
+      source: '2',
+      sourceHandle: '2',
+      target: '3',
+      targetHandle: '3',
+      type: 'associationEdge',
+      markerEnd: {
+        type: 'arrowclosed' as MarkerType,
+        height: 30,
+        width: 30,
+      },
+      label: 'assoc-2-en (en)',
+      data: {
+        handleDelete: handleDelete,
+        splitEdge: splitEdge,
+      },
+      id: 'reactflow__edge-2-3',
+    },
+  ];
+}

--- a/datamodel-ui/src/modules/graph/utils.test.ts
+++ b/datamodel-ui/src/modules/graph/utils.test.ts
@@ -1,0 +1,171 @@
+import {
+  convertToNodes,
+  createNewAssociationEdge,
+  createNewCornerEdge,
+  getConnectedCornerIds,
+  handleEdgeDelete,
+} from './utils';
+import {
+  connectedEdgesRemoved,
+  connectedEdgesRemovedMultiple,
+  convertedExpected,
+  convertedLangVersionedExpected,
+  threeEdgesOneMultipleSplit,
+  twoEdgesOneSplit,
+  visualizationTypeArray,
+} from './util.test.data';
+import { MarkerType } from 'reactflow';
+
+describe('graph-util', () => {
+  it('should return an empty array if given an empty array', () => {
+    const returned = convertToNodes([]);
+
+    expect(returned).toStrictEqual([]);
+  });
+
+  it('should convert VisualizationType[] to a Node[]', () => {
+    const input = visualizationTypeArray;
+
+    const expected = convertedExpected;
+    const expectedLangVersioned = convertedLangVersionedExpected;
+
+    const returned = convertToNodes(input);
+    expect(returned).toStrictEqual(expected);
+
+    const returnedLangVersioned = convertToNodes(input, 'en');
+    expect(returnedLangVersioned).toStrictEqual(expectedLangVersioned);
+  });
+
+  it('should return an empty array if input data is an empty array', () => {
+    const input = getConnectedCornerIds([], '1');
+
+    expect(input).toStrictEqual([]);
+  });
+
+  it('should return an empty array if source is missing', () => {
+    const input = getConnectedCornerIds(twoEdgesOneSplit);
+
+    expect(input).toStrictEqual([]);
+  });
+
+  it('should get all connected edge ids between two class node', () => {
+    const input1 = getConnectedCornerIds(twoEdgesOneSplit, 'corner-12312312');
+    const input2 = getConnectedCornerIds(
+      threeEdgesOneMultipleSplit,
+      'corner-4'
+    );
+
+    expect(input1).toHaveLength(2);
+    expect(input1).toStrictEqual(connectedEdgesRemoved);
+
+    expect(input2).toHaveLength(5);
+    expect(input2).toStrictEqual(connectedEdgesRemovedMultiple);
+  });
+
+  it('should create a association edge', () => {
+    const deleteMock = jest.fn();
+    const splitMock = jest.fn();
+
+    const input = createNewAssociationEdge(
+      'association',
+      deleteMock,
+      splitMock,
+      {}
+    );
+
+    const expected = {
+      type: 'associationEdge',
+      markerEnd: {
+        type: 'arrowclosed',
+        height: 30,
+        width: 30,
+      },
+      label: 'association',
+      data: {
+        handleDelete: deleteMock,
+        splitEdge: splitMock,
+      },
+    };
+
+    expect(input).toStrictEqual(expected);
+  });
+
+  it('should create a association edge with params', () => {
+    const deleteMock = jest.fn();
+    const splitMock = jest.fn();
+
+    const input = createNewAssociationEdge(
+      'association',
+      deleteMock,
+      splitMock,
+      {
+        param1: 'basic string',
+        param2: {
+          label: 'object with values of different type',
+          number: 1,
+          list: ['list-item-1', 'list-item-2'],
+        },
+      }
+    );
+
+    const expected = {
+      type: 'associationEdge',
+      markerEnd: {
+        type: 'arrowclosed',
+        height: 30,
+        width: 30,
+      },
+      label: 'association',
+      data: {
+        handleDelete: deleteMock,
+        splitEdge: splitMock,
+      },
+      param1: 'basic string',
+      param2: {
+        label: 'object with values of different type',
+        number: 1,
+        list: ['list-item-1', 'list-item-2'],
+      },
+    };
+
+    expect(input).toStrictEqual(expected);
+  });
+
+  it('should create a new corner edge', () => {
+    const input = createNewCornerEdge('source', 'target', {});
+
+    const expected = {
+      id: 'reactflow__edge-source-#corner-target',
+      source: 'source',
+      sourceHandle: 'source',
+      target: 'target',
+      targetHandle: 'target',
+      type: 'defaultEdge',
+      data: {},
+    };
+
+    expect(input).toStrictEqual(expected);
+  });
+
+  it('should an edge between two class nodes', () => {
+    const input = handleEdgeDelete('reactflow__edge-class-1-class-2', [
+      {
+        source: 'class-1',
+        sourceHandle: 'class-1',
+        target: 'class-2',
+        targetHandle: 'class-2',
+        type: 'associationEdge',
+        markerEnd: {
+          type: 'arrowclosed' as MarkerType,
+          height: 30,
+          width: 30,
+        },
+        label: 'Association',
+        data: {},
+        id: 'reactflow__edge-class-1-class-2',
+      },
+    ]);
+
+    expect(input).toStrictEqual([]);
+  });
+});

--- a/datamodel-ui/src/modules/graph/utils.test.ts
+++ b/datamodel-ui/src/modules/graph/utils.test.ts
@@ -2,6 +2,7 @@ import {
   convertToNodes,
   createNewAssociationEdge,
   createNewCornerEdge,
+  generateInitialEdges,
   getConnectedCornerIds,
   handleEdgeDelete,
 } from './utils';
@@ -10,6 +11,7 @@ import {
   connectedEdgesRemovedMultiple,
   convertedExpected,
   convertedLangVersionedExpected,
+  initialEdges,
   threeEdgesOneMultipleSplit,
   twoEdgesOneSplit,
   visualizationTypeArray,
@@ -147,7 +149,7 @@ describe('graph-util', () => {
     expect(input).toStrictEqual(expected);
   });
 
-  it('should an edge between two class nodes', () => {
+  it('should remove an edge between two class nodes', () => {
     const input = handleEdgeDelete('reactflow__edge-class-1-class-2', [
       {
         source: 'class-1',
@@ -167,5 +169,68 @@ describe('graph-util', () => {
     ]);
 
     expect(input).toStrictEqual([]);
+  });
+
+  it('should remove a corner', () => {
+    const input = handleEdgeDelete('reactflow__edge-class-1-#corner-#corner', [
+      {
+        source: 'class-1',
+        sourceHandle: 'class-1',
+        target: '#corner',
+        targetHandle: '#corner',
+        type: 'defaultEdge',
+        data: {},
+        id: 'reactflow__edge-class-1-#corner-#corner',
+      },
+      {
+        source: '#corner',
+        sourceHandle: '#corner',
+        target: 'class-2',
+        targetHandle: 'class-2',
+        type: 'associationEdge',
+        markerEnd: {
+          type: 'arrowclosed' as MarkerType,
+          height: 30,
+          width: 30,
+        },
+        label: 'Association',
+        data: {},
+        id: 'reactflow__edge-#corner-#corner-class-2',
+      },
+    ]);
+
+    expect(input).toStrictEqual([
+      {
+        source: 'class-1',
+        sourceHandle: 'class-1',
+        target: 'class-2',
+        targetHandle: 'class-2',
+        type: 'associationEdge',
+        markerEnd: {
+          type: 'arrowclosed' as MarkerType,
+          height: 30,
+          width: 30,
+        },
+        label: 'Association',
+        data: {},
+        id: 'reactflow__edge-class-1-class-2',
+      },
+    ]);
+  });
+
+  it('should generate association edges', () => {
+    const mockDelete = jest.fn();
+    const mockSplit = jest.fn();
+
+    const input = generateInitialEdges(
+      visualizationTypeArray,
+      mockDelete,
+      mockSplit,
+      'fi'
+    );
+
+    const expected = initialEdges(mockDelete, mockSplit);
+
+    expect(input).toStrictEqual(expected);
   });
 });

--- a/datamodel-ui/src/modules/graph/utils.ts
+++ b/datamodel-ui/src/modules/graph/utils.ts
@@ -1,6 +1,70 @@
 import { VisualizationType } from '@app/common/interfaces/visualization.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
-import { MarkerType, Node } from 'reactflow';
+import { Edge, MarkerType, Node } from 'reactflow';
+
+export function convertToNodes(data: VisualizationType[]): Node[] {
+  const size = data.length;
+  const spread = Math.floor(Math.sqrt(size));
+
+  if (size < 1) {
+    return [];
+  }
+
+  return data.map((obj, idx) => ({
+    id: obj.identifier,
+    position: { x: 400 * (idx % spread), y: 200 * Math.floor(idx / spread) },
+    data: {
+      identifier: obj.identifier,
+      label: getLanguageVersion({
+        data: obj.label,
+        lang: 'fi',
+        appendLocale: true,
+      }),
+      resources: [],
+    },
+    type: 'classNode',
+  }));
+}
+
+export function getConnectedCornerIds(
+  data: Edge[],
+  source?: string,
+  target?: string
+): string[] {
+  if (!source || !target) {
+    return [];
+  }
+
+  return getRelatedEdgeIds(data, source);
+}
+
+function getRelatedEdgeIds(
+  data: Edge[],
+  source: string,
+  ids?: string[]
+): string[] {
+  const s = data.find((edge) => edge.target === source);
+  const retVal = s?.id ?? '';
+  const newSource = s?.source;
+
+  if (retVal && newSource && retVal.includes('corner')) {
+    return getRelatedEdgeIds(
+      data,
+      newSource,
+      ids
+        ? [...ids, retVal]
+        : [data.find((edge) => edge.source === source)?.id ?? '']
+    );
+  }
+
+  return ids
+    ? [...ids, data.find((edge) => edge.source === source)?.id ?? '']
+    : [data.find((edge) => edge.source === source)?.id ?? ''];
+}
+
+/*
+  Mock data generators below. Note! Might be outdated
+*/
 
 export function generateNodesMock(size?: number) {
   const spread = Math.floor(Math.sqrt(size ?? 3));
@@ -41,28 +105,4 @@ export function generateEdgesMock(maxRange: number) {
       label: `edge-${idx + 1}-${target}`,
     };
   });
-}
-
-export function convertToNodes(data: VisualizationType[]): Node[] {
-  const size = data.length;
-  const spread = Math.floor(Math.sqrt(size));
-
-  if (size < 1) {
-    return [];
-  }
-
-  return data.map((obj, idx) => ({
-    id: obj.identifier,
-    position: { x: 400 * (idx % spread), y: 200 * Math.floor(idx / spread) },
-    data: {
-      identifier: obj.identifier,
-      label: getLanguageVersion({
-        data: obj.label,
-        lang: 'fi',
-        appendLocale: true,
-      }),
-      resources: [],
-    },
-    type: 'classNode',
-  }));
 }

--- a/datamodel-ui/src/modules/graph/utils.ts
+++ b/datamodel-ui/src/modules/graph/utils.ts
@@ -1,14 +1,19 @@
 import { VisualizationType } from '@app/common/interfaces/visualization.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
-import { Edge, MarkerType, Node } from 'reactflow';
+import { Edge, MarkerType, Node, XYPosition } from 'reactflow';
 
-export function convertToNodes(data: VisualizationType[]): Node[] {
+export function convertToNodes(
+  data: VisualizationType[],
+  lang?: string
+): Node[] {
+  if (data.length < 1) {
+    return [];
+  }
+
   const size = data.length;
   const spread = Math.floor(Math.sqrt(size));
 
-  if (size < 1) {
-    return [];
-  }
+  console.log('data', data);
 
   return data.map((obj, idx) => ({
     id: obj.identifier,
@@ -17,21 +22,74 @@ export function convertToNodes(data: VisualizationType[]): Node[] {
       identifier: obj.identifier,
       label: getLanguageVersion({
         data: obj.label,
-        lang: 'fi',
+        lang: lang ? lang : 'fi',
         appendLocale: true,
       }),
-      resources: [],
+      resources: obj.attributes
+        ? obj.attributes.map((attr) => ({
+            identifier: attr.identifier,
+            label: getLanguageVersion({
+              data: attr.label,
+              lang: lang ? lang : 'fi',
+              appendLocale: true,
+            }),
+          }))
+        : [],
     },
     type: 'classNode',
   }));
 }
 
-export function getConnectedCornerIds(
-  data: Edge[],
-  source?: string,
-  target?: string
-): string[] {
-  if (!source || !target) {
+export function createNewAssociationEdge(
+  label: string,
+  handleDelete: (id: string, source: string, target: string) => void,
+  splitEdge: (source: string, target: string, x: number, y: number) => void,
+  params: any
+) {
+  return {
+    ...params,
+    type: 'associationEdge',
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      height: 30,
+      width: 30,
+    },
+    label: label,
+    data: {
+      ...params.data,
+      handleDelete: handleDelete,
+      splitEdge: splitEdge,
+    },
+  };
+}
+
+export function createNewCornerNode(id: string, position: XYPosition) {
+  return {
+    id: id,
+    data: {},
+    position: position,
+    type: 'cornerNode',
+  };
+}
+
+export function createNewCornerEdge(
+  source: string,
+  target: string,
+  data: object
+) {
+  return {
+    id: `reactflow__edge-${source}-#corner-${target}`,
+    source: source,
+    sourceHandle: source,
+    target: target,
+    targetHandle: target,
+    type: 'defaultEdge',
+    data: data,
+  };
+}
+
+export function getConnectedCornerIds(data: Edge[], source?: string): string[] {
+  if (!source || data.length < 1) {
     return [];
   }
 
@@ -47,13 +105,17 @@ function getRelatedEdgeIds(
   const retVal = s?.id ?? '';
   const newSource = s?.source;
 
-  if (retVal && newSource && retVal.includes('corner')) {
+  if (!s && ids) {
+    return ids;
+  }
+
+  if (retVal && newSource && retVal.includes('#corner')) {
     return getRelatedEdgeIds(
       data,
       newSource,
       ids
         ? [...ids, retVal]
-        : [data.find((edge) => edge.source === source)?.id ?? '']
+        : [data.find((edge) => edge.source === source)?.id ?? '', retVal]
     );
   }
 
@@ -62,47 +124,67 @@ function getRelatedEdgeIds(
     : [data.find((edge) => edge.source === source)?.id ?? ''];
 }
 
-/*
-  Mock data generators below. Note! Might be outdated
-*/
+export function getUnusedCornerIds(nodes: Node[], edges: Edge[]): string[] {
+  if (nodes.length < 1) {
+    return [];
+  }
 
-export function generateNodesMock(size?: number) {
-  const spread = Math.floor(Math.sqrt(size ?? 3));
+  const corners = nodes.filter((node) => node.id.includes('#corner'));
 
-  return Array.from(Array(size ?? 3)).map((_, idx) => ({
-    id: `${idx + 1}`,
-    position: { x: 400 * (idx % spread), y: 200 * Math.floor(idx / spread) },
-    data: {
-      identifier: (idx + 1).toString(),
-      label: (idx + 1).toString(),
-      resources: Array.from(Array(Math.floor(Math.random() * 3))).map(
-        (_, cIdx) => ({
-          identifier: `${idx + 1}-${cIdx + 1}`,
-          label: `Attribuutti #${cIdx + 1}`,
-        })
-      ),
-    },
-    type: 'classNode',
-  }));
+  if (corners.length < 1) {
+    return [];
+  }
+
+  const ids: string[] = [];
+
+  corners.forEach((corner) => {
+    if (
+      edges.filter(
+        (edge) => edge.source === corner.id || edge.target === corner.id
+      ).length < 2
+    ) {
+      ids.push(corner.id);
+    }
+  });
+
+  return ids;
 }
 
-export function generateEdgesMock(maxRange: number) {
-  const min = Math.round(maxRange / 2);
+export function handleEdgeDelete(edgeId: string, edges: Edge[]) {
+  const delEdge = edges.find((e) => e.id === edgeId);
 
-  return Array.from(
-    Array(Math.floor(Math.random() * (maxRange - min) + min))
-  ).map((_, idx) => {
-    const target = Math.floor(Math.random() * maxRange);
+  if (!delEdge) {
+    return edges;
+  }
 
-    return {
-      id: `reactflow__edge-${idx + 1}-${target}`,
-      source: `${idx + 1}`,
-      target: `${target}`,
-      type: 'associationEdge',
-      markerEnd: {
-        type: MarkerType.Arrow,
-      },
-      label: `edge-${idx + 1}-${target}`,
-    };
-  });
+  // Filter edge if it is directly connected between two class nodes
+  if (
+    !delEdge.target.includes('#corner') &&
+    !delEdge.source.includes('#corner')
+  ) {
+    return edges.filter((e) => e.id !== edgeId);
+  }
+
+  // If edge isn't the last edge between two class nodes (= associationEdge),
+  // bypass the corner node otherwise delete the entire edge between two classes
+  if (delEdge.target.includes('#corner') && delEdge.type === 'defaultEdge') {
+    return edges
+      .filter((e) => e.id !== edgeId)
+      .map((e) => {
+        if (e.source === delEdge.target) {
+          return {
+            ...e,
+            source: delEdge.source,
+            sourceHandle: delEdge.source,
+          };
+        }
+
+        return e;
+      });
+  } else if (delEdge.type === 'associationEdge') {
+    const connectedIds = getConnectedCornerIds(edges, delEdge.source);
+    return edges.filter((e) => !connectedIds.includes(e.id));
+  }
+
+  return edges;
 }


### PR DESCRIPTION
Changes in this PR:
- Support for custom edges added. Users can add corners (=invisible nodes) to an association between two class nodes to draw the edge to their liking.
- Linked attributes are shown in class nodes in graph