### PR TITLE
.png download support added

### DIFF
--- a/datamodel-ui/package.json
+++ b/datamodel-ui/package.json
@@ -20,6 +20,7 @@
     "@fontsource/source-sans-pro": "^4.5.9",
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.4.0",
+    "html-to-image": "^1.11.11",
     "iron-session": "^6.3.1",
     "next": "^12.1.6",
     "next-i18next": "^12.0.1",

--- a/datamodel-ui/src/common/components/model-tools/download-picture.tsx
+++ b/datamodel-ui/src/common/components/model-tools/download-picture.tsx
@@ -1,0 +1,51 @@
+import { toPng } from 'html-to-image';
+import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
+import { Button, IconDownload } from 'suomifi-ui-components';
+import { useGetModelQuery } from '../model/model.slice';
+
+function downloadImg(dataUrl: string, fileName: string) {
+  const a = document.createElement('a');
+  a.setAttribute('download', `${fileName}.png`);
+  a.setAttribute('href', dataUrl);
+  a.click();
+}
+
+export default function DownloadPicture({ modelId }: { modelId: string }) {
+  const { getNodes } = useReactFlow();
+  const { data } = useGetModelQuery(modelId);
+
+  const handleClick = () => {
+    const el = document
+      .getElementsByClassName('react-flow__renderer')
+      .item(0) as HTMLElement;
+
+    if (!el) {
+      return;
+    }
+
+    const imgWidth = el.clientWidth;
+    const imgHeight = el.clientHeight;
+    const nodesBounds = getRectOfNodes(getNodes());
+    const transform = getTransformForBounds(
+      nodesBounds,
+      imgWidth,
+      imgHeight,
+      0.5,
+      2
+    );
+    const fileName = data?.prefix ?? 'model';
+
+    toPng(el, {
+      backgroundColor: 'white',
+      width: imgWidth,
+      height: imgHeight,
+      style: {
+        width: imgWidth.toString(),
+        height: imgHeight.toString(),
+        transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})})`,
+      },
+    }).then((dataUrl) => downloadImg(dataUrl, fileName));
+  };
+
+  return <Button icon={<IconDownload />} onClick={() => handleClick()} />;
+}

--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -5,7 +5,6 @@ import {
   HintText,
   IconChevronLeft,
   IconChevronRight,
-  IconDownload,
   IconFullscreen,
   IconMapMyLocation,
   IconMinus,
@@ -31,10 +30,13 @@ import {
   setSavePosition,
 } from '../model/model.slice';
 import HasPermission from '@app/common/utils/has-permission';
+import DownloadPicture from './download-picture';
 
 export default function ModelTools({
+  modelId,
   applicationProfile,
 }: {
+  modelId: string;
   applicationProfile: boolean;
 }) {
   const { t } = useTranslation('common');
@@ -118,7 +120,8 @@ export default function ModelTools({
             icon={<IconMapMyLocation />}
             onClick={() => handleCenterNode()}
           />
-          <Button icon={<IconDownload />} />
+
+          <DownloadPicture modelId={modelId} />
 
           {hasPermission && (
             <Button

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -160,7 +160,10 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
       <ContentWrapper>
         <Graph modelId={modelId}>
           <Drawer views={views} />
-          <ModelTools applicationProfile={modelInfo?.type === 'PROFILE'} />
+          <ModelTools
+            modelId={modelId}
+            applicationProfile={modelInfo?.type === 'PROFILE'}
+          />
         </Graph>
       </ContentWrapper>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@fontsource/source-sans-pro": "^4.5.9",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.4.0",
+        "html-to-image": "^1.11.11",
         "iron-session": "^6.3.1",
         "next": "^12.1.6",
         "next-i18next": "^12.0.1",
@@ -10346,6 +10347,11 @@
       "dependencies": {
         "void-elements": "3.1.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",
@@ -27582,6 +27588,11 @@
         "void-elements": "3.1.0"
       }
     },
+    "html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
+    },
     "html-webpack-plugin": {
       "version": "5.5.0",
       "dev": true,
@@ -34280,6 +34291,7 @@
         "eslint-plugin-jest-dom": "^4.0.1",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-testing-library": "^5.0.6",
+        "html-to-image": "^1.11.11",
         "i18next-parser": "^8.0.0",
         "identity-obj-proxy": "^3.0.0",
         "iron-session": "^6.3.1",


### PR DESCRIPTION
Changes in this PR:
- Added `html-to-image` dependency for graph image export
- Graph view can be exported as a `.png`