### PR TITLE
YTI-2624 handle external resources in the list

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -121,6 +121,7 @@ const initialState = {
   selected: {
     id: '',
     type: '',
+    modelId: null,
   },
   hovered: {
     id: '',
@@ -159,6 +160,7 @@ export const modelSlice = createSlice({
         selected: {
           id: action.payload.id,
           type: action.payload.type,
+          modelId: action.payload.modelId,
         },
         view: {
           ...initialView,
@@ -233,9 +235,12 @@ export function selectSelected() {
 
 export function setSelected(
   id: string,
-  type: keyof typeof initialView
+  type: keyof typeof initialView,
+  modelId?: string
 ): AppThunk {
-  return (dispatch) => dispatch(modelSlice.actions.setSelected({ id, type }));
+  console.info('set selected', id, modelId);
+  return (dispatch) =>
+    dispatch(modelSlice.actions.setSelected({ id, type, modelId }));
 }
 
 export function resetSelected(): AppThunk {

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -238,7 +238,6 @@ export function setSelected(
   type: keyof typeof initialView,
   modelId?: string
 ): AppThunk {
-  console.info('set selected', id, modelId);
   return (dispatch) =>
     dispatch(modelSlice.actions.setSelected({ id, type, modelId }));
 }

--- a/datamodel-ui/src/modules/model/search-view.tsx
+++ b/datamodel-ui/src/modules/model/search-view.tsx
@@ -59,9 +59,9 @@ export default function SearchView({ modelId }: { modelId: string }) {
       )
     );
     router.replace(
-      `${modelId}/${data.resourceType.toLowerCase()}${
-        resourceModelId !== modelId ? '-ext' : ''
-      }/${data.identifier}`
+      `${modelId}/${data.resourceType.toLowerCase()}/${
+        resourceModelId !== modelId ? `${resourceModelId}:` : ''
+      }${data.identifier}`
     );
   };
 

--- a/datamodel-ui/src/modules/model/search-view.tsx
+++ b/datamodel-ui/src/modules/model/search-view.tsx
@@ -13,6 +13,7 @@ import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { translateResourceType } from '@app/common/utils/translation-helpers';
 import { useStoreDispatch } from '@app/store';
 import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import { SearchInput, Text } from 'suomifi-ui-components';
 import DrawerContent from 'yti-common-ui/drawer/drawer-content-wrapper';
@@ -33,6 +34,7 @@ export default function SearchView({ modelId }: { modelId: string }) {
     pageFrom: (currentPage - 1) * 20,
     resourceTypes: [],
   });
+  const router = useRouter();
 
   const getResourceType = (type: ResourceType): keyof ViewList => {
     switch (type) {
@@ -46,8 +48,21 @@ export default function SearchView({ modelId }: { modelId: string }) {
   };
 
   const handleItemClick = (data: InternalClass) => {
+    const resourceModelId = data.namespace.split('/').filter(Boolean).pop();
+
     dispatch(setView(getResourceType(data.resourceType), 'info'));
-    dispatch(setSelected(data.identifier, getResourceType(data.resourceType)));
+    dispatch(
+      setSelected(
+        data.identifier,
+        getResourceType(data.resourceType),
+        resourceModelId
+      )
+    );
+    router.replace(
+      `${modelId}/${data.resourceType.toLowerCase()}${
+        resourceModelId !== modelId ? '-ext' : ''
+      }/${data.identifier}`
+    );
   };
 
   const handleQueryChange = (e: string) => {
@@ -100,7 +115,10 @@ export default function SearchView({ modelId }: { modelId: string }) {
                     </Text>
                   </>
                 ),
-                subtitle: `${modelId}:${item.identifier}`,
+                subtitle: `${item.namespace
+                  ?.split('/')
+                  ?.filter(Boolean)
+                  ?.pop()}:${item.identifier}`,
                 onClick: () => handleItemClick(item),
                 onMouseEnter: () => {
                   dispatch(

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -104,7 +104,6 @@ export default function ResourceView({
         modelPrefix
       )
     );
-
     router.replace(
       `${modelId}/${
         type === ResourceType.ASSOCIATION ? 'association' : 'attribute'

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -65,13 +65,6 @@ export default function ResourceView({
   const [currentPage, setCurrentPage] = useState(1);
   const [query, setQuery] = useState('');
   const [isEdit, setIsEdit] = useState(false);
-  const [currentResourceId, setCurrentResourceId] = useState<
-    string | undefined
-  >(
-    getResourceInfo(router.query.slug)?.type === type.toString().toLowerCase()
-      ? getResourceInfo(router.query.slug)?.id
-      : undefined
-  );
 
   const { data, refetch } = useQueryInternalResourcesQuery({
     query: query ?? '',
@@ -84,11 +77,11 @@ export default function ResourceView({
   const { data: resourceData, refetch: refetchResource } = useGetResourceQuery(
     {
       modelId: globalSelected.modelId ?? modelId,
-      resourceIdentifier: currentResourceId ?? '',
+      resourceIdentifier: globalSelected.id ?? '',
       applicationProfile,
     },
     {
-      skip: typeof currentResourceId === 'undefined',
+      skip: !globalSelected.id,
     }
   );
 
@@ -111,10 +104,11 @@ export default function ResourceView({
         modelPrefix
       )
     );
+
     router.replace(
       `${modelId}/${
         type === ResourceType.ASSOCIATION ? 'association' : 'attribute'
-      }${modelPrefix !== modelId ? '-ext' : ''}/${id}`
+      }/${modelPrefix !== modelId ? `${modelPrefix}:` : ''}${id}`
     );
   };
 
@@ -178,17 +172,6 @@ export default function ResourceView({
       setHeaderHeight(ref.current.clientHeight);
     }
   }, [ref, view]);
-
-  useEffect(() => {
-    if (
-      type === ResourceType.ASSOCIATION
-        ? globalSelected.type === 'associations'
-        : globalSelected.type === 'attributes' &&
-          currentResourceId !== globalSelected.id
-    ) {
-      setCurrentResourceId(globalSelected.id);
-    }
-  }, [globalSelected, currentResourceId, type]);
 
   return (
     <>
@@ -272,7 +255,6 @@ export default function ResourceView({
     if (!view.info || !resourceData) {
       return <></>;
     }
-    // TODO: globalSelected will be reset???
     return (
       <ResourceInfo
         data={resourceData}
@@ -285,7 +267,7 @@ export default function ResourceView({
   }
 
   function renderEdit() {
-    if (!view.edit || !hasPermission) {
+    if (!view.edit || !hasPermission || globalSelected.modelId !== modelId) {
       return <></>;
     }
 

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -83,7 +83,7 @@ export default function ResourceView({
 
   const { data: resourceData, refetch: refetchResource } = useGetResourceQuery(
     {
-      modelId: modelId,
+      modelId: globalSelected.modelId ?? modelId,
       resourceIdentifier: currentResourceId ?? '',
       applicationProfile,
     },
@@ -97,7 +97,7 @@ export default function ResourceView({
     setCurrentPage(1);
   };
 
-  const handleShowResource = (id: string) => {
+  const handleShowResource = (id: string, modelPrefix: string) => {
     dispatch(
       setView(
         type === ResourceType.ASSOCIATION ? 'associations' : 'attributes',
@@ -107,13 +107,14 @@ export default function ResourceView({
     dispatch(
       setSelected(
         id,
-        type === ResourceType.ASSOCIATION ? 'associations' : 'attributes'
+        type === ResourceType.ASSOCIATION ? 'associations' : 'attributes',
+        modelPrefix
       )
     );
     router.replace(
       `${modelId}/${
         type === ResourceType.ASSOCIATION ? 'association' : 'attribute'
-      }/${id}`
+      }${modelPrefix !== modelId ? '-ext' : ''}/${id}`
     );
   };
 
@@ -241,14 +242,18 @@ export default function ResourceView({
             <Text>{t('datamodel-no-attributes')}</Text>
           ) : (
             <DrawerItemList
-              items={data.responseObjects.map((item) => ({
-                label: getLanguageVersion({
-                  data: item.label,
-                  lang: i18n.language,
-                }),
-                subtitle: `${modelId}:${item.identifier}`,
-                onClick: () => handleShowResource(item.identifier),
-              }))}
+              items={data.responseObjects.map((item) => {
+                const prefix =
+                  item.namespace?.split('/')?.filter(Boolean)?.pop() ?? modelId;
+                return {
+                  label: getLanguageVersion({
+                    data: item.label,
+                    lang: i18n.language,
+                  }),
+                  subtitle: `${prefix}:${item.identifier}`,
+                  onClick: () => handleShowResource(item.identifier, prefix),
+                };
+              })}
             />
           )}
 
@@ -267,13 +272,14 @@ export default function ResourceView({
     if (!view.info || !resourceData) {
       return <></>;
     }
-
+    // TODO: globalSelected will be reset???
     return (
       <ResourceInfo
         data={resourceData}
         modelId={modelId}
         handleEdit={handleEdit}
         handleReturn={handleReturn}
+        isPartOfCurrentModel={globalSelected.modelId === modelId}
       />
     );
   }

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -266,7 +266,7 @@ export default function ResourceView({
   }
 
   function renderEdit() {
-    if (!view.edit || !hasPermission || globalSelected.modelId !== modelId) {
+    if (!view.edit || !hasPermission) {
       return <></>;
     }
 

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -28,6 +28,7 @@ interface CommonViewProps {
   modelId: string;
   handleReturn: () => void;
   handleEdit: () => void;
+  isPartOfCurrentModel: boolean;
 }
 
 export default function ResourceInfo({
@@ -35,6 +36,7 @@ export default function ResourceInfo({
   modelId,
   handleReturn,
   handleEdit,
+  isPartOfCurrentModel,
 }: CommonViewProps) {
   const { t, i18n } = useTranslation('common');
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -66,7 +68,7 @@ export default function ResourceInfo({
           >
             {data ? translateCommonForm('return', data.type, t) : t('back')}
           </Button>
-          {hasPermission && data && (
+          {hasPermission && isPartOfCurrentModel && data && (
             <div>
               <Button
                 variant="secondary"

--- a/datamodel-ui/src/modules/resource/utils.ts
+++ b/datamodel-ui/src/modules/resource/utils.ts
@@ -13,7 +13,7 @@ export function resourceToResourceFormType(
     status: 'DRAFT',
     equivalentResource: [],
     subResourceOf:
-      data.subResourceOf.length > 0
+      data.subResourceOf?.length > 0
         ? data.subResourceOf.map((sro) => {
             if (
               sro.endsWith('/owl#topDataProperty') ||

--- a/datamodel-ui/src/pages/model/[...slug].tsx
+++ b/datamodel-ui/src/pages/model/[...slug].tsx
@@ -150,13 +150,23 @@ export const getServerSideProps = createCommonGetServerSideProps(
         await Promise.all(store.dispatch(getClassRunningQueriesThunk()));
       }
 
-      if (['association', 'attribute'].includes(resourceType)) {
+      if (
+        [
+          'association',
+          'attribute',
+          'attribute-ext',
+          'association-ext',
+        ].includes(resourceType)
+      ) {
         store.dispatch(
           setView(
-            resourceType === 'association' ? 'associations' : 'attributes',
+            resourceType.startsWith('association')
+              ? 'associations'
+              : 'attributes',
             'info'
           )
         );
+        // TODO: should check ends with -ext?
         store.dispatch(
           getResource.initiate({
             modelId: modelId,


### PR DESCRIPTION
Support to view external resources 
- add model id to globalSelected object
- add curie to uri in case of external resource, e.g. `/model/profile/model_id/attribute/ext:test-attribute`
- remove setting currentResource id because the same information is available in globalSelected -object
