### PR TITLE
YTI2693 change visualization response type

### DIFF
--- a/datamodel-ui/src/common/components/visualization/visualization.slice.tsx
+++ b/datamodel-ui/src/common/components/visualization/visualization.slice.tsx
@@ -1,7 +1,7 @@
 import { HYDRATE } from 'next-redux-wrapper';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
-import { VisualizationType } from '@app/common/interfaces/visualization.interface';
+import { VisualizationResult } from '@app/common/interfaces/visualization.interface';
 
 export const visualizationApi = createApi({
   reducerPath: 'visualizationApi',
@@ -13,7 +13,7 @@ export const visualizationApi = createApi({
     }
   },
   endpoints: (builder) => ({
-    getVisualization: builder.query<VisualizationType[], string>({
+    getVisualization: builder.query<VisualizationResult, string>({
       query: (modelId) => ({
         url: `/visualization/${modelId}`,
         method: 'GET',

--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -13,6 +13,20 @@ export interface VisualizationType {
   associations: {
     identifier: string;
     label: { [key: string]: string };
-    route: string[];
+    referenceTarget: string;
   }[];
+}
+
+export interface VisualizationHiddenNode {
+  identifier: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  referenceTarget: string;
+}
+
+export interface VisualizationResult {
+  nodes: VisualizationType[];
+  hiddenNodes: VisualizationHiddenNode[];
 }

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -163,9 +163,14 @@ const GraphContent = ({ modelId, children }: GraphProps) => {
 
   useEffect(() => {
     if (isSuccess) {
-      setNodes(convertToNodes(data, i18n.language));
+      setNodes(convertToNodes(data.nodes, i18n.language));
       setEdges(
-        generateInitialEdges(data, deleteEdgeById, splitEdge, i18n.language)
+        generateInitialEdges(
+          data.nodes,
+          deleteEdgeById,
+          splitEdge,
+          i18n.language
+        )
       );
     }
   }, [

--- a/datamodel-ui/src/modules/graph/util.test.data.ts
+++ b/datamodel-ui/src/modules/graph/util.test.data.ts
@@ -21,7 +21,7 @@ export const visualizationTypeArray: VisualizationType[] = [
           fi: 'assoc-1-fi',
           en: 'assoc-1-en',
         },
-        route: ['2'],
+        referenceTarget: '2',
       },
     ],
   },
@@ -42,7 +42,7 @@ export const visualizationTypeArray: VisualizationType[] = [
         label: {
           en: 'assoc-2-en',
         },
-        route: ['3'],
+        referenceTarget: '3',
       },
     ],
   },

--- a/datamodel-ui/src/modules/graph/utils.ts
+++ b/datamodel-ui/src/modules/graph/utils.ts
@@ -67,9 +67,9 @@ export function generateInitialEdges(
           {
             source: obj.identifier,
             sourceHandle: obj.identifier,
-            target: assoc.route[0],
-            targetHandle: assoc.route[0],
-            id: `reactflow__edge-${obj.identifier}-${assoc.route[0]}`,
+            target: assoc.referenceTarget,
+            targetHandle: assoc.referenceTarget,
+            id: `reactflow__edge-${obj.identifier}-${assoc.referenceTarget}`,
           }
         )
       )


### PR DESCRIPTION
Backend changes: https://github.com/VRK-YTI/yti-datamodel-api/pull/164

- Change visualization response type 
- Change association property route (array) -> referenceTarget (string)