### PR TITLE
Yti 2754 drawer title improvements

### DIFF
--- a/common-ui/components/drawer/drawer.styles.tsx
+++ b/common-ui/components/drawer/drawer.styles.tsx
@@ -85,8 +85,6 @@ export const DrawerButtonGroup = styled.div<{ $isSmall: boolean }>`
   flex-direction: ${(props) => (props.$isSmall ? 'row' : 'column')};
   height: 100%;
   background: ${(props) => props.theme.suomifi.colors.highlightLight3};
-  overflow-y: auto;
-  overflow-x: hidden;
 
   ${(props) =>
     props.$isSmall
@@ -101,13 +99,16 @@ export const DrawerButtonGroup = styled.div<{ $isSmall: boolean }>`
       }
       `
       : `
-  > button {
-    border-top: 1px solid ${props.theme.suomifi.colors.whiteBase} !important;
-    border-bottom: 1px solid ${props.theme.suomifi.colors.whiteBase} !important;
-    font-size: 12px;
-    padding: 20px 10px;
-    height: min-content;
-  }
+      overflow-y: auto;
+      overflow-x: hidden;
+
+      > button {
+        border-top: 1px solid ${props.theme.suomifi.colors.whiteBase} !important;
+        border-bottom: 1px solid ${props.theme.suomifi.colors.whiteBase} !important;
+        font-size: 12px;
+        padding: 20px 10px;
+        height: min-content;
+      }
   `}
 `;
 

--- a/common-ui/components/drawer/drawer.styles.tsx
+++ b/common-ui/components/drawer/drawer.styles.tsx
@@ -85,6 +85,8 @@ export const DrawerButtonGroup = styled.div<{ $isSmall: boolean }>`
   flex-direction: ${(props) => (props.$isSmall ? 'row' : 'column')};
   height: 100%;
   background: ${(props) => props.theme.suomifi.colors.highlightLight3};
+  overflow-y: auto;
+  overflow-x: hidden;
 
   ${(props) =>
     props.$isSmall

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -429,24 +429,6 @@ export default function ClassForm({
           >
             {t('back', { ns: 'common' })}
           </Button>
-        </div>
-
-        <HeaderRow>
-          <Text variant="bold">
-            {Object.values(data.label).filter(
-              (l) => l !== '' && typeof l !== 'undefined'
-            ).length > 0
-              ? getLanguageVersion({
-                  data: Object.fromEntries(
-                    Object.entries(data.label).filter(
-                      (l) => l[1] !== '' && typeof l[1] !== 'undefined'
-                    )
-                  ),
-                  lang: i18n.language,
-                  appendLocale: true,
-                })
-              : t('class-name')}
-          </Text>
 
           <div style={{ display: 'flex', gap: '10px' }}>
             <Button onClick={() => handleSubmit()} id="submit-button">
@@ -473,6 +455,24 @@ export default function ClassForm({
               {t('cancel-variant')}
             </Button>
           </div>
+        </div>
+
+        <HeaderRow>
+          <Text variant="bold">
+            {Object.values(data.label).filter(
+              (l) => l !== '' && typeof l !== 'undefined'
+            ).length > 0
+              ? getLanguageVersion({
+                  data: Object.fromEntries(
+                    Object.entries(data.label).filter(
+                      (l) => l[1] !== '' && typeof l[1] !== 'undefined'
+                    )
+                  ),
+                  lang: i18n.language,
+                  appendLocale: true,
+                })
+              : t('class-name')}
+          </Text>
         </HeaderRow>
 
         {userPosted &&

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -9,7 +9,7 @@ import {
   ExternalLink,
   IconArrowLeft,
   IconCopy,
-  IconMenu,
+  IconOptionsVertical,
   Link,
   Text,
   Tooltip,
@@ -266,7 +266,7 @@ export default function ClassInfo({
             <div>
               <Button
                 variant="secondary"
-                iconRight={<IconMenu />}
+                iconRight={<IconOptionsVertical />}
                 onClick={() => setShowTooltip(!showTooltip)}
                 ref={toolTipRef}
               >

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -4,10 +4,10 @@ import {
   Expander,
   ExpanderContent,
   ExpanderTitleButton,
-  IconMenu,
   Tooltip,
   IconCheckCircle,
   IconDisabled,
+  IconOptionsVertical,
 } from 'suomifi-ui-components';
 import { useTranslation } from 'next-i18next';
 import {
@@ -133,7 +133,7 @@ export default function ResourceInfo({
           <div>
             <Button
               variant="secondary"
-              iconRight={<IconMenu />}
+              iconRight={<IconOptionsVertical />}
               onClick={() => setShowTooltip(!showTooltip)}
             >
               {t('actions')}

--- a/datamodel-ui/src/modules/linked-data-view/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-view/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   ExternalLink,
-  IconMenu,
+  IconOptionsVertical,
   Text,
   Tooltip,
 } from 'suomifi-ui-components';
@@ -77,7 +77,7 @@ export default function LinkedDataView({
             <div>
               <Button
                 variant="secondary"
-                iconRight={<IconMenu />}
+                iconRight={<IconOptionsVertical />}
                 onClick={() => setShowTooltip(!showTooltip)}
                 ref={toolTipRef}
               >

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   ExternalLink,
-  IconMenu,
+  IconOptionsVertical,
   Text,
   Tooltip,
 } from 'suomifi-ui-components';
@@ -149,7 +149,7 @@ export default function ModelInfoView() {
             <Button
               variant="secondary"
               onClick={() => setShowTooltip(!showTooltip)}
-              iconRight={<IconMenu />}
+              iconRight={<IconOptionsVertical />}
               ref={toolTipRef}
               id="actions-button"
             >

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -365,12 +365,6 @@ export default function ResourceForm({
           >
             {t('back', { ns: 'common' })}
           </Button>
-        </div>
-        <HeaderRow>
-          <Text variant="bold">
-            {Object.entries(data.label).find((l) => l[1] !== '')?.[1] ??
-              translateCommonForm('name', data.type, t)}
-          </Text>
 
           <div style={{ display: 'flex', gap: '10px' }}>
             <Button onClick={() => handleSubmit()} id="submit-button">
@@ -397,6 +391,13 @@ export default function ResourceForm({
               {t('cancel-variant')}
             </Button>
           </div>
+        </div>
+
+        <HeaderRow>
+          <Text variant="bold">
+            {Object.entries(data.label).find((l) => l[1] !== '')?.[1] ??
+              translateCommonForm('name', data.type, t)}
+          </Text>
         </HeaderRow>
 
         {userPosted &&

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   IconArrowLeft,
-  IconMenu,
+  IconOptionsVertical,
   InlineAlert,
   Text,
   Tooltip,
@@ -114,7 +114,7 @@ export default function ResourceInfo({
             <div>
               <Button
                 variant="secondary"
-                iconRight={<IconMenu />}
+                iconRight={<IconOptionsVertical />}
                 style={{ height: 'min-content' }}
                 onClick={() => setShowTooltip(!showTooltip)}
                 id="actions-button"


### PR DESCRIPTION
Changes in this PR:
- Tooltip icon changed to correct one
- Drawer tab titles stay in same position
- Moved Save and Cancel buttons in class and resource forms to be in the top of drawer like in other tabs
- Added y-scroll support to drawer tab buttons for smaller screen users