### PR TITLE
Fix crash bugs and languages have to be inputted properly

### DIFF
--- a/datamodel-ui/src/common/utils/get-organizations.ts
+++ b/datamodel-ui/src/common/utils/get-organizations.ts
@@ -1,4 +1,5 @@
 import { Organization } from '../interfaces/organizations.interface';
+import { getLanguageVersion } from './get-language-version';
 
 export default function getOrganizations(
   organizationsData?: Organization[],
@@ -12,7 +13,11 @@ export default function getOrganizations(
     const id = org.id.replaceAll('urn:uuid:', '');
     return {
       id: id,
-      label: org.label[lang ?? 'fi'],
+      label: getLanguageVersion({
+        data: org.label,
+        lang: lang ?? 'fi',
+        appendLocale: true,
+      }),
     };
   });
 }

--- a/datamodel-ui/src/modules/model-form/generate-payload.tsx
+++ b/datamodel-ui/src/modules/model-form/generate-payload.tsx
@@ -15,19 +15,15 @@ export default function generatePayload(data: ModelFormType): NewModel {
         }),
         {}
       ),
-    label: data.languages
-      .filter((l) => l.title !== '')
-      .reduce(
-        (obj, l) => ({
-          ...obj,
-          [l.uniqueItemId]: l.title,
-        }),
-        {}
-      ),
+    label: data.languages.reduce(
+      (obj, l) => ({
+        ...obj,
+        [l.uniqueItemId]: l.title,
+      }),
+      {}
+    ),
     groups: data.serviceCategories.map((s) => s.uniqueItemId),
-    languages: data.languages
-      .filter((l) => l.title !== '')
-      .map((l) => l.uniqueItemId),
+    languages: data.languages.map((l) => l.uniqueItemId),
     organizations: data.organizations.map((o) => o.uniqueItemId),
     prefix: data.prefix,
     status: 'DRAFT',

--- a/datamodel-ui/src/modules/model-form/model-form-modal.tsx
+++ b/datamodel-ui/src/modules/model-form/model-form-modal.tsx
@@ -71,7 +71,7 @@ export default function ModelFormModal({ refetch }: ModelFormModalProps) {
     const errors = validateForm(formData);
     setErrors(errors);
 
-    if (Object.values(errors).includes(true)) {
+    if (Object.values(errors).includes(true) || errors.titleAmount.length > 0) {
       return;
     }
 


### PR DESCRIPTION
Changelog:
YTI-2648:  all names for chosen language have to be inputted
YTI-2647:  if a name has not been not been inputted show error and dont submit
YTI-2650: organization not having a translated name caused a crash on when closing the multiselect