### PR TITLE
YTI-2643: Added datamodel type to resources and fix endpoint

### DIFF
--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -40,8 +40,14 @@ function pathForModelType(isApplicationProfile?: boolean) {
   return isApplicationProfile ? 'profile/' : 'library/';
 }
 
-function pathForResourceType(type: ResourceType) {
-  return type === ResourceType.ATTRIBUTE ? 'attribute' : 'association';
+function pathForResourceType(
+  type: ResourceType,
+  isApplicationProfile?: boolean
+) {
+  if (isApplicationProfile) {
+    return '';
+  }
+  return type === ResourceType.ATTRIBUTE ? '/attribute' : '/association';
 }
 
 export const resourceApi = createApi({
@@ -70,10 +76,13 @@ export const resourceApi = createApi({
         url: !value.resourceId
           ? `/resource/${pathForModelType(value.applicationProfile)}${
               value.modelId
-            }/${pathForResourceType(value.data.type)}`
+            }${pathForResourceType(value.data.type, value.applicationProfile)}`
           : `/resource/${pathForModelType(value.applicationProfile)}${
               value.modelId
-            }/${pathForResourceType(value.data.type)}/${value.resourceId}`,
+            }${pathForResourceType(
+              value.data.type,
+              value.applicationProfile
+            )}/${value.resourceId}`,
         method: 'PUT',
         data: {
           ...convertToPUT(value.data, value.resourceId ? true : false),

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -217,6 +217,7 @@ export default function ResourceView({
                 }}
                 handleFollowUp={handleFollowUp}
                 buttonIcon={true}
+                applicationProfile={applicationProfile}
               />
             )}
           </div>
@@ -285,7 +286,7 @@ export default function ResourceView({
         modelId={modelId}
         languages={languages}
         terminologies={terminologies}
-        applicationProfile={false}
+        applicationProfile={applicationProfile}
         isEdit={isEdit}
         handleReturn={isEdit ? handleFormReturn : handleReturn}
       />

--- a/datamodel-ui/src/modules/resource/resource-modal/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-modal/index.tsx
@@ -34,6 +34,7 @@ interface ResourceModalProps {
   };
   handleFollowUp: (value?: { label: string; uri: string }) => void;
   buttonIcon?: boolean;
+  applicationProfile?: boolean;
 }
 
 export default function ResourceModal({
@@ -42,6 +43,7 @@ export default function ResourceModal({
   buttonTranslations,
   handleFollowUp,
   buttonIcon,
+  applicationProfile,
 }: ResourceModalProps) {
   const { t, i18n } = useTranslation('admin');
   const { isSmall } = useBreakpoints();
@@ -207,6 +209,7 @@ export default function ResourceModal({
             searchParams={searchParams}
             setSearchParams={handleSearch}
             setContentLanguage={setContentLanguage}
+            applicationProfile={applicationProfile}
             languageVersioned
             modelId={modelId}
           />


### PR DESCRIPTION
Changelog:
- Fix application profile creation, broken due to wrong endpoint path from frontend
- All application profile modals (attribute, association, class) now can filter with datamodel type