### PR TITLE
YTI-2627 Namespace selection

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -184,6 +184,7 @@
   "missing-prefix": "Prefix hasn't been set",
   "namespace": "Namespace",
   "namespace-is-not-valid": "Namespace isn't valid",
+  "namespace-missing-info": "If you didn't find the namespace you need, please contact the administrator",
   "namespace-with-examples": "Namespace (URI, URN etc.)",
   "no-terminologies-available": "No terminologies available",
   "no-work-group-comment": "No work group comment",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -184,6 +184,7 @@
   "missing-prefix": "Tietomallin tunnusta ei ole määritelty",
   "namespace": "Nimiavaruus",
   "namespace-is-not-valid": "Nimiavaruus ei ole laillisessa muodossa",
+  "namespace-missing-info": "Mikäli et löydä tarvitsemaasi tietomallia, ota yhteyttä ylläpitoon",
   "namespace-with-examples": "Nimiavaruus (URI, URN tms.)",
   "no-terminologies-available": "Sanastoja ei saatavilla",
   "no-work-group-comment": "Ei työryhmän sisäistä kommenttia",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -184,6 +184,7 @@
   "missing-prefix": "",
   "namespace": "",
   "namespace-is-not-valid": "",
+  "namespace-missing-info": "",
   "namespace-with-examples": "",
   "no-terminologies-available": "",
   "no-work-group-comment": "",

--- a/datamodel-ui/src/common/components/namespaces/namespaces.slice.ts
+++ b/datamodel-ui/src/common/components/namespaces/namespaces.slice.ts
@@ -1,0 +1,32 @@
+import { HYDRATE } from 'next-redux-wrapper';
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
+
+export const namespacesApi = createApi({
+  reducerPath: 'namespacesApi',
+  baseQuery: getDatamodelApiBaseQuery((headers) => ({
+    ...headers,
+    accept: 'application/json',
+  })),
+  tagTypes: ['namespaces'],
+  extractRehydrationInfo(action, { reducerPath }) {
+    if (action.type === HYDRATE) {
+      return action.payload[reducerPath];
+    }
+  },
+  endpoints: (builder) => ({
+    getNamespaces: builder.query<string[], void>({
+      query: () => ({
+        url: '/frontend/namespaces',
+        method: 'GET',
+      }),
+    }),
+  }),
+});
+
+export const { getNamespaces } = namespacesApi.endpoints;
+
+export const {
+  useGetNamespacesQuery,
+  util: { getRunningQueriesThunk },
+} = namespacesApi;

--- a/datamodel-ui/src/common/utils/get-value.ts
+++ b/datamodel-ui/src/common/utils/get-value.ts
@@ -26,6 +26,8 @@ function getLangObject(data: { [key: string]: string }) {
   });
 }
 
+export const ADMIN_EMAIL = 'yhteentoimivuus@dvv.fi';
+
 export function getTitle(data?: ModelType, lang?: string): string {
   if (!data) {
     return '';
@@ -95,7 +97,7 @@ export function getComments(data?: ModelType): LangObject[] {
 }
 
 export function getContact(data?: ModelType): string {
-  return data?.contact ?? 'yhteentoimivuus@dvv.fi';
+  return data?.contact ?? ADMIN_EMAIL;
 }
 
 export function getDocumentation(data?: ModelType): string {

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -29,6 +29,7 @@ import HasPermission from '@app/common/utils/has-permission';
 import DeleteModal from '../delete-modal';
 import { useSelector } from 'react-redux';
 import { selectDisplayLang } from '@app/common/components/model/model.slice';
+import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
 interface ClassInfoProps {
   data?: ClassType;
@@ -381,7 +382,7 @@ export default function ClassInfo({
             {t('class-contact-description')}
             <ExternalLink
               href={`mailto:${
-                data.contact ?? 'yhteentoimivuus@dvv.fi'
+                data.contact ?? ADMIN_EMAIL
               }?subject=${getLanguageVersion({
                 data: data.label,
                 lang: displayLang ?? i18n.language,

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -18,6 +18,7 @@ import SanitizedTextContent from 'yti-common-ui/sanitized-text-content';
 import HasPermission from '@app/common/utils/has-permission';
 import { useSelector } from 'react-redux';
 import { selectDisplayLang } from '@app/common/components/model/model.slice';
+import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
 export default function CommonViewContent({
   modelId,
@@ -362,7 +363,7 @@ export default function CommonViewContent({
         {translateCommonForm('contact-description', data.type, t)}
         <ExternalLink
           href={`mailto:${
-            data.contact ?? 'yhteentoimivuus@dvv.fi'
+            data.contact ?? ADMIN_EMAIL
           }?subject=${getLanguageVersion({
             data: data.label,
             lang: displayLang ?? i18n.language,

--- a/datamodel-ui/src/modules/linked-model/index.tsx
+++ b/datamodel-ui/src/modules/linked-model/index.tsx
@@ -5,6 +5,7 @@ import {
   Chip,
   ExternalLink,
   IconPlus,
+  InlineAlert,
   Modal,
   ModalContent,
   ModalFooter,
@@ -17,6 +18,9 @@ import { useGetSearchModelsQuery } from '@app/common/components/search-models/se
 import { useTranslation } from 'next-i18next';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import isURL from 'validator/lib/isURL';
+import { useGetNamespacesQuery } from '@app/common/components/namespaces/namespaces.slice';
+import { WideSingleSelect } from '../model-form/model-form.styles';
+import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
 export default function LinkedModel({
   initialData,
@@ -78,6 +82,10 @@ export default function LinkedModel({
     },
     { skip: keyword === '' }
   );
+
+  const { data: namespaces } = useGetNamespacesQuery(void null, {
+    skip: !showExternalForm,
+  });
 
   const setDataValue = (key: keyof typeof data, value: string) => {
     if (userPosted && Object.values(errors).some((val) => val === true)) {
@@ -214,7 +222,7 @@ export default function LinkedModel({
         <ModalTitle>{t('add-reference-to-data-model')}</ModalTitle>
 
         <ContentWrapper>
-          <div>
+          <div className="namespaceInternal">
             <TextInput
               labelText={t('search-data-model')}
               onChange={(e) => setKeyword(e?.toString() ?? '')}
@@ -317,6 +325,34 @@ export default function LinkedModel({
         <ModalTitle>{t('add-reference-to-data-model-outside')}</ModalTitle>
 
         <ContentWrapper>
+          <WideSingleSelect
+            labelText={t('namespace-with-examples')}
+            items={
+              namespaces?.map((ns) => ({
+                uniqueItemId: ns,
+                labelText: ns,
+              })) ?? []
+            }
+            visualPlaceholder={t('input-uri-namespace')}
+            clearButtonLabel=""
+            itemAdditionHelpText=""
+            ariaOptionsAvailableText=""
+            onItemSelect={(e) => setDataValue('namespace', e?.toString() ?? '')}
+            id="namespaces-dropdown"
+            status={userPosted && errors.namespace ? 'error' : 'default'}
+            statusText={
+              userPosted && errors.namespace ? t('namespace-is-not-valid') : ''
+            }
+          />
+          <InlineAlert>
+            {t('namespace-missing-info')}{' '}
+            <ExternalLink
+              href={`mailto:${ADMIN_EMAIL}`}
+              labelNewWindow={t('link-opens-new-window-external')}
+            >
+              {ADMIN_EMAIL}
+            </ExternalLink>
+          </InlineAlert>
           <TextInput
             labelText={t('data-model-name')}
             visualPlaceholder={t('input-data-model-name')}
@@ -324,18 +360,6 @@ export default function LinkedModel({
             onChange={(e) => setDataValue('name', e?.toString() ?? '')}
             status={userPosted && errors.name ? 'error' : 'default'}
             id="data-model-name-input"
-          />
-
-          <TextInput
-            labelText={t('namespace-with-examples')}
-            visualPlaceholder={t('input-uri-namespace')}
-            fullWidth
-            onChange={(e) => setDataValue('namespace', e?.toString() ?? '')}
-            status={userPosted && errors.namespace ? 'error' : 'default'}
-            statusText={
-              userPosted && errors.namespace ? t('namespace-is-not-valid') : ''
-            }
-            id="namespace-input"
           />
 
           <TextInput

--- a/datamodel-ui/src/modules/linked-model/linked-model.styles.tsx
+++ b/datamodel-ui/src/modules/linked-model/linked-model.styles.tsx
@@ -5,7 +5,7 @@ export const ContentWrapper = styled.div`
   flex-direction: column;
   gap: ${(props) => props.theme.suomifi.spacing.m};
 
-  div:first-child {
+  div.namespaceInternal {
     display: inherit;
     flex-direction: row;
     justify-content: space-between;

--- a/datamodel-ui/src/modules/model-form/generate-payload.tsx
+++ b/datamodel-ui/src/modules/model-form/generate-payload.tsx
@@ -1,5 +1,6 @@
 import { ModelFormType } from '@app/common/interfaces/model-form.interface';
 import { NewModel } from '@app/common/interfaces/new-model.interface';
+import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
 export default function generatePayload(data: ModelFormType): NewModel {
   const SUOMI_FI_NAMESPACE = 'http://uri.suomi.fi/datamodel/ns/';
@@ -28,6 +29,6 @@ export default function generatePayload(data: ModelFormType): NewModel {
     prefix: data.prefix,
     status: 'DRAFT',
     type: data.type.toUpperCase(),
-    contact: data.contact !== '' ? data.contact : 'yhteentoimivuus@dvv.fi',
+    contact: data.contact !== '' ? data.contact : ADMIN_EMAIL,
   };
 }

--- a/datamodel-ui/src/modules/model-form/model-form.styles.tsx
+++ b/datamodel-ui/src/modules/model-form/model-form.styles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Block, MultiSelect } from 'suomifi-ui-components';
+import { Block, MultiSelect, SingleSelect } from 'suomifi-ui-components';
 
 export const ModelFormContainer = styled(Block)`
   display: flex;
@@ -18,6 +18,10 @@ export const BlockContainer = styled.div`
 `;
 
 export const WideMultiSelect = styled(MultiSelect)`
+  min-width: 100%;
+`;
+
+export const WideSingleSelect = styled(SingleSelect)`
   min-width: 100%;
 `;
 

--- a/datamodel-ui/src/modules/model/generate-payload.tsx
+++ b/datamodel-ui/src/modules/model/generate-payload.tsx
@@ -3,6 +3,7 @@ import {
   ModelType,
   ModelUpdatePayload,
 } from '@app/common/interfaces/model.interface';
+import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
 export default function generatePayload(
   data: ModelFormType | ModelType
@@ -53,7 +54,7 @@ export default function generatePayload(
       terminologies: data.terminologies.map((t) => t.uri),
       codeLists: data.codeLists.map((c) => c.id),
       documentation: data.documentation ?? {},
-      contact: data.contact !== '' ? data.contact : 'yhteentoimivuus@dvv.fi',
+      contact: data.contact !== '' ? data.contact : ADMIN_EMAIL,
     };
   }
 }

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -15,6 +15,7 @@ import {
 } from 'suomifi-ui-components';
 import { BasicBlock, MultilingualBlock } from 'yti-common-ui/block';
 import {
+  ADMIN_EMAIL,
   getIsPartOfWithId,
   getOrganizationsWithId,
   getUri,
@@ -294,14 +295,14 @@ export default function ModelInfoView() {
             href={`mailto:${
               modelInfo.contact && modelInfo.contact !== ''
                 ? modelInfo.contact
-                : 'yhteentoimivuus@dvv.fi'
+                : ADMIN_EMAIL
             }?subject=${getLanguageVersion({
               data: modelInfo.label,
               lang: i18n.language,
             })}`}
             labelNewWindow={t('link-opens-new-window-external')}
           >
-            {modelInfo.contact ?? 'yhteentoimivuus@dvv.fi'}
+            {modelInfo.contact ?? ADMIN_EMAIL}
           </ExternalLink>
         </BasicBlock>
       </DrawerContent>

--- a/datamodel-ui/src/store/index.tsx
+++ b/datamodel-ui/src/store/index.tsx
@@ -23,6 +23,7 @@ import { visualizationApi } from '@app/common/components/visualization/visualiza
 import { activeSlice } from '@app/common/components/active/active.slice';
 import { codeApi } from '@app/common/components/code/code.slice';
 import { datatypesApi } from '@app/common/components/datatypes/datatypes.slice';
+import { namespacesApi } from '@app/common/components/namespaces/namespaces.slice';
 
 // make Context from next-redux-wrapper compatible with next-iron-session
 export type NextIronContext = Context | (Context & { req: NextApiRequest });
@@ -53,6 +54,7 @@ export function makeStore(ctx: NextIronContext) {
       [activeSlice.name]: activeSlice.reducer,
       [codeApi.reducerPath]: codeApi.reducer,
       [datatypesApi.reducerPath]: datatypesApi.reducer,
+      [namespacesApi.reducerPath]: namespacesApi.reducer,
     },
 
     middleware: (getDefaultMiddleware) =>
@@ -72,7 +74,8 @@ export function makeStore(ctx: NextIronContext) {
         conceptSearchApi.middleware,
         visualizationApi.middleware,
         codeApi.middleware,
-        datatypesApi.middleware
+        datatypesApi.middleware,
+        namespacesApi.middleware
       ),
 
     // Development tools should be available only in development environments


### PR DESCRIPTION
- Fetch available namespaces from backend (see [changes](https://github.com/VRK-YTI/yti-datamodel-api/pull/160)) and populate results to SingeSelect component
- Some style fixes in the namespace modal
- Add constant for admin email