### PR TITLE
Yti 2654 multiple error msg fix

### DIFF
--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -4,8 +4,8 @@ import { useMemo, useState } from 'react';
 import {
   Dropdown,
   DropdownItem,
+  MultiSelect,
   SearchInput,
-  SingleSelect,
   SingleSelectData,
 } from 'suomifi-ui-components';
 import { SearchToolsBlock } from './multi-column-search.styles';
@@ -16,6 +16,7 @@ import { InternalResourcesSearchParams } from '../search-internal-resources/sear
 import { Status } from 'yti-common-ui/interfaces/status.interface';
 import ResourceList, { ResultType } from '../resource-list';
 import { DetachedPagination } from 'yti-common-ui/pagination';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 interface MultiColumnSearchProps {
   primaryColumnName: string;
@@ -236,28 +237,60 @@ export default function MultiColumnSearch({
           ))}
         </Dropdown>
 
-        <SingleSelect
+        <MultiSelect
           labelText={t('information-domain')}
-          itemAdditionHelpText=""
+          items={serviceCategories.sort((a, b) => {
+            if (a.uniqueItemId === '-1' || b.uniqueItemId === '-1') {
+              return a.uniqueItemId === '-1' ? -1 : 1;
+            }
+
+            if (
+              !searchParams.groups ||
+              searchParams.groups.length === 0 ||
+              (searchParams.groups?.includes(a.uniqueItemId) &&
+                searchParams.groups?.includes(b.uniqueItemId))
+            ) {
+              return compareLocales(a.labelText, b.labelText);
+            }
+
+            return searchParams.groups?.includes(a.uniqueItemId) ? -1 : 1;
+          })}
+          defaultSelectedItems={serviceCategories.filter(
+            (category) => category.uniqueItemId === '-1'
+          )}
+          selectedItems={
+            searchParams.groups && searchParams.groups.length > 0
+              ? serviceCategories.filter((category) =>
+                  searchParams.groups?.includes(category.uniqueItemId)
+                )
+              : [
+                  serviceCategories.find(
+                    (category) => category.uniqueItemId === '-1'
+                  ) as SingleSelectData,
+                ]
+          }
+          noItemsText=""
           ariaOptionsAvailableText={
             t('information-domains-available') as string
           }
-          clearButtonLabel={t('clear-selection')}
-          defaultSelectedItem={serviceCategories.find(
-            (category) => category.uniqueItemId === '-1'
-          )}
-          onItemSelect={(e) =>
+          ariaOptionChipRemovedText=""
+          ariaSelectedAmountTextFunction={() => ''}
+          onItemSelectionsChange={(values) => {
+            if (
+              values.length < 1 ||
+              values[values.length - 1]?.uniqueItemId === '-1'
+            ) {
+              handleSearchChange('groups', ['-1']);
+              return;
+            }
+
             handleSearchChange(
               'groups',
-              e !== null && e !== '-1' ? [e] : ['-1']
-            )
-          }
-          selectedItem={serviceCategories.find((category) =>
-            searchParams.groups && searchParams.groups.length > 0
-              ? category.uniqueItemId === searchParams.groups[0]
-              : category.uniqueItemId === '-1'
-          )}
-          items={serviceCategories}
+              values
+                .map((val) => val.uniqueItemId)
+                .filter((val) => val !== '-1')
+            );
+          }}
           id="information-domain-picker"
         />
 

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -432,7 +432,7 @@ export default function ClassForm({
 
           <div style={{ display: 'flex', gap: '10px' }}>
             <Button onClick={() => handleSubmit()} id="submit-button">
-              {userPosted ? (
+              {updateResult.isLoading || createResult.isLoading ? (
                 <div role="alert">
                   <StyledSpinner
                     variant="small"

--- a/datamodel-ui/src/modules/class-form/utils.ts
+++ b/datamodel-ui/src/modules/class-form/utils.ts
@@ -61,23 +61,26 @@ export function validateClassForm(data: ClassFormType): ClassFormErrors {
     returnErrors.label = false;
   }
 
-  if (data.identifier && data.identifier !== '') {
+  if (data.identifier !== '') {
     returnErrors.identifier = false;
+  } else {
+    return {
+      ...returnErrors,
+      identifierInitChar: false,
+      identifierLength: false,
+      identifierCharacters: false,
+    };
   }
 
-  if (
-    data.identifier &&
-    data.identifier.length > 1 &&
-    data.identifier.length < 33
-  ) {
+  if (data.identifier.length > 1 && data.identifier.length < 33) {
     returnErrors.identifierLength = false;
   }
 
-  if (data.identifier && /^[^0-9]/.test(data.identifier)) {
+  if (/^[^0-9]/.test(data.identifier) || data.identifier === '') {
     returnErrors.identifierInitChar = false;
   }
 
-  if (data.identifier && data.identifier.match(/^[a-z0-9\-_]+$/)) {
+  if (data.identifier.match(/^[a-z0-9\-_]+$/)) {
     returnErrors.identifierCharacters = false;
   }
 

--- a/datamodel-ui/src/modules/class-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-modal/index.tsx
@@ -98,7 +98,7 @@ export default function ClassModal({
 
   const handleSubmit = () => {
     if (selectedId === '') {
-      setVisible(false);
+      handleClose();
       handleFollowUp();
       return;
     }
@@ -106,7 +106,7 @@ export default function ClassModal({
     const target = result.data?.responseObjects.find(
       (r) => r.id === selectedId
     );
-    setVisible(false);
+    handleClose();
     handleFollowUp(
       target,
       searchParams.limitToModelType === 'PROFILE' ?? undefined

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -129,7 +129,7 @@ export default function ClassView({
           ],
         })
       );
-      setView('classes', 'edit');
+      setView('classes', 'create');
       return;
     }
 
@@ -137,7 +137,7 @@ export default function ClassView({
       setClass(internalClassToClassForm(value, languages, applicationProfile))
     );
 
-    setView('classes', 'edit');
+    setView('classes', 'create');
   };
 
   const handleAppProfileFollowUpAction = (data?: {
@@ -302,7 +302,7 @@ export default function ClassView({
   }
 
   function renderForm() {
-    if (!view.edit) {
+    if (!view.edit && !view.create) {
       return <></>;
     }
 

--- a/datamodel-ui/src/modules/documentation/index.tsx
+++ b/datamodel-ui/src/modules/documentation/index.tsx
@@ -69,7 +69,6 @@ export default function Documentation({
   const [headerHeight, setHeaderHeight] = useState(0);
   const [value, setValue] = useState<{ [key: string]: string }>({});
   const [isEdit, setIsEdit] = useState(false);
-  const [userPosted, setUserPosted] = useState(false);
   const [currentLanguage, setCurrentLanguage] = useState(
     languages.sort((a, b) => compareLocales(a, b))[0]
   );
@@ -123,8 +122,6 @@ export default function Documentation({
       return;
     }
 
-    setUserPosted(true);
-
     const payload = generatePayload({ ...modelData, documentation: value });
 
     updateModel({
@@ -135,7 +132,6 @@ export default function Documentation({
   };
 
   const handleCancel = () => {
-    setUserPosted(false);
     setIsEdit(false);
     setValue(
       modelData?.documentation
@@ -250,7 +246,6 @@ export default function Documentation({
   useEffect(() => {
     if (result.isSuccess) {
       setIsEdit(false);
-      setUserPosted(false);
       disableConfirmation();
       refetch();
       dispatch(setNotification('DOCUMENTATION_EDIT'));
@@ -288,7 +283,7 @@ export default function Documentation({
               }}
             >
               <Button onClick={() => handleSubmit()} id="submit-button">
-                {userPosted ? (
+                {result.isLoading ? (
                   <div role="alert">
                     <StyledSpinner
                       variant="small"

--- a/datamodel-ui/src/modules/model-form/index.tsx
+++ b/datamodel-ui/src/modules/model-form/index.tsx
@@ -30,6 +30,7 @@ import { Status } from '@app/common/interfaces/status.interface';
 import { FormUpdateErrors } from '../model/validate-form-update';
 import { useGetLanguagesQuery } from '@app/common/components/code/code.slice';
 import LinkBlock from './link-block';
+import { compareLocales } from '@app/common/utils/compare-locals';
 
 interface ModelFormProps {
   formData: ModelFormType;
@@ -247,9 +248,9 @@ export default function ModelForm({
           noItemsText={''}
           status={errors?.languageAmount ? 'error' : 'default'}
           disabled={disabled}
-          defaultSelectedItems={formData.languages.filter(
-            (lang) => lang.selected
-          )}
+          defaultSelectedItems={formData.languages
+            .filter((lang) => lang.selected)
+            .sort((a, b) => compareLocales(a.uniqueItemId, b.uniqueItemId))}
         />
       </div>
     );

--- a/datamodel-ui/src/modules/model/model-edit-view.tsx
+++ b/datamodel-ui/src/modules/model/model-edit-view.tsx
@@ -141,7 +141,7 @@ export default function ModelEditView({
           <Text variant="bold">{t('details', { ns: 'common' })}</Text>
           <HeaderRow>
             <Button onClick={() => handleSubmit()}>
-              {userPosted ? (
+              {result.isLoading ? (
                 <div role="alert">
                   <StyledSpinner
                     variant="small"
@@ -188,14 +188,14 @@ export default function ModelEditView({
       return [];
     }
 
-    const langsWithError = Object.entries(errors)
-      .filter(([_, value]) => Array.isArray(value))
-      ?.flatMap(([key, value]) =>
-        (value as string[]).map(
-          (lang) =>
-            `${translateModelFormErrors(key, t)} ${translateLanguage(lang, t)}`
-        )
-      );
+    const langsWithError =
+      errors.titleAmount.length > 0
+        ? [
+            `${translateModelFormErrors('titleAmount', t)} ${errors.titleAmount
+              .map((lang) => translateLanguage(lang, t))
+              .join(', ')}`,
+          ]
+        : [];
 
     const otherErrors = Object.entries(errors)
       .filter(([_, value]) => value && !Array.isArray(value))

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -368,7 +368,7 @@ export default function ResourceForm({
 
           <div style={{ display: 'flex', gap: '10px' }}>
             <Button onClick={() => handleSubmit()} id="submit-button">
-              {userPosted ? (
+              {updateResult.isLoading || createResult.isLoading ? (
                 <div role="alert">
                   <StyledSpinner
                     variant="small"

--- a/datamodel-ui/src/modules/resource/resource-form/validate-form.ts
+++ b/datamodel-ui/src/modules/resource/resource-form/validate-form.ts
@@ -42,23 +42,26 @@ export default function validateForm(data: ResourceFormType): CommonFormErrors {
     errors.label = false;
   }
 
-  if (data.identifier && data.identifier !== '') {
+  if (data.identifier !== '') {
     errors.identifier = false;
+  } else {
+    return validateNumeric(data, {
+      ...errors,
+      identifierInitChar: false,
+      identifierLength: false,
+      identifierCharacters: false,
+    });
   }
 
-  if (data.identifier && /^[^[0-9]/.test(data.identifier)) {
+  if (/^[^[0-9]/.test(data.identifier)) {
     errors.identifierInitChar = false;
   }
 
-  if (
-    data.identifier &&
-    data.identifier.length > 1 &&
-    data.identifier.length < 33
-  ) {
+  if (data.identifier.length > 1 && data.identifier.length < 33) {
     errors.identifierLength = false;
   }
 
-  if (data.identifier && data.identifier.match(/^[a-z0-9\-_]+$/)) {
+  if (data.identifier.match(/^[a-z0-9\-_]+$/)) {
     errors.identifierCharacters = false;
   }
 


### PR DESCRIPTION
Changes in this PR:
- Displayed error messages tweaked to be a shorter list
- Bug in `ClassModal` filter when submitting and opening the modal again and the filter values would be incorrect fixed
- Multiple groups can be added to filter instead of just one
- Spinner set to track `isLoading` instead of `userPosted`. If an error occurred in form the spinner would spin forever