### PR TITLE
YTI-2425 Use separate endpoint for each model type

### DIFF
--- a/datamodel-ui/src/common/components/class/class.slice.tsx
+++ b/datamodel-ui/src/common/components/class/class.slice.tsx
@@ -59,7 +59,7 @@ function convertToPUT(
 }
 
 function pathForModelType(isApplicationProfile?: boolean) {
-  return isApplicationProfile ? 'profile/' : 'ontology/';
+  return isApplicationProfile ? 'profile/' : 'library/';
 }
 
 export const classApi = createApi({

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -22,7 +22,7 @@ export const modelApi = createApi({
   endpoints: (builder) => ({
     putModel: builder.mutation<string, NewModel>({
       query: (value) => ({
-        url: '/model',
+        url: `/model/${value.type === 'LIBRARY' ? 'library' : 'profile'}`,
         method: 'PUT',
         data: value,
       }),
@@ -38,10 +38,13 @@ export const modelApi = createApi({
       {
         payload: ModelUpdatePayload;
         prefix: string;
+        isApplicationProfile: boolean;
       }
     >({
       query: (value) => ({
-        url: `/model/${value.prefix}`,
+        url: `/model/${value.isApplicationProfile ? 'profile' : 'library'}/${
+          value.prefix
+        }`,
         method: 'POST',
         data: value.payload,
       }),

--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -37,7 +37,7 @@ function convertToPUT(
 }
 
 function pathForModelType(isApplicationProfile?: boolean) {
-  return isApplicationProfile ? 'profile/' : 'ontology/';
+  return isApplicationProfile ? 'profile/' : 'library/';
 }
 
 export const resourceApi = createApi({

--- a/datamodel-ui/src/modules/documentation/index.tsx
+++ b/datamodel-ui/src/modules/documentation/index.tsx
@@ -101,6 +101,7 @@ export default function Documentation({ modelId }: { modelId: string }) {
     postModel({
       payload: payload,
       prefix: modelData.prefix,
+      isApplicationProfile: modelData.type === 'PROFILE',
     });
   };
 

--- a/datamodel-ui/src/modules/linked-data-form/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-form/index.tsx
@@ -78,7 +78,11 @@ export default function LinkedDataForm({
   const handleSubmit = () => {
     const internalNamespaces = data.internalNamespaces.map((n) => n.uri);
     const payload = generatePayload({ ...data, internalNamespaces });
-    postModel({ payload: payload, prefix: data.prefix });
+    postModel({
+      payload: payload,
+      prefix: data.prefix,
+      isApplicationProfile: data.type === 'PROFILE',
+    });
   };
 
   useEffect(() => {

--- a/datamodel-ui/src/modules/model/model-edit-view.tsx
+++ b/datamodel-ui/src/modules/model/model-edit-view.tsx
@@ -103,7 +103,11 @@ export default function ModelEditView({
 
     const payload = generatePayload(formData);
 
-    postModel({ payload: payload, prefix: formData.prefix });
+    postModel({
+      payload: payload,
+      prefix: formData.prefix,
+      isApplicationProfile: formData.type === 'PROFILE',
+    });
   };
 
   return (


### PR DESCRIPTION
- Use different endpoints for libraries and profiles
- Rename path /ontology -> /library

See also backend changes: https://github.com/VRK-YTI/yti-datamodel-api/pull/148