### PR TITLE
Fixed button disabled state and code list changes

### DIFF
--- a/datamodel-ui/src/modules/code-list-modal/index.tsx
+++ b/datamodel-ui/src/modules/code-list-modal/index.tsx
@@ -153,9 +153,7 @@ function CodeListModalContent({
     group: '',
     status: '',
   });
-  const [selected, setSelected] = useState<string[]>(
-    initialData.map((d) => d.id) ?? []
-  );
+  const [selected, setSelected] = useState<ModelCodeList[]>(initialData ?? []);
   const [currPage, setCurrPage] = useState(1);
   const { data: codes, isSuccess } = useGetCodesQuery({
     lang: i18n.language ?? 'fi',
@@ -197,7 +195,7 @@ function CodeListModalContent({
       group: '',
       status: '',
     });
-    setSelected(initialData.map((d) => d.id));
+    setSelected(initialData);
     close();
     setCurrPage(1);
   };
@@ -207,20 +205,12 @@ function CodeListModalContent({
       return;
     }
 
-    setData(
-      codes.results
-        .filter((code) => selected.includes(code.uri))
-        .map((code) => ({
-          prefLabel: code.prefLabel,
-          status: code.status,
-          id: code.uri,
-        }))
-    );
+    setData(selected);
     handleClose();
   };
 
   useEffect(() => {
-    setSelected(initialData.map((d) => d.id));
+    setSelected(initialData);
   }, [initialData]);
 
   return (
@@ -242,19 +232,18 @@ function CodeListModalContent({
           <SelectedChipsWrapper>
             {selected.map((select) => {
               const label = getLanguageVersion({
-                data: codes?.results.find((code) => code.uri === select)
-                  ?.prefLabel,
+                data: select.prefLabel,
                 lang: i18n.language,
               });
               return (
                 <Chip
-                  key={`selected-code-${select}`}
+                  key={`selected-code-${select.id}`}
                   removable
                   onClick={() =>
-                    setSelected(selected.filter((s) => s !== select))
+                    setSelected(selected.filter((s) => s.id !== select.id))
                   }
                 >
-                  {label !== '' ? label : select}
+                  {label !== '' ? label : select.id}
                 </Chip>
               );
             })}
@@ -281,7 +270,14 @@ function CodeListModalContent({
 
       <ModalFooter>
         <Button
-          disabled={selected.length < 1}
+          disabled={
+            initialData.length === 0
+              ? selected.length < 1
+              : selected.length === initialData.length &&
+                selected.every((s) =>
+                  initialData.map((d) => d.id).includes(s.id)
+                )
+          }
           onClick={() => handleSubmit()}
           id="submit-button"
         >

--- a/datamodel-ui/src/modules/code-list-modal/results-and-info-block.tsx
+++ b/datamodel-ui/src/modules/code-list-modal/results-and-info-block.tsx
@@ -13,6 +13,7 @@ import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { translateStatus } from 'yti-common-ui/utils/translation-helpers';
 import { useState } from 'react';
 import { useGetCodeRegistryQuery } from '@app/common/components/code/code.slice';
+import { ModelCodeList } from '@app/common/interfaces/model.interface';
 
 interface ResultsAndInfoBlockProps {
   codes?: {
@@ -24,9 +25,9 @@ interface ResultsAndInfoBlockProps {
     results: CodeType[];
   };
   extendedView?: boolean;
-  selected: string[];
+  selected: ModelCodeList[];
   isSuccess?: boolean;
-  setSelected: (value: string[]) => void;
+  setSelected: (value: ModelCodeList[]) => void;
 }
 
 export default function ResultsAndInfoBlock({
@@ -73,12 +74,19 @@ export default function ResultsAndInfoBlock({
                 <Checkbox
                   onClick={() =>
                     setSelected(
-                      selected.includes(code.uri)
-                        ? selected.filter((s) => s !== code.uri)
-                        : [...selected, code.uri]
+                      selected.map((s) => s.id).includes(code.uri)
+                        ? selected.filter((s) => s.id !== code.uri)
+                        : [
+                            ...selected,
+                            {
+                              id: code.uri,
+                              prefLabel: code.prefLabel,
+                              status: code.status,
+                            },
+                          ]
                     )
                   }
-                  checked={selected.includes(code.uri)}
+                  checked={selected.map((s) => s.id).includes(code.uri)}
                   id={`code-list-checkbox_${code.uri}`}
                 >
                   {getLanguageVersion({

--- a/datamodel-ui/src/modules/linked-data-form/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-form/index.tsx
@@ -185,6 +185,7 @@ export default function LinkedDataForm({
               <>
                 {t('linked-codelists', { ns: 'common' })}
                 <Text smallScreen style={{ color: '#5F686D' }}>
+                  {' '}
                   ({t('optional')})
                 </Text>
               </>

--- a/datamodel-ui/src/modules/linked-model/index.tsx
+++ b/datamodel-ui/src/modules/linked-model/index.tsx
@@ -178,7 +178,14 @@ export default function LinkedModel({
             disabled={
               showExternalForm
                 ? Object.values(data).filter((val) => val !== '').length < 3
-                : selected.length < 1
+                : (initialData.internalNamespaces.length === 0 &&
+                    selected.length === 0) ||
+                  (selected.length === initialData.internalNamespaces.length &&
+                    selected.every((s) =>
+                      initialData.internalNamespaces
+                        .map((i) => i.namespace)
+                        .includes(s.namespace)
+                    ))
             }
             id="submit-button"
           >

--- a/datamodel-ui/src/modules/resource/resource-form/components/attribute-restrictions.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/attribute-restrictions.tsx
@@ -206,7 +206,6 @@ export default function AttributeRestrictions({
               itemAdditionHelpText=""
               chipListVisible
               onItemSelectionsChange={(e) => {
-                console.log(e);
                 return handleUpdate(
                   'allowedValues',
                   e.map((val) => {
@@ -258,7 +257,6 @@ export default function AttributeRestrictions({
               {data.allowedValues && (
                 <>
                   {data.allowedValues.map((value) => {
-                    console.log(value);
                     return (
                       <TextInput
                         key={`allowed-value-${value.id}`}


### PR DESCRIPTION
Changes in this PR:
- Fixed submit button disabled state detection in linked code lists and data models modal. Now if changes are detected, the user can submit these correctly
- Code list modal selection changed to use json internally instead of string. Tracking just the uri of the selected code list(s) caused a bug where the code list information couldn't be fetched properly when changing search results page
- Removed few unused `console.log()`