### PR TITLE
Selected groups in MultiSelect are displayed in field correctly

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -274,6 +274,8 @@
   "select-value": "Select value",
   "select-values": "Select values",
   "selected-data-model-class": "Selected data model class",
+  "selected-n-items_one": "Selected {{count}} item",
+  "selected-n-items_other": "Selected {{count}} items",
   "show-groups-register": "Show groups (register)",
   "show-statuses": "Show statuses",
   "smaller-or-as-small-as": "Smaller or as small as",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -274,6 +274,8 @@
   "select-value": "Valitse arvo",
   "select-values": "Valitse arvot",
   "selected-data-model-class": "Valittu ydintietomallin luokka",
+  "selected-n-items_one": "Valittu {{count}} kpl",
+  "selected-n-items_other": "Valittu {{count}} kpl",
   "show-groups-register": "Näytä ryhmät (rekisteri)",
   "show-statuses": "Näytä tilat",
   "smaller-or-as-small-as": "Pienempi tai yhtä pieni kuin",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -274,6 +274,8 @@
   "select-value": "",
   "select-values": "",
   "selected-data-model-class": "",
+  "selected-n-items_one": "",
+  "selected-n-items_other": "",
   "show-groups-register": "",
   "show-statuses": "",
   "smaller-or-as-small-as": "",

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -256,6 +256,15 @@ export default function MultiColumnSearch({
           defaultSelectedItems={serviceCategories.filter(
             (category) => category.uniqueItemId === '-1'
           )}
+          visualPlaceholder={
+            !searchParams.groups || searchParams.groups.length < 1
+              ? t('information-domains-all')
+              : searchParams.groups.length > 1
+              ? t('selected-n-items', { count: searchParams.groups.length })
+              : serviceCategories.find(
+                  (c) => c.uniqueItemId === (searchParams.groups as string[])[0]
+                )?.labelText
+          }
           selectedItems={
             searchParams.groups && searchParams.groups.length > 0
               ? serviceCategories.filter((category) =>

--- a/datamodel-ui/src/common/components/multi-column-search/multi-column-search.styles.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/multi-column-search.styles.tsx
@@ -38,4 +38,9 @@ export const SearchToolsBlock = styled.div`
       white-space: nowrap !important;
     }
   }
+
+  .fi-filter-input_input::placeholder {
+    color: ${(props) => props.theme.suomifi.colors.blackBase};
+    font-style: normal;
+  }
 `;


### PR DESCRIPTION
Changes in this PR:
- Selected groups user adds to `<MultiSelect />` in modal filter are displayed as follow:
  - Nothing selected = All groups
  - One selected = Selected groups name
  - More than one selected = N amount selected