### PR TITLE
Yti 2749 edge highlight improvements

### DIFF
--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -101,6 +101,8 @@
   "go-to": "Go to",
   "graph": "Graph",
   "graph-settings": "Graph settings",
+  "highlight-class-association-restrictions": "Highlight class association restrictions",
+  "highlight-class-associations": "Highlight class associations",
   "impersonate-user": "Impersonate user",
   "information-domains": "Information domains",
   "interoperability-logo-title": "Interoperability platform logo",

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -101,6 +101,8 @@
   "go-to": "Siirry",
   "graph": "Kaavio",
   "graph-settings": "Kaavion asetukset",
+  "highlight-class-association-restrictions": "Korosta luokkien assosiaatiorajoitteet",
+  "highlight-class-associations": "Korosta luokkien assosiaatiot",
   "impersonate-user": "Esiinny käyttäjänä",
   "information-domains": "Tietoalueet",
   "interoperability-logo-title": "",

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -101,6 +101,8 @@
   "go-to": "",
   "graph": "",
   "graph-settings": "",
+  "highlight-class-association-restrictions": "",
+  "highlight-class-associations": "",
   "impersonate-user": "",
   "information-domains": "",
   "interoperability-logo-title": "",

--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -209,6 +209,19 @@ export default function ModelTools({
               >
                 {t('show-original-class')}
               </ToggleButton>
+              <ToggleButton
+                checked={tools.showClassHighlights}
+                onClick={() =>
+                  dispatch(
+                    setModelTools(
+                      'showClassHighlights',
+                      !tools.showClassHighlights
+                    )
+                  )
+                }
+              >
+                {t('highlight-class-associations')}
+              </ToggleButton>
             </ToggleButtonGroup>
 
             <div>
@@ -279,6 +292,19 @@ export default function ModelTools({
                 }
               >
                 {t('attribute-restr')}
+              </ToggleButton>
+              <ToggleButton
+                checked={tools.showClassHighlights}
+                onClick={() =>
+                  dispatch(
+                    setModelTools(
+                      'showClassHighlights',
+                      !tools.showClassHighlights
+                    )
+                  )
+                }
+              >
+                {t('highlight-class-association-restrictions')}
               </ToggleButton>
             </ToggleButtonGroup>
 

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -149,6 +149,7 @@ const initialState = {
     showAttributeRestrictions: true,
     showByName: true,
     showById: false,
+    showClassHighlights: false,
   },
 };
 

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -225,11 +225,11 @@ export default function CommonViewContent({
         {data.type === ResourceType.ASSOCIATION && (
           <>
             <BasicBlock title={t('source-class', { ns: 'admin' })}>
-              {data.range ? data.range?.curie : t('no-source-class')}
+              {data.domain ? data.domain.curie : t('no-source-class')}
             </BasicBlock>
 
             <BasicBlock title={t('target-class', { ns: 'admin' })}>
-              {data.domain ? data.domain?.curie : t('no-target-class')}
+              {data.range ? data.range.curie : t('no-target-class')}
             </BasicBlock>
           </>
         )}

--- a/datamodel-ui/src/modules/graph/edges/edge.tsx
+++ b/datamodel-ui/src/modules/graph/edges/edge.tsx
@@ -39,7 +39,11 @@ export default function DefaultEdge({
     useCallback((store) => store.nodeInternals.get(target), [target])
   );
 
-  const { sx, sy, tx, ty } = getEdgeParams(sourceNode, targetNode);
+  const { sx, sy, tx, ty } = getEdgeParams(
+    sourceNode,
+    targetNode,
+    data.offsetSource
+  );
 
   const [edgePath, labelX, labelY] = getStraightPath({
     sourceX: sx,

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -17,6 +17,7 @@ import { useStoreDispatch } from '@app/store';
 import {
   resetHighlighted,
   selectDisplayLang,
+  selectModelTools,
   selectResetPosition,
   selectSavePosition,
   selectSelected,
@@ -38,7 +39,9 @@ import getUnusedCornerIds from './utils/get-unused-corner-ids';
 import { setNotification } from '@app/common/components/notifications/notifications.slice';
 import DefaultEdge from './edges/edge';
 import createEdge from './utils/create-edge';
-import getConnectedElements from './utils/get-connected-elements';
+import getConnectedElements, {
+  getClassConnectedElements,
+} from './utils/get-connected-elements';
 import handleCornerNodeDelete from './utils/handle-corner-node-delete';
 
 interface GraphProps {
@@ -60,6 +63,7 @@ const GraphContent = ({
   const displayLang = useSelector(selectDisplayLang());
   const savePosition = useSelector(selectSavePosition());
   const resetPosition = useSelector(selectResetPosition());
+  const tools = useSelector(selectModelTools());
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [cleanUnusedCorners, setCleanUnusedCorners] = useState(false);
@@ -180,13 +184,18 @@ const GraphContent = ({
 
   const onNodeMouseEnter = useCallback(
     (e, node) => {
-      if (node.type !== 'cornerNode') {
+      if (node.type !== 'cornerNode' && !tools.showClassHighlights) {
+        return;
+      }
+
+      if (tools.showClassHighlights && node.type === 'classNode') {
+        dispatch(setHighlighted(getClassConnectedElements(node, nodes, edges)));
         return;
       }
 
       dispatch(setHighlighted(getConnectedElements(node, nodes, edges)));
     },
-    [dispatch, edges, nodes]
+    [dispatch, edges, nodes, tools.showClassHighlights]
   );
 
   const onNodeMouseLeave = useCallback(() => {
@@ -194,10 +203,12 @@ const GraphContent = ({
       const selectedEdge = edges.find(
         (e) => e.data.identifier === globalSelected.id
       );
+
       selectedEdge &&
         dispatch(
           setHighlighted(getConnectedElements(selectedEdge, nodes, edges))
         );
+
       return;
     }
 

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -190,8 +190,19 @@ const GraphContent = ({
   );
 
   const onNodeMouseLeave = useCallback(() => {
+    if (globalSelected.id && globalSelected.type === 'associations') {
+      const selectedEdge = edges.find(
+        (e) => e.data.identifier === globalSelected.id
+      );
+      selectedEdge &&
+        dispatch(
+          setHighlighted(getConnectedElements(selectedEdge, nodes, edges))
+        );
+      return;
+    }
+
     dispatch(resetHighlighted());
-  }, [dispatch]);
+  }, [dispatch, globalSelected, edges, nodes]);
 
   const onEdgeMouseEnter = useCallback(
     (e, edge) => {
@@ -201,8 +212,19 @@ const GraphContent = ({
   );
 
   const onEdgeMouseLeave = useCallback(() => {
+    if (globalSelected.id && globalSelected.type === 'associations') {
+      const selectedEdge = edges.find(
+        (e) => e.data.identifier === globalSelected.id
+      );
+      selectedEdge &&
+        dispatch(
+          setHighlighted(getConnectedElements(selectedEdge, nodes, edges))
+        );
+      return;
+    }
+
     dispatch(resetHighlighted());
-  }, [dispatch]);
+  }, [dispatch, globalSelected, edges, nodes]);
 
   useEffect(() => {
     if (isSuccess || (isSuccess && resetPosition)) {

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -1,17 +1,19 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import {
+  resetHighlighted,
   resetHovered,
   selectDisplayLang,
   selectHovered,
   selectModelTools,
   selectSelected,
+  setHighlighted,
   setHovered,
   setSelected,
 } from '@app/common/components/model/model.slice';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Handle, Position } from 'reactflow';
+import { Handle, Position, useReactFlow } from 'reactflow';
 import {
   IconChevronDown,
   IconChevronUp,
@@ -35,6 +37,7 @@ import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import HasPermission from '@app/common/utils/has-permission';
 import { useAddNodeShapePropertyReferenceMutation } from '@app/common/components/class/class.slice';
 import ResourceModal from '@app/modules/class-view/resource-modal';
+import getConnectedElements from '../utils/get-connected-elements';
 
 interface ClassNodeProps {
   id: string;
@@ -62,6 +65,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
   const { i18n } = useTranslation('common');
   const hasPermission = HasPermission({ actions: 'EDIT_CLASS' });
   const dispatch = useStoreDispatch();
+  const { getNodes, getEdges } = useReactFlow();
   const globalSelected = useSelector(selectSelected());
   const globalHover = useSelector(selectHovered());
   const globalShowAttributes = useSelector(selectModelTools()).showAttributes;
@@ -106,6 +110,35 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
       nodeshapeId: data.identifier,
       uri: value.uri,
     });
+  };
+
+  const handleResourceClick = (
+    id: string,
+    type: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE
+  ) => {
+    dispatch(
+      setSelected(
+        id,
+        type === ResourceType.ASSOCIATION ? 'associations' : 'attributes'
+      )
+    );
+  };
+
+  const handleResourceHover = (
+    id?: string,
+    type?: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE
+  ) => {
+    if (!id) {
+      dispatch(resetHighlighted());
+    }
+
+    const targetEdge = getEdges().find((edge) => edge.data.identifier === id);
+
+    if (type === ResourceType.ASSOCIATION && targetEdge) {
+      dispatch(
+        setHighlighted(getConnectedElements(targetEdge, getNodes(), getEdges()))
+      );
+    }
   };
 
   useEffect(() => {
@@ -194,12 +227,16 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
           <Resource
             key={`${id}-child-${r.identifier}`}
             className="node-resource"
-            onClick={() => dispatch(setSelected(r.identifier, 'attributes'))}
+            onClick={() => handleResourceClick(r.identifier, r.type)}
             $highlight={
-              globalSelected.type === 'attributes' &&
+              (globalSelected.type === 'associations'
+                ? ResourceType.ASSOCIATION
+                : ResourceType.ATTRIBUTE) === r.type &&
               globalSelected.id !== '' &&
               globalSelected.id === r.identifier
             }
+            onMouseEnter={() => handleResourceHover(r.identifier, r.type)}
+            onMouseLeave={() => handleResourceHover()}
           >
             {data.applicationProfile &&
               (r.type === ResourceType.ASSOCIATION ? (

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -125,10 +125,11 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
   };
 
   const handleResourceHover = (
-    id?: string,
-    type?: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE
+    id: string,
+    type: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE,
+    hide?: boolean
   ) => {
-    if (!id) {
+    if (hide && type === ResourceType.ASSOCIATION) {
       dispatch(resetHighlighted());
     }
 
@@ -236,7 +237,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
               globalSelected.id === r.identifier
             }
             onMouseEnter={() => handleResourceHover(r.identifier, r.type)}
-            onMouseLeave={() => handleResourceHover()}
+            onMouseLeave={() => handleResourceHover(r.identifier, r.type, true)}
           >
             {data.applicationProfile &&
               (r.type === ResourceType.ASSOCIATION ? (

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/convert-to-edges.test.data.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/convert-to-edges.test.data.ts
@@ -3,80 +3,84 @@ import {
   VisualizationType,
 } from '@app/common/interfaces/visualization.interface';
 
-export const visualizationTypeArray: VisualizationType[] = [
-  {
-    identifier: '1',
-    label: {
-      fi: 'label-1-fi',
-      en: 'label-1-en',
-    },
-    parentClasses: [],
-    position: {
-      x: 0,
-      y: 0,
-    },
-    attributes: [],
-    associations: [
-      {
-        identifier: 'association-1',
-        label: {
-          fi: 'assoc-1-2-fi',
-          en: 'assoc-1-2-en',
-        },
-        referenceTarget: '2',
+export function visualizationTypeArray(corner?: boolean): VisualizationType[] {
+  return [
+    {
+      identifier: '1',
+      label: {
+        fi: 'label-1-fi',
+        en: 'label-1-en',
       },
-    ],
-  },
-  {
-    identifier: '2',
-    label: {
-      en: 'label-2-en',
-    },
-    parentClasses: [],
-    position: {
-      x: 0,
-      y: 0,
-    },
-    attributes: [],
-    associations: [],
-  },
-  {
-    identifier: '3',
-    label: {
-      fi: 'label-3-fi',
-      en: 'label-3-en',
-      sv: 'label-3-sv',
-    },
-    parentClasses: [],
-    position: {
-      x: 0,
-      y: 0,
-    },
-    attributes: [],
-    associations: [],
-  },
-  {
-    identifier: '4',
-    label: {
-      fi: 'label-4-fi',
-    },
-    parentClasses: [],
-    position: {
-      x: 0,
-      y: 0,
-    },
-    attributes: [],
-    associations: [
-      {
-        identifier: 'association-4',
-        label: {
-          fi: 'assoc-4-3-fi',
-        },
-        referenceTarget: '3',
+      parentClasses: [],
+      position: {
+        x: 0,
+        y: 0,
       },
-    ],
-  },
-];
+      attributes: [],
+      associations: [
+        {
+          identifier: 'association-1',
+          label: {
+            fi: 'assoc-1-2-fi',
+            en: 'assoc-1-2-en',
+          },
+          referenceTarget: corner ? 'corner-1' : '2',
+        },
+      ],
+    },
+    {
+      identifier: '2',
+      label: {
+        en: 'label-2-en',
+      },
+      parentClasses: [],
+      position: {
+        x: 0,
+        y: 0,
+      },
+      attributes: [],
+      associations: [],
+    },
+    {
+      identifier: '3',
+      label: {
+        fi: 'label-3-fi',
+        en: 'label-3-en',
+        sv: 'label-3-sv',
+      },
+      parentClasses: [],
+      position: {
+        x: 0,
+        y: 0,
+      },
+      attributes: [],
+      associations: [],
+    },
+    {
+      identifier: '4',
+      label: {
+        fi: 'label-4-fi',
+      },
+      parentClasses: [],
+      position: {
+        x: 0,
+        y: 0,
+      },
+      attributes: [],
+      associations: corner
+        ? []
+        : [
+            {
+              identifier: 'association-4',
+              label: {
+                fi: 'assoc-4-3-fi',
+              },
+              referenceTarget: '3',
+            },
+          ],
+    },
+  ];
+}
 
 export const visualizationHiddenTypeArray: VisualizationHiddenNode[] = [
   {
@@ -187,7 +191,17 @@ export const dottedEdgeExpected = [
   },
 ];
 
-export const hiddenEdgeExpected = [
+export const withHiddenEdgeExpected = [
+  {
+    id: 'reactflow__edge-1-#corner-1',
+    type: 'generalEdge',
+    source: '1',
+    sourceHandle: '1',
+    target: '#corner-1',
+    targetHandle: '#corner-1',
+    markerEnd: undefined,
+    data: {},
+  },
   {
     id: 'reactflow__edge-#corner-1-#corner-2',
     type: 'generalEdge',
@@ -212,11 +226,10 @@ export const hiddenEdgeExpected = [
     target: '3',
     targetHandle: '3',
     data: {
-      identifier: '3',
+      identifier: 'association-1',
       label: {
-        fi: 'label-3-fi',
-        en: 'label-3-en',
-        sv: 'label-3-sv',
+        fi: 'assoc-1-2-fi',
+        en: 'assoc-1-2-en',
       },
     },
   },

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/convert-to-edges.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/convert-to-edges.test.ts
@@ -1,10 +1,10 @@
 import convertToEdges from '.';
 import {
   dottedEdgeExpected,
-  hiddenEdgeExpected,
   solidEdgeExpected,
   visualizationHiddenTypeArray,
   visualizationTypeArray,
+  withHiddenEdgeExpected,
 } from './convert-to-edges.test.data';
 
 describe('convert-to-edges', () => {
@@ -15,14 +15,14 @@ describe('convert-to-edges', () => {
   });
 
   it('should return solid edges', () => {
-    const returned = convertToEdges(visualizationTypeArray, []);
+    const returned = convertToEdges(visualizationTypeArray(), []);
 
     expect(returned).toHaveLength(2);
     expect(returned).toStrictEqual(solidEdgeExpected);
   });
 
   it('should return dotted edges', () => {
-    const returned = convertToEdges(visualizationTypeArray, [], true);
+    const returned = convertToEdges(visualizationTypeArray(), [], true);
 
     expect(returned).toHaveLength(2);
     expect(returned).toStrictEqual(dottedEdgeExpected);
@@ -30,12 +30,10 @@ describe('convert-to-edges', () => {
 
   it('should return edges with corners', () => {
     const returned = convertToEdges(
-      visualizationTypeArray,
+      visualizationTypeArray(true),
       visualizationHiddenTypeArray
     );
 
-    const expected = [...solidEdgeExpected, ...hiddenEdgeExpected];
-
-    expect(returned).toStrictEqual(expected);
+    expect(returned).toStrictEqual(withHiddenEdgeExpected);
   });
 });

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -18,6 +18,12 @@ export default function convertToEdges(
     return [];
   }
 
+  const associationLabels: {
+    targetId: string;
+    identifier: string;
+    label: { [key: string]: string };
+  }[] = [];
+
   const edges = nodes
     .filter(
       (node) => node.associations.length > 0 || node.parentClasses.length > 0
@@ -27,6 +33,12 @@ export default function convertToEdges(
         .filter((assoc) => assoc.referenceTarget)
         .flatMap((assoc, idx) => {
           if (assoc.referenceTarget?.startsWith('corner')) {
+            associationLabels.push({
+              targetId: getEndEdge(assoc.referenceTarget),
+              identifier: assoc.identifier,
+              label: assoc.label,
+            });
+
             return createEdge({
               params: {
                 source: node.identifier,
@@ -98,17 +110,17 @@ export default function convertToEdges(
       });
     }
 
-    const targetClass = nodes.find(
-      (n) => n.identifier === node.referenceTarget
+    const associationInfo = associationLabels.find(
+      (a) => a.targetId === node.referenceTarget
     );
 
-    if (!targetClass) {
+    if (!associationInfo) {
       return null;
     }
 
     return createEdge({
-      label: targetClass.label,
-      identifier: node.referenceTarget,
+      label: associationInfo.label,
+      identifier: associationInfo.identifier,
       params: {
         source: nodeIdentifier,
         sourceHandle: nodeIdentifier,
@@ -120,4 +132,18 @@ export default function convertToEdges(
   });
 
   return [...edges, ...(splitEdges.filter((edge) => edge !== null) as Edge[])];
+
+  function getEndEdge(id: string): string {
+    const targetNode = hiddenNodes.find((n) => n.identifier === id);
+
+    if (!targetNode) {
+      return '';
+    }
+
+    if (targetNode.referenceTarget.startsWith('corner-')) {
+      return getEndEdge(targetNode.referenceTarget);
+    }
+
+    return targetNode.referenceTarget;
+  }
 }

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -20,6 +20,7 @@ export default function convertToEdges(
 
   const associationLabels: {
     targetId: string;
+    offsetSource?: number;
     identifier: string;
     label: { [key: string]: string };
   }[] = [];
@@ -37,6 +38,9 @@ export default function convertToEdges(
               targetId: getEndEdge(assoc.referenceTarget),
               identifier: assoc.identifier,
               label: assoc.label,
+              offsetSource: applicationProfile
+                ? node.attributes.length + idx + 1
+                : undefined,
             });
 
             return createEdge({
@@ -128,6 +132,7 @@ export default function convertToEdges(
         targetHandle: node.referenceTarget,
         id: `reactflow__edge-${nodeIdentifier}-${node.referenceTarget}`,
       },
+      offsetSource: associationInfo.offsetSource,
     });
   });
 

--- a/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
@@ -54,3 +54,21 @@ export default function getConnectedElements(
     ...getConnected(start as Edge, 'source'),
   ].filter((value, index, arr) => arr.indexOf(value) === index);
 }
+
+export function getClassConnectedElements(
+  start: Node,
+  nodes: Node[],
+  edges: Edge[]
+): string[] {
+  const relatedEdges = edges.filter(
+    (e) => e.target === start.id || e.source === start.id
+  );
+
+  if (relatedEdges.length < 1) {
+    return [];
+  }
+
+  return relatedEdges
+    .flatMap((e) => getConnectedElements(e, nodes, edges))
+    .filter((value, index, arr) => arr.indexOf(value) === index);
+}


### PR DESCRIPTION
Changes in this PR:
- Selected associations stay highlighted
- Toggle to highlight class node inbound and outbound edges
- Fixed small bug where domain and range were in incorrect order