### PR TITLE
Fixed glitchy email unsubscription functionality

### DIFF
--- a/terminology-ui/src/common/components/subscription/remove-subscription.tsx
+++ b/terminology-ui/src/common/components/subscription/remove-subscription.tsx
@@ -17,8 +17,6 @@ import {
   RemoveModalContent,
   RemoveModalUl,
 } from './subscription.styles';
-import { useStoreDispatch } from '@app/store';
-import { subscriptionApi } from './subscription.slice';
 
 interface RemoveSubscriptionProps {
   resources?: Resource[];
@@ -39,7 +37,6 @@ export default function RemoveSubscription({
   const { t, i18n } = useTranslation('own-information');
   const { isSmall } = useBreakpoints();
   const [visible, setVisible] = useState(false);
-  const dispatch = useStoreDispatch();
 
   const handleUnsubscribe = () => {
     if (!resource) {
@@ -47,14 +44,15 @@ export default function RemoveSubscription({
     }
 
     setUnsubscribedItem(
-      getPrefLabel({ prefLabels: resource.prefLabel, lang: i18n.language })
+      resource.prefLabel
+        ? getPrefLabel({ prefLabels: resource.prefLabel, lang: i18n.language })
+        : resource.uri
     );
     setVisible(false);
     toggleSubscription({
       action: 'DELETE',
       uri: resource.uri.replace(/\/terminological[\w-]+/g, '/'),
     });
-    dispatch(subscriptionApi.internalActions.resetApiState());
   };
 
   const handleUnsubscribeAll = () => {
@@ -66,11 +64,15 @@ export default function RemoveSubscription({
       .map((resource) => resource.uri.replace(/\/terminological[\w-]+/g, '/'))
       .join(',');
     setUnsubscribedItem(
-      getPrefLabel({ prefLabels: resources[0].prefLabel, lang: i18n.language })
+      resources[0].prefLabel
+        ? getPrefLabel({
+            prefLabels: resources[0].prefLabel,
+            lang: i18n.language,
+          })
+        : resources[0].uri
     );
     setVisible(false);
     toggleSubscription({ action: 'DELETE', uri: uris });
-    dispatch(subscriptionApi.internalActions.resetApiState());
   };
 
   return (
@@ -122,10 +124,12 @@ export default function RemoveSubscription({
               {resources.map((resource, idx) => (
                 <li key={`resource-${idx}`}>
                   <Text smallScreen className="to-be-removed-subscription">
-                    {getPrefLabel({
-                      prefLabels: resource.prefLabel,
-                      lang: i18n.language,
-                    })}
+                    {resource.prefLabel
+                      ? getPrefLabel({
+                          prefLabels: resource.prefLabel,
+                          lang: i18n.language,
+                        })
+                      : resource.uri}
                   </Text>
                 </li>
               ))}
@@ -134,10 +138,12 @@ export default function RemoveSubscription({
           {resource && (
             <Paragraph>
               <Text smallScreen>
-                {getPrefLabel({
-                  prefLabels: resource.prefLabel,
-                  lang: i18n.language,
-                })}
+                {resource.prefLabel
+                  ? getPrefLabel({
+                      prefLabels: resource.prefLabel,
+                      lang: i18n.language,
+                    })
+                  : resource.uri}
               </Text>
             </Paragraph>
           )}

--- a/terminology-ui/src/common/components/subscription/subscription.slice.tsx
+++ b/terminology-ui/src/common/components/subscription/subscription.slice.tsx
@@ -29,7 +29,7 @@ export const subscriptionApi = createApi({
         },
       }),
     }),
-    getSubscriptions: builder.query<Subscriptions, null>({
+    getSubscriptions: builder.query<Subscriptions, void>({
       query: () => ({
         url:
           process.env.ENV_TYPE !== 'production'

--- a/terminology-ui/src/common/interfaces/subscription.interface.ts
+++ b/terminology-ui/src/common/interfaces/subscription.interface.ts
@@ -12,10 +12,10 @@ export interface Subscriptions {
 }
 
 export interface Resource {
-  application: 'string';
-  prefLabel: {
+  application: string;
+  prefLabel?: {
     [value: string]: string;
   };
-  type: 'string';
-  uri: 'string';
+  type: string;
+  uri: string;
 }

--- a/terminology-ui/src/modules/own-information/index.tsx
+++ b/terminology-ui/src/modules/own-information/index.tsx
@@ -31,7 +31,7 @@ export default function OwnInformation() {
   const { t, i18n } = useTranslation('own-information');
   const { data: organizations } = useGetOrganizationsQuery(i18n.language);
   const { data: subscriptions, refetch: refetchSubscriptions } =
-    useGetSubscriptionsQuery(null);
+    useGetSubscriptionsQuery();
   const { data: requests } = useGetRequestsQuery();
 
   if (user.anonymous) {

--- a/terminology-ui/src/modules/own-information/subscription-block.tsx
+++ b/terminology-ui/src/modules/own-information/subscription-block.tsx
@@ -92,10 +92,12 @@ export default function SubscriptionBlock({
                   href={`/terminology-api/api/v1/resolve?uri=${resource.uri}`}
                 >
                   <SuomiLink href="">
-                    {getPrefLabel({
-                      prefLabels: resource.prefLabel,
-                      lang: i18n.language,
-                    })}
+                    {resource.prefLabel
+                      ? getPrefLabel({
+                          prefLabels: resource.prefLabel,
+                          lang: i18n.language,
+                        })
+                      : resource.uri}
                   </SuomiLink>
                 </Link>
                 <RemoveSubscription

--- a/terminology-ui/src/pages/own-information.tsx
+++ b/terminology-ui/src/pages/own-information.tsx
@@ -45,7 +45,7 @@ export default function OwnInformationPage(props: OwnInformationPageProps) {
 export const getServerSideProps = createCommonGetServerSideProps(
   async ({ store, locale }) => {
     store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
-    store.dispatch(getSubscriptions.initiate(null));
+    store.dispatch(getSubscriptions.initiate());
     store.dispatch(getRequests.initiate());
 
     await Promise.all(store.dispatch(getOrganizationsRunningQueriesThunk()));


### PR DESCRIPTION
Changes in this PR:
- Removed unnecessary API state reset call after an email subscription/subscriptions has been unsubscribed from. The API is called already in a parent component after the unsubscribe call is successful
- Added minor refactoring and improved typing