### PR TITLE
YTI-2612 Fix ordering properrty lists

### DIFF
--- a/terminology-ui/src/common/utils/compare-locals.ts
+++ b/terminology-ui/src/common/utils/compare-locals.ts
@@ -7,9 +7,12 @@ export interface TermBlockType {
 }
 
 // Prioritizes Finnish and Swedish over other languages
-export function compareLocales(t1: Property, t2: Property): number {
-  const t1Lang = t1.lang.toLowerCase();
-  const t2Lang = t2.lang.toLowerCase();
+export function compareLocales(
+  t1: Property | string,
+  t2: Property | string
+): number {
+  const t1Lang = typeof t1 === 'object' ? t1.lang.toLowerCase() : t1;
+  const t2Lang = typeof t2 === 'object' ? t2.lang.toLowerCase() : t2;
 
   if (t1Lang === 'fi' || t2Lang === 'fi') {
     return t1Lang === 'fi' ? -1 : 1;
@@ -24,4 +27,29 @@ export function compareLocales(t1: Property, t2: Property): number {
   }
 
   return 0;
+}
+
+/**
+ * Preserves order withing the language
+ *
+ * @param properties
+ * @returns
+ */
+export function sortPropertyListByLanguage(
+  properties?: Property[]
+): Property[] {
+  // map properties by language
+  const propertiesByLanguage =
+    properties?.slice().reduce((result, property) => {
+      if (!result[property.lang]) {
+        result[property.lang] = [];
+      }
+      result[property.lang].unshift(property);
+      return result;
+    }, {} as { [key: string]: Property[] }) ?? {};
+
+  // sort by key (=language) and flat map
+  return Object.keys(propertiesByLanguage)
+    .sort(compareLocales)
+    .flatMap((lang) => propertiesByLanguage[lang]);
 }

--- a/terminology-ui/src/modules/concept/utils.tsx
+++ b/terminology-ui/src/modules/concept/utils.tsx
@@ -1,6 +1,9 @@
 import { Concept } from '@app/common/interfaces/concept.interface';
 import { Term } from '@app/common/interfaces/term.interface';
-import { compareLocales } from '@app/common/utils/compare-locals';
+import {
+  compareLocales,
+  sortPropertyListByLanguage,
+} from '@app/common/utils/compare-locals';
 import { TFunction } from 'next-i18next';
 
 const langOrder: { [key: string]: string } = {
@@ -68,14 +71,8 @@ export function getBlockData(t: TFunction, concept?: Concept) {
       ?.slice()
       .sort((t1, t2) => compareLocales(t1, t2)) ?? [];
 
-  const notes =
-    concept.properties.note?.slice().sort((t1, t2) => compareLocales(t1, t2)) ??
-    [];
-
-  const examples =
-    concept.properties.example
-      ?.slice()
-      .sort((t1, t2) => compareLocales(t1, t2)) ?? [];
+  const notes = sortPropertyListByLanguage(concept.properties.note);
+  const examples = sortPropertyListByLanguage(concept.properties.example);
 
   return { terms, definitions, notes, examples };
 }


### PR DESCRIPTION
compareLocales method returns 0 when comparing values with the same locale. This might cause that the list in not in the same order in different browsers. Added an extra step to compare functionality that the property list is mapped by language and sorting is performed based on language key. 