### PR TITLE
YTI-2578 search modal extended info

### DIFF
--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -102,8 +102,7 @@
     "sv": "Swedish"
   },
   "languages-available": "Languages available",
-  "library": "Core Vocabulary",
-  "library-variant": "Core Data Model",
+  "library": "Core Data Model",
   "library-with-count_one": "Core Data Model ({{count}}) item",
   "library-with-count_other": "Core Data Model ({{count}}) items",
   "link-opens-new-window-external": "Link opens a new window to",

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -102,8 +102,7 @@
     "sv": "ruotsi"
   },
   "languages-available": "Kieliä saatavilla",
-  "library": "Tietokomponenttikirjasto",
-  "library-variant": "Ydintietomalli",
+  "library": "Ydintietomalli",
   "library-with-count_one": "Ydintietomalli ({{count}}) kpl",
   "library-with-count_other": "Ydintietomalli ({{count}}) kpl",
   "link-opens-new-window-external": "Avaa uuden ikkunan sivulle",

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -103,7 +103,6 @@
   },
   "languages-available": "",
   "library": "",
-  "library-variant": "",
   "library-with-count_one": "",
   "library-with-count_other": "",
   "link-opens-new-window-external": "",

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -190,7 +190,7 @@ export default function MultiColumnSearch({
             }}
           >
             <DropdownItem value={'LIBRARY'}>
-              {t('library-variant', { ns: 'common' })}
+              {t('library', { ns: 'common' })}
             </DropdownItem>
             <DropdownItem value={'PROFILE'}>
               {t('profile', { ns: 'common' })}
@@ -272,6 +272,7 @@ export default function MultiColumnSearch({
         items={results}
         selected={selectedId}
         handleClick={handleRadioButtonClick}
+        serviceCategories={serviceCategoriesResult}
       />
     </div>
   );

--- a/datamodel-ui/src/common/components/resource-list/index.tsx
+++ b/datamodel-ui/src/common/components/resource-list/index.tsx
@@ -7,7 +7,12 @@ import {
   Text,
 } from 'suomifi-ui-components';
 import { StatusChip, ResultsTable } from './resource-list.styles';
-import { useTranslation } from 'next-i18next';
+import { i18n, useTranslation } from 'next-i18next';
+import { translateModelType } from '@app/common/utils/translation-helpers';
+import { Type } from '@app/common/interfaces/type.interface';
+import { ServiceCategory } from '@app/common/interfaces/service-categories.interface';
+import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import SanitizedTextContent from 'yti-common-ui/sanitized-text-content';
 
 export interface ResultType {
   target: {
@@ -21,7 +26,7 @@ export interface ResultType {
   };
   partOf?: {
     label: string;
-    type: string;
+    type: Type;
     domains: string[];
   };
   subClass: {
@@ -38,6 +43,7 @@ interface ResourceListProps {
   selected?: string | string[];
   extraHeader?: React.ReactFragment;
   handleClick: (value: string | string[]) => void;
+  serviceCategories?: ServiceCategory[];
 }
 
 export default function ResourceList({
@@ -47,6 +53,7 @@ export default function ResourceList({
   selected,
   extraHeader,
   handleClick,
+  serviceCategories,
 }: ResourceListProps) {
   const { t } = useTranslation('admin');
 
@@ -163,32 +170,48 @@ export default function ResourceList({
                   <Text>{item.partOf.label}</Text>
                   <div>
                     <Text>
-                      <Icon icon="calendar" /> {item.partOf.type}
+                      <Icon icon="calendar" />{' '}
+                      {translateModelType(item.partOf.type, t)}
                     </Text>{' '}
                     <StatusChip $isValid={item.target.isValid}>
                       {item.target.status}
                     </StatusChip>
                   </div>
-                  <Text>{item.partOf.domains.join(', ')}</Text>
+                  <Text>
+                    {item.partOf.domains
+                      .map((domain) =>
+                        getLanguageVersion({
+                          data: serviceCategories?.find(
+                            (cat) => cat.identifier === domain
+                          )?.label,
+                          lang: i18n?.language ?? 'fi',
+                        })
+                      )
+                      .join(', ')}
+                  </Text>
                 </div>
               </td>
             )}
             <td>
               <div>
-                <ExternalLink
-                  href={item.subClass.link}
-                  labelNewWindow={t('link-opens-new-window-external', {
-                    ns: 'common',
-                  })}
-                >
-                  {item.subClass.label}
-                </ExternalLink>
-                <Text>{item.subClass.partOf}</Text>
+                {item.subClass.link && (
+                  <>
+                    <ExternalLink
+                      href={item.subClass.link}
+                      labelNewWindow={t('link-opens-new-window-external', {
+                        ns: 'common',
+                      })}
+                    >
+                      {item.subClass.label}
+                    </ExternalLink>
+                    <Text>{item.subClass.partOf}</Text>
+                  </>
+                )}
               </div>
             </td>
             <td>
               <div>
-                <Text>{item.target.note}</Text>
+                <SanitizedTextContent text={item.target.note} />
               </div>
             </td>
           </tr>

--- a/datamodel-ui/src/common/components/resource-list/resource-list.styles.tsx
+++ b/datamodel-ui/src/common/components/resource-list/resource-list.styles.tsx
@@ -53,6 +53,15 @@ export const ResultsTable = styled.table<{ $expandedLastCell?: boolean }>`
         display: flex;
         flex-direction: column;
       }
+
+      td:last-child > div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-height: 80px;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+      }
     }
   }
 

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -2,7 +2,10 @@ import { HYDRATE } from 'next-redux-wrapper';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
 import { Status } from '@app/common/interfaces/status.interface';
-import { SearchInternalClasses } from '@app/common/interfaces/search-internal-classes.interface';
+import {
+  SearchInternalClasses,
+  SearchInternalClassesInfo,
+} from '@app/common/interfaces/search-internal-classes.interface';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { Type } from '@app/common/interfaces/type.interface';
 
@@ -17,12 +20,17 @@ export interface InternalResourcesSearchParams {
   pageSize?: number;
   pageFrom?: number;
   limitToModelType?: Type;
+  extend?: boolean;
 }
 
 function createUrl(obj: InternalResourcesSearchParams): string {
-  let baseQuery = `/frontend/searchInternalResources?query=${
-    obj.query
-  }&pageSize=${obj.pageSize ?? 50}&pageFrom=${obj.pageFrom ?? 0}`;
+  const basePath = obj.extend
+    ? '/frontend/searchInternalResourcesInfo'
+    : '/frontend/searchInternalResources';
+
+  let baseQuery = `${basePath}?query=${obj.query}&pageSize=${
+    obj.pageSize ?? 50
+  }&pageFrom=${obj.pageFrom ?? 0}`;
 
   if (obj.sortLang) {
     baseQuery = baseQuery.concat(`&sortLang=${obj.sortLang}`);
@@ -89,6 +97,15 @@ export const searchInternalResourcesApi = createApi({
         method: 'GET',
       }),
     }),
+    getInternalResourcesInfo: builder.mutation<
+      SearchInternalClassesInfo,
+      InternalResourcesSearchParams
+    >({
+      query: (object) => ({
+        url: createUrl(Object.assign(object, { extend: true })),
+        method: 'GET',
+      }),
+    }),
   }),
 });
 
@@ -98,5 +115,6 @@ export const { getInternalResources, queryInternalResources } =
 export const {
   useGetInternalResourcesMutation,
   useQueryInternalResourcesQuery,
+  useGetInternalResourcesInfoMutation,
   util: { getRunningQueriesThunk },
 } = searchInternalResourcesApi;

--- a/datamodel-ui/src/common/interfaces/internal-class.interface.ts
+++ b/datamodel-ui/src/common/interfaces/internal-class.interface.ts
@@ -1,5 +1,6 @@
 import { ResourceType } from './resource-type.interface';
 import { Status } from './status.interface';
+import { Type } from './type.interface';
 
 export interface InternalClass {
   created: string;
@@ -17,4 +18,24 @@ export interface InternalClass {
   };
   resourceType: ResourceType;
   status: Status;
+}
+
+export interface InternalClassInfo extends InternalClass {
+  dataModelInfo: {
+    label: {
+      [key: string]: string;
+    };
+    groups: string[];
+    status: Status;
+    modelType: Type;
+  };
+  conceptInfo: {
+    conceptURI: string;
+    conceptLabel: {
+      [key: string]: string;
+    };
+    terminologyLabel: {
+      [key: string]: string;
+    };
+  };
 }

--- a/datamodel-ui/src/common/interfaces/search-internal-classes.interface.ts
+++ b/datamodel-ui/src/common/interfaces/search-internal-classes.interface.ts
@@ -1,6 +1,11 @@
-import { InternalClass } from './internal-class.interface';
+import { InternalClass, InternalClassInfo } from './internal-class.interface';
 
 export interface SearchInternalClasses {
   totalHitCount: number;
   responseObjects: InternalClass[];
+}
+
+export interface SearchInternalClassesInfo {
+  totalHitCount: number;
+  responseObjects: InternalClassInfo[];
 }

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -5,11 +5,11 @@ import { Type } from '../interfaces/type.interface';
 export function translateModelType(type: Type, t: TFunction) {
   switch (type) {
     case 'LIBRARY':
-      return t('library');
+      return t('library', { ns: 'common' });
     case 'PROFILE':
-      return t('profile');
+      return t('profile', { ns: 'common' });
     default:
-      return t('profile');
+      return t('profile', { ns: 'common' });
   }
 }
 

--- a/datamodel-ui/src/modules/association-modal/index.tsx
+++ b/datamodel-ui/src/modules/association-modal/index.tsx
@@ -11,7 +11,7 @@ import { LargeModal } from './association-modal.styles';
 import { useTranslation } from 'next-i18next';
 import {
   InternalResourcesSearchParams,
-  useGetInternalResourcesMutation,
+  useGetInternalResourcesInfoMutation,
 } from '@app/common/components/search-internal-resources/search-internal-resources.slice';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
@@ -41,7 +41,8 @@ export default function AssociationModal({
   const [visible, setVisible] = useState(false);
   const [selectedId, setSelectedId] = useState('');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
-  const [searchInternalResources, result] = useGetInternalResourcesMutation();
+  const [searchInternalResources, result] =
+    useGetInternalResourcesInfoMutation();
   const [contentLanguage, setContentLanguage] = useState<string>();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
@@ -117,7 +118,11 @@ export default function AssociationModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.identifier,
-            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true }),
+            label: getLanguageVersion({
+              data: r.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
@@ -125,19 +130,31 @@ export default function AssociationModal({
             modified: format(r.modified, (i18n.language as Locale) ?? 'fi'),
             note: getLanguageVersion({
               data: r.note,
-              lang: i18n.language,
+              lang: contentLanguage ?? i18n.language,
               appendLocale: true,
             }),
           },
           partOf: {
-            label: 'Tietomallin nimi',
-            type: 'Tietomallin tyyppi',
-            domains: ['Asuminen', 'Elinkeinot'],
+            label: getLanguageVersion({
+              data: r.dataModelInfo.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            type: r.dataModelInfo.modelType,
+            domains: r.dataModelInfo.groups,
           },
           subClass: {
-            label: 'Linkki käsitteeseen',
-            link: '#',
-            partOf: 'Sanaston nimi',
+            label: getLanguageVersion({
+              data: r.conceptInfo?.conceptLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            link: r.conceptInfo?.conceptURI,
+            partOf: getLanguageVersion({
+              data: r.conceptInfo?.terminologyLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
           },
         }))
       );

--- a/datamodel-ui/src/modules/attribute-modal/index.tsx
+++ b/datamodel-ui/src/modules/attribute-modal/index.tsx
@@ -11,7 +11,7 @@ import { LargeModal } from './attribute-modal.styles';
 import { useTranslation } from 'next-i18next';
 import {
   InternalResourcesSearchParams,
-  useGetInternalResourcesMutation,
+  useGetInternalResourcesInfoMutation,
 } from '@app/common/components/search-internal-resources/search-internal-resources.slice';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
@@ -41,7 +41,8 @@ export default function AttributeModal({
   const [visible, setVisible] = useState(false);
   const [selectedId, setSelectedId] = useState('');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
-  const [searchInternalResources, result] = useGetInternalResourcesMutation();
+  const [searchInternalResources, result] =
+    useGetInternalResourcesInfoMutation();
   const [contentLanguage, setContentLanguage] = useState<string>();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
@@ -117,7 +118,11 @@ export default function AttributeModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.identifier,
-            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true }),
+            label: getLanguageVersion({
+              data: r.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
@@ -130,14 +135,26 @@ export default function AttributeModal({
             }),
           },
           partOf: {
-            label: 'Tietomallin nimi',
-            type: 'Tietomallin tyyppi',
-            domains: ['Asuminen', 'Elinkeinot'],
+            label: getLanguageVersion({
+              data: r.dataModelInfo.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            type: r.dataModelInfo.modelType,
+            domains: r.dataModelInfo.groups,
           },
           subClass: {
-            label: 'Linkki käsitteeseen',
-            link: '#',
-            partOf: 'Sanaston nimi',
+            label: getLanguageVersion({
+              data: r.conceptInfo?.conceptLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            link: r.conceptInfo?.conceptURI,
+            partOf: getLanguageVersion({
+              data: r.conceptInfo?.terminologyLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
           },
         }))
       );

--- a/datamodel-ui/src/modules/class-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-modal/index.tsx
@@ -11,10 +11,10 @@ import {
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import MultiColumnSearch from '@app/common/components/multi-column-search';
 import { LargeModal, OpenModalButton } from './class-modal.styles';
-import { InternalClass } from '@app/common/interfaces/internal-class.interface';
+import { InternalClassInfo } from '@app/common/interfaces/internal-class.interface';
 import {
   InternalResourcesSearchParams,
-  useGetInternalResourcesMutation,
+  useGetInternalResourcesInfoMutation,
 } from '@app/common/components/search-internal-resources/search-internal-resources.slice';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { ResultType } from '@app/common/components/resource-list';
@@ -23,7 +23,10 @@ export interface ClassModalProps {
   modelId: string;
   modalButtonLabel?: string;
   mode?: 'create' | 'select';
-  handleFollowUp: (value?: InternalClass, targetIsAppProfile?: boolean) => void;
+  handleFollowUp: (
+    value?: InternalClassInfo,
+    targetIsAppProfile?: boolean
+  ) => void;
   applicationProfile?: boolean;
   initialSelected?: string;
 }
@@ -42,7 +45,8 @@ export default function ClassModal({
   const [selectedId, setSelectedId] = useState(initialSelected ?? '');
   const [resultsFormatted, setResultsFormatted] = useState<ResultType[]>([]);
   const [contentLanguage, setContentLanguage] = useState<string>();
-  const [searchInternalResources, result] = useGetInternalResourcesMutation();
+  const [searchInternalResources, result] =
+    useGetInternalResourcesInfoMutation();
   const [searchParams, setSearchParams] =
     useState<InternalResourcesSearchParams>({
       query: '',
@@ -120,26 +124,42 @@ export default function ClassModal({
         result.data.responseObjects.map((r) => ({
           target: {
             identifier: r.id,
-            label: getLanguageVersion({ data: r.label, lang: contentLanguage ?? i18n.language, appendLocale: true}),
+            label: getLanguageVersion({
+              data: r.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
             linkLabel: getLinkLabel(r.namespace, r.identifier),
             link: r.id,
             status: translateStatus(r.status, t),
             isValid: r.status === 'VALID',
             note: getLanguageVersion({
               data: r.note,
-              lang: i18n.language,
+              lang: contentLanguage ?? i18n.language,
               appendLocale: true,
             }),
           },
           partOf: {
-            label: 'Tietomallin nimi',
-            type: 'Tietomallin tyyppi',
-            domains: ['Asuminen', 'Elinkeinot'],
+            label: getLanguageVersion({
+              data: r.dataModelInfo.label,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            type: r.dataModelInfo.modelType,
+            domains: r.dataModelInfo.groups,
           },
           subClass: {
-            label: 'Linkki käsitteeseen',
-            link: '#',
-            partOf: 'Sanaston nimi',
+            label: getLanguageVersion({
+              data: r.conceptInfo?.conceptLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
+            link: r.conceptInfo?.conceptURI,
+            partOf: getLanguageVersion({
+              data: r.conceptInfo?.terminologyLabel,
+              lang: contentLanguage ?? i18n.language,
+              appendLocale: true,
+            }),
           },
         }))
       );

--- a/datamodel-ui/src/modules/class-restriction-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-restriction-modal/index.tsx
@@ -75,7 +75,7 @@ export default function ClassRestrictionModal({
                   partOf: {
                     domains: ['domain-1'],
                     label: 'partOfLabel',
-                    type: 'tyyppi',
+                    type: 'LIBRARY',
                   },
                   target: {
                     identifier: 'id-11',
@@ -122,7 +122,7 @@ export default function ClassRestrictionModal({
                   partOf: {
                     domains: ['domain-1'],
                     label: 'partOfLabel',
-                    type: 'tyyppi',
+                    type: 'LIBRARY',
                   },
                   target: {
                     identifier: 'id-1',
@@ -143,7 +143,7 @@ export default function ClassRestrictionModal({
                   partOf: {
                     domains: ['domain-1'],
                     label: 'partOfLabel',
-                    type: 'tyyppi',
+                    type: 'LIBRARY',
                   },
                   target: {
                     identifier: 'id-2',
@@ -164,7 +164,7 @@ export default function ClassRestrictionModal({
                   partOf: {
                     domains: ['domain-2'],
                     label: 'partOfLabel',
-                    type: 'tyyppi',
+                    type: 'LIBRARY',
                   },
                   target: {
                     identifier: 'id-3',

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -214,7 +214,7 @@ export default function FrontPage() {
               },
               {
                 id: 'library',
-                label: t('library-variant'),
+                label: t('library'),
               },
             ]}
             partOfText={t('card-information-domains')}

--- a/datamodel-ui/src/modules/model-form/index.tsx
+++ b/datamodel-ui/src/modules/model-form/index.tsx
@@ -125,7 +125,7 @@ export default function ModelForm({
             id="library-radio-button"
             disabled={disabled}
           >
-            {t('library-variant', { ns: 'common' })}
+            {t('library', { ns: 'common' })}
           </RadioButton>
         </RadioButtonGroup>
 


### PR DESCRIPTION
- use separate endpoint when searching resources in modals (see [backend changes](https://github.com/VRK-YTI/yti-datamodel-api/pull/141/))
- display data model and concept information in search results
- remove old translations for core data model (Tietokomponenttikirjasto)