### PR TITLE
YTI-2580: Language option functionality in modals

### DIFF
--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -23,6 +23,7 @@ interface MultiColumnSearchProps {
   setSelectedId: (value: string) => void;
   searchParams: InternalResourcesSearchParams;
   setSearchParams: (value: InternalResourcesSearchParams) => void;
+  setContentLanguage: (value: string) => void;
   languageVersioned?: boolean;
   applicationProfile?: boolean;
   modelId: string;
@@ -35,6 +36,7 @@ export default function MultiColumnSearch({
   setSelectedId,
   searchParams,
   setSearchParams,
+  setContentLanguage,
   languageVersioned,
   modelId,
   applicationProfile,
@@ -254,6 +256,7 @@ export default function MultiColumnSearch({
                 (lang) => lang.uniqueItemId === i18n.language ?? 'fi'
               )?.uniqueItemId ?? 'fi'
             }
+            onChange={setContentLanguage}
           >
             {languages.map((lang) => (
               <DropdownItem key={lang.uniqueItemId} value={lang.uniqueItemId}>

--- a/datamodel-ui/src/modules/association-modal/index.tsx
+++ b/datamodel-ui/src/modules/association-modal/index.tsx
@@ -142,7 +142,7 @@ export default function AssociationModal({
         }))
       );
     }
-  }, [result, i18n.language, t]);
+  }, [result, i18n.language, contentLanguage, t]);
 
   return (
     <div>

--- a/datamodel-ui/src/modules/association-modal/index.tsx
+++ b/datamodel-ui/src/modules/association-modal/index.tsx
@@ -42,6 +42,7 @@ export default function AssociationModal({
   const [selectedId, setSelectedId] = useState('');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
   const [searchInternalResources, result] = useGetInternalResourcesMutation();
+  const [contentLanguage, setContentLanguage] = useState<string>();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
       query: '',
@@ -68,6 +69,7 @@ export default function AssociationModal({
       pageFrom: 0,
       resourceTypes: [ResourceType.ASSOCIATION],
     });
+    setContentLanguage(undefined);
     setVisible(false);
   };
 
@@ -115,7 +117,7 @@ export default function AssociationModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.identifier,
-            label: getLanguageVersion({ data: r.label, lang: i18n.language }),
+            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true }),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
@@ -165,6 +167,7 @@ export default function AssociationModal({
             setSelectedId={setSelectedId}
             searchParams={searchParams}
             setSearchParams={handleSearch}
+            setContentLanguage={setContentLanguage}
             languageVersioned
             modelId={modelId}
           />

--- a/datamodel-ui/src/modules/attribute-modal/index.tsx
+++ b/datamodel-ui/src/modules/attribute-modal/index.tsx
@@ -42,6 +42,7 @@ export default function AttributeModal({
   const [selectedId, setSelectedId] = useState('');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
   const [searchInternalResources, result] = useGetInternalResourcesMutation();
+  const [contentLanguage, setContentLanguage] = useState<string>();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
       query: '',
@@ -68,6 +69,7 @@ export default function AttributeModal({
       pageFrom: 0,
       resourceTypes: [ResourceType.ATTRIBUTE],
     });
+    setContentLanguage(undefined);
     setVisible(false);
   };
 
@@ -115,7 +117,7 @@ export default function AttributeModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.identifier,
-            label: getLanguageVersion({ data: r.label, lang: i18n.language }),
+            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true }),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
@@ -123,7 +125,7 @@ export default function AttributeModal({
             modified: format(r.modified, (i18n.language as Locale) ?? 'fi'),
             note: getLanguageVersion({
               data: r.note,
-              lang: i18n.language,
+              lang: contentLanguage ?? i18n.language,
               appendLocale: true,
             }),
           },
@@ -140,7 +142,7 @@ export default function AttributeModal({
         }))
       );
     }
-  }, [result, i18n.language, t]);
+  }, [result, i18n.language, t, contentLanguage]);
 
   return (
     <div>
@@ -165,6 +167,7 @@ export default function AttributeModal({
             setSelectedId={setSelectedId}
             searchParams={searchParams}
             setSearchParams={handleSearch}
+            setContentLanguage={setContentLanguage}
             languageVersioned
             modelId={modelId}
           />

--- a/datamodel-ui/src/modules/class-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-modal/index.tsx
@@ -144,7 +144,7 @@ export default function ClassModal({
         }))
       );
     }
-  }, [result, i18n.language, t]);
+  }, [result, i18n.language, t, contentLanguage]);
 
   return (
     <>

--- a/datamodel-ui/src/modules/class-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-modal/index.tsx
@@ -41,6 +41,7 @@ export default function ClassModal({
   const [visible, setVisible] = useState(false);
   const [selectedId, setSelectedId] = useState(initialSelected ?? '');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
+  const [contentLanguage, setContentLanguage] = useState<string>();
   const [searchInternalResources, result] = useGetInternalResourcesMutation();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
@@ -74,6 +75,7 @@ export default function ClassModal({
       limitToModelType: 'LIBRARY',
       resourceTypes: [ResourceType.CLASS],
     });
+    setContentLanguage(undefined);
     setVisible(false);
   };
 
@@ -118,7 +120,7 @@ export default function ClassModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.id,
-            label: getLanguageVersion({ data: r.label, lang: i18n.language }),
+            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true}),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
@@ -169,9 +171,10 @@ export default function ClassModal({
             setSelectedId={setSelectedId}
             searchParams={searchParams}
             setSearchParams={handleSearch}
+            setContentLanguage={setContentLanguage}
             modelId={modelId}
             applicationProfile={applicationProfile}
-            languageVersioned={applicationProfile}
+            languageVersioned
           />
         </ModalContent>
         <ModalFooter>


### PR DESCRIPTION
Changelog:
- Language option in modals now work
- Append language tag if chosen language not available for label
![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/19401683/751c8340-7735-45d6-bd60-58dd3889402f)
