### PR TITLE
YTI-2620 change terms' order

### DIFF
--- a/terminology-ui/src/common/utils/compare-locals.ts
+++ b/terminology-ui/src/common/utils/compare-locals.ts
@@ -7,18 +7,9 @@ export interface TermBlockType {
 }
 
 // Prioritizes Finnish and Swedish over other languages
-export function compareLocales(
-  t1: TermBlockType | Property,
-  t2: TermBlockType | Property
-): number {
-  const t1Lang =
-    'regex' in t1
-      ? t1.lang.toLowerCase()
-      : t1.term.properties.prefLabel?.[0].lang.toLowerCase() ?? '';
-  const t2Lang =
-    'regex' in t2
-      ? t2.lang.toLowerCase()
-      : t2.term.properties.prefLabel?.[0].lang.toLowerCase() ?? '';
+export function compareLocales(t1: Property, t2: Property): number {
+  const t1Lang = t1.lang.toLowerCase();
+  const t2Lang = t2.lang.toLowerCase();
 
   if (t1Lang === 'fi' || t2Lang === 'fi') {
     return t1Lang === 'fi' ? -1 : 1;

--- a/terminology-ui/src/modules/concept/utils.test.tsx
+++ b/terminology-ui/src/modules/concept/utils.test.tsx
@@ -1,0 +1,126 @@
+import { getBlockData } from './utils';
+
+describe('order concept data', () => {
+  it('should order terms', () => {
+    const x = '';
+
+    const data = getBlockData(
+      jest.fn((x) => x),
+      concept
+    );
+    const termLabels = data.terms.map(
+      (t) => t.term.properties.prefLabel?.[0].value
+    );
+    const defintions = data.definitions.map((def) => def.value);
+
+    const expectedTermOrder = [
+      'finnish pref term',
+      'finnish synonym',
+      'finnish not recommended',
+      'swedish pref term',
+      'swedish synonym',
+      'german pref term',
+    ];
+
+    const expectedDefinitionOrder = [
+      'finnish definition',
+      'swedish definition',
+    ];
+
+    expect(JSON.stringify(termLabels)).toBe(JSON.stringify(expectedTermOrder));
+    expect(JSON.stringify(defintions)).toBe(
+      JSON.stringify(expectedDefinitionOrder)
+    );
+  });
+});
+
+const concept = {
+  id: '123',
+  properties: {
+    definition: [
+      {
+        lang: 'sv',
+        value: 'swedish definition',
+      },
+      {
+        lang: 'fi',
+        value: 'finnish definition',
+      },
+    ],
+  },
+  referrers: {},
+  references: {
+    altLabelXl: [
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'fi',
+              value: 'finnish synonym',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'sv',
+              value: 'swedish synonym',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+    ],
+    prefLabelXl: [
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'fi',
+              value: 'finnish pref term',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'de',
+              value: 'german pref term',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'sv',
+              value: 'swedish pref term',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+    ],
+    notRecommendedSynonym: [
+      {
+        properties: {
+          prefLabel: [
+            {
+              lang: 'fi',
+              value: 'finnish not recommended',
+              regex: '(?s)^.*$',
+            },
+          ],
+        },
+      },
+    ],
+  },
+};

--- a/terminology-ui/src/modules/concept/utils.tsx
+++ b/terminology-ui/src/modules/concept/utils.tsx
@@ -1,6 +1,38 @@
 import { Concept } from '@app/common/interfaces/concept.interface';
+import { Term } from '@app/common/interfaces/term.interface';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import { TFunction } from 'next-i18next';
+
+const langOrder: { [key: string]: string } = {
+  fi: 'a',
+  sv: 'b',
+  en: 'c',
+};
+
+const termTypeOrder: { [key: string]: string } = {
+  prefLabelXl: 'a',
+  altLabelXl: 'b',
+};
+
+/**
+ * Create compare key to simplify ordering terms.
+ * Terms order withing language: recommended term, synonyms, other terms
+ * Final order:
+ * - finnish terms
+ * - swedish terms
+ * - english terms
+ * - terms in other languages ordered by language name
+ *
+ * @param term term object
+ * @param type term's type
+ * @returns
+ */
+function getCompareKey(term: Term, type: string) {
+  const lang = term.properties.prefLabel?.[0].lang;
+  return `${langOrder[lang ?? ''] ?? `x_${lang}`}_${
+    termTypeOrder[type] ?? 'x'
+  }`;
+}
 
 export function getBlockData(t: TFunction, concept?: Concept) {
   if (!concept) {
@@ -11,20 +43,24 @@ export function getBlockData(t: TFunction, concept?: Concept) {
     ...(concept.references.prefLabelXl ?? []).map((term) => ({
       term,
       type: t('field-terms-preferred', { ns: 'concept' }),
+      compareKey: getCompareKey(term, 'prefLabelXl'),
     })),
     ...(concept.references.altLabelXl ?? []).map((term) => ({
       term,
       type: t('field-terms-alternative', { ns: 'concept' }),
+      compareKey: getCompareKey(term, 'altLabelXl'),
     })),
     ...(concept.references.notRecommendedSynonym ?? []).map((term) => ({
       term,
       type: t('field-terms-non-recommended', { ns: 'concept' }),
+      compareKey: getCompareKey(term, 'notRecommendedSynonym'),
     })),
     ...(concept.references.hiddenTerm ?? []).map((term) => ({
       term,
       type: t('field-terms-hidden', { ns: 'concept' }),
+      compareKey: getCompareKey(term, 'hiddenTerm'),
     })),
-  ].sort((t1, t2) => compareLocales(t1, t2));
+  ].sort((t1, t2) => t1.compareKey.localeCompare(t2.compareKey));
 
   const definitions =
     concept.properties.definition


### PR DESCRIPTION
Generated compare key for terms to simplify ordering. Terms are grouped by language and their order is
- Preferable term
- Synonyms
- Other terms

Language order is
- Finnish terms
- Swedish terms
- English terms
- Terms in other language ordered by language name