### PR TITLE
YTI-2651: Fix ternary operator adding http to external ns

### DIFF
--- a/datamodel-ui/src/modules/linked-model/index.tsx
+++ b/datamodel-ui/src/modules/linked-model/index.tsx
@@ -132,7 +132,7 @@ export default function LinkedModel({
       setExternalData({
         ...data,
         namespace:
-          !data.namespace.startsWith('http://') ||
+          !data.namespace.startsWith('http://') &&
           !data.namespace.startsWith('https://')
             ? `http://${data.namespace}`
             : data.namespace,


### PR DESCRIPTION
Changelog:
Fix ternary operator adding http at the end of external namespaces