### PR TITLE
Tweaked Class typing and replaced translation

### DIFF
--- a/datamodel-ui/src/common/components/class/class.slice.tsx
+++ b/datamodel-ui/src/common/components/class/class.slice.tsx
@@ -21,10 +21,12 @@ function convertToPUT(
 
   const ret = {
     ...retVal,
-    equivalentClass: data.equivalentClass.map((eq) => eq.identifier),
+    equivalentClass: data.equivalentClass?.map((eq) => eq.identifier) ?? [],
     subClassOf: data.subClassOf
-      .filter((soc) => soc.identifier !== 'owl:Thing')
-      .map((sco) => sco.identifier),
+      ? data.subClassOf
+          .filter((soc) => soc.identifier !== 'owl:Thing')
+          .map((sco) => sco.identifier)
+      : [],
     subject: conceptURI,
     ...(basedOnNodeShape
       ? {
@@ -171,19 +173,6 @@ export const classSlice = createSlice({
       };
     },
   },
-  // extraReducers: (builder) => {
-  //   builder.addMatcher(
-  //     classApi.endpoints.getClass.matchFulfilled, (state, action) => {
-  //       if (isEqual(state, action.payload)) {
-  //         return state;
-  //       }
-  //       return action.payload;
-  //     }
-  //   );
-  //   builder.addMatcher(isHydrate, (_, action) => {
-  //     return action.payload.model;
-  //   });
-  // }
 });
 
 export function selectClass() {

--- a/datamodel-ui/src/common/interfaces/class-form.interface.ts
+++ b/datamodel-ui/src/common/interfaces/class-form.interface.ts
@@ -4,14 +4,14 @@ import { Status } from './status.interface';
 export interface ClassFormType {
   editorialNote: string;
   concept?: ConceptType;
-  equivalentClass: {
+  equivalentClass?: {
     label: string;
     identifier: string;
   }[];
   identifier: string;
   label: { [key: string]: string };
   note: { [key: string]: string };
-  subClassOf: {
+  subClassOf?: {
     label: string;
     identifier: string;
     attributes: string[];

--- a/datamodel-ui/src/common/interfaces/class.interface.ts
+++ b/datamodel-ui/src/common/interfaces/class.interface.ts
@@ -17,8 +17,8 @@ export interface ClassType {
   label: { [key: string]: string };
   editorialNote?: string;
   status: Status;
-  equivalentClass: string[];
-  subClassOf: string[];
+  equivalentClass?: string[];
+  subClassOf?: string[];
   subject?: ConceptType;
   identifier: string;
   created: string;

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -229,9 +229,9 @@ export default function ClassForm({
     key: 'subClassOf' | 'equivalentClass'
   ) => {
     if (key === 'subClassOf') {
-      const newSubClasses = data.subClassOf.filter(
-        (subclass) => subclass.identifier !== id
-      );
+      const newSubClasses = data.subClassOf
+        ? data.subClassOf.filter((subclass) => subclass.identifier !== id)
+        : [];
 
       if (newSubClasses.length < 1) {
         handleUpdate({
@@ -255,8 +255,8 @@ export default function ClassForm({
 
     handleUpdate({
       ...data,
-      [key]: data[key]
-        ? data[key].filter((item) => item.identifier !== id)
+      [key]: data.equivalentClass
+        ? data.equivalentClass.filter((item) => item.identifier !== id)
         : [],
     });
   };
@@ -271,10 +271,11 @@ export default function ClassForm({
 
     if (key === 'subClassOf') {
       const initData =
+        data.subClassOf &&
         data.subClassOf.length === 1 &&
         data.subClassOf[0].identifier === 'owl:Thing'
           ? []
-          : data.subClassOf;
+          : data.subClassOf ?? [];
 
       handleUpdate({
         ...data,
@@ -296,7 +297,7 @@ export default function ClassForm({
       handleUpdate({
         ...data,
         equivalentClass: [
-          ...data.equivalentClass,
+          ...(data.equivalentClass ?? []),
           {
             label: `${value.namespace.split('/').filter(Boolean).pop()}:${
               value.identifier
@@ -507,7 +508,7 @@ export default function ClassForm({
               />
             }
             items={
-              data.subClassOf.length > 0
+              data.subClassOf && data.subClassOf.length > 0
                 ? data.subClassOf.map((s) => ({
                     label: s.label,
                     id: s.identifier,

--- a/datamodel-ui/src/modules/class-view/utils.ts
+++ b/datamodel-ui/src/modules/class-view/utils.ts
@@ -76,7 +76,7 @@ export function classTypeToClassForm(data: ClassType): ClassFormType {
     concept: data.subject,
     editorialNote: data.editorialNote ?? '',
     equivalentClass:
-      data.equivalentClass.map((ec) => ({
+      data.equivalentClass?.map((ec) => ({
         identifier: ec,
         label: ec,
       })) ?? [],
@@ -85,10 +85,11 @@ export function classTypeToClassForm(data: ClassType): ClassFormType {
     note: data.note,
     status: data.status,
     subClassOf:
+      data.subClassOf &&
       data.subClassOf.filter(
         (soc) => soc !== 'http://www.w3.org/2002/07/owl#Thing'
       ).length > 0
-        ? data.subClassOf.map((sco) => ({
+        ? data.subClassOf?.map((sco) => ({
             identifier: sco,
             label: sco,
             attributes: [],

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -124,7 +124,7 @@ export default function CommonViewContent({
               <BasicBlock title={t('allowed-values')}>
                 {data.allowedValues && data.allowedValues.length > 0
                   ? data.allowedValues.join(', ')
-                  : t('selected-codelists')}
+                  : t('not-defined')}
               </BasicBlock>
 
               <BasicBlock title={t('default-value', { ns: 'admin' })}>


### PR DESCRIPTION
Changes in this PR:
- `equivalentClass` and `subResourceOf` in `Class` type changed to possibly be undefined which better reflects real life cases
- Changed an incorrect translation 