### PR TITLE
YTI-2692: Fix inuse

### DIFF
--- a/datamodel-ui/src/common/utils/get-api-errors.ts
+++ b/datamodel-ui/src/common/utils/get-api-errors.ts
@@ -17,6 +17,9 @@ export default function getApiError(
     error.data !== null
   ) {
     if ('details' in error.data && error.data.details) {
+      if (typeof error.data.details === 'string') {
+        return [`Error: ${error.data.details}`];
+      }
       return (error as AxiosQueryErrorFields).data.details.map(
         (detail) =>
           `VALIDATION ERROR: Field: ${detail.field.toUpperCase()} | Error: ${

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -90,11 +90,6 @@ export default function ResourceView({
     }
   );
 
-  useEffect(() => {
-    console.log(modelId);
-    console.log(!globalSelected.id || !globalSelected.modelId);
-  }, [globalSelected, modelId]);
-
   const { data: inUse, refetch: refetchInUse } = useGetResourceActiveQuery(
     {
       prefix: modelId,

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -90,6 +90,11 @@ export default function ResourceView({
     }
   );
 
+  useEffect(() => {
+    console.log(modelId);
+    console.log(!globalSelected.id || !globalSelected.modelId);
+  }, [globalSelected, modelId]);
+
   const { data: inUse, refetch: refetchInUse } = useGetResourceActiveQuery(
     {
       prefix: modelId,

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -66,7 +66,7 @@ export default function ResourceInfo({
   const [deleteVisible, setDeleteVisible] = useState(false);
   const [localCopyVisible, setLocalCopyVisible] = useState(false);
   const [externalEdit, setExternalEdit] = useState(false);
-  const [externalActive, setExternalActive] = useState(inUse ?? true);
+  const [externalActive, setExternalActive] = useState(inUse);
   const [togglePropertyShape, toggleResult] = useTogglePropertyShapeMutation();
   const { ref: toolTipRef } = useGetAwayListener(showTooltip, setShowTooltip);
 
@@ -78,6 +78,10 @@ export default function ResourceInfo({
       });
     }
   };
+
+  useEffect(() => {
+    setExternalActive(inUse);
+  }, [inUse]);
 
   useEffect(() => {
     if (toggleResult.isSuccess) {
@@ -146,7 +150,10 @@ export default function ResourceInfo({
                     <>
                       <Button
                         variant="secondaryNoBorder"
-                        onClick={() => setExternalEdit(true)}
+                        onClick={() => {
+                          setExternalActive(inUse);
+                          setExternalEdit(true);
+                        }}
                         id="edit-button"
                       >
                         {t('edit', { ns: 'admin' })}
@@ -236,7 +243,7 @@ export default function ResourceInfo({
                   </InlineAlert>
                 )}
                 <ApplicationProfileTop
-                  inUse={externalActive}
+                  inUse={externalActive === undefined ? true : externalActive}
                   setInUse={setExternalActive}
                   type={data.type}
                   applicationProfile={applicationProfile}


### PR DESCRIPTION
Changelog:
- Due to inUse being undefined when first rendering it sets externalActive to undefined
- This has been changed to now update externalActive when inUse updates, meaning when the result from the api call comes
- This does not change functionality otherwise
- Better api errors, there might be cases where details is string instead of object, so in those cases we just return details as string