### PR TITLE
YTI-2591 use attribute's model id in fetch

### DIFF
--- a/datamodel-ui/src/modules/class-view/class-view.tsx
+++ b/datamodel-ui/src/modules/class-view/class-view.tsx
@@ -419,7 +419,7 @@ export default function ClassView({
                     <ResourceInfo
                       key={`${data.identifier}-attr-${attr.identifier}`}
                       data={attr}
-                      modelId={modelId}
+                      modelId={attr.modelId}
                     />
                   ))}
                 </ExpanderGroup>


### PR DESCRIPTION
Pass attribute's model id to rendering component, because it might refer to an external data model