### PR TITLE
YTI-3196: Change how status works

### DIFF
--- a/common-ui/components/search-results/result-card.styles.tsx
+++ b/common-ui/components/search-results/result-card.styles.tsx
@@ -74,9 +74,10 @@ export const PartOf = styled.p`
 
 export const Status = styled(StaticChip)<CardChipProps>`
   background-color: ${(props) =>
-    props.valid
-      ? 'hsl(166, 90%, 30%)'
-      : props.theme.suomifi.colors.depthDark1} !important;
+    (props.status === 'VALID' && props.theme.suomifi.colors.successBase) ||
+    ((props.status === 'DRAFT' || props.status === 'SUGGESTED') &&
+      props.theme.suomifi.colors.warningBase) ||
+    props.theme.suomifi.colors.depthDark1} !important;
   font-size: 12px;
   line-height: 0;
   padding: 0px 5px !important;

--- a/common-ui/components/search-results/result-card.tsx
+++ b/common-ui/components/search-results/result-card.tsx
@@ -97,10 +97,7 @@ export default function ResultCard({
         {noChip ? (
           translateStatus(status ?? 'DRAFT', t)
         ) : (
-          <Status
-            valid={status === 'VALID' ? 'true' : undefined}
-            id="card-status"
-          >
+          <Status status={status ?? 'DRAFT'} id="card-status">
             {translateStatus(status ?? 'DRAFT', t)}
           </Status>
         )}

--- a/common-ui/components/search-results/search-count-tags.props.ts
+++ b/common-ui/components/search-results/search-count-tags.props.ts
@@ -1,3 +1,3 @@
 export interface CardChipProps {
-  valid?: string;
+  status: string;
 }

--- a/common-ui/components/search-results/search-count-tags.tsx
+++ b/common-ui/components/search-results/search-count-tags.tsx
@@ -99,7 +99,7 @@ export default function SearchCountTags({
   }
 
   function renderStatusTags() {
-    return ['valid', 'draft', 'retired', 'superseded', 'invalid']
+    return ['valid', 'draft', 'retired', 'superseded', 'invalid', 'suggested']
       .map((status) => {
         if (
           urlState.status.includes(status) ||

--- a/common-ui/components/title/title.styles.tsx
+++ b/common-ui/components/title/title.styles.tsx
@@ -15,7 +15,7 @@ export const Description = styled(Text)`
 export const StatusChip = styled(StaticChip)<TitleProps>`
   background-color: ${(props) =>
     props.valid
-      ? 'hsl(166, 90%, 30%)'
+      ? props.theme.suomifi.colors.successBase
       : props.theme.suomifi.colors.depthDark1} !important;
   font-size: 12px;
   line-height: 0;

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -13,10 +13,10 @@ import { useGetServiceCategoriesQuery } from '../service-categories/service-cate
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { isEqual } from 'lodash';
 import { InternalResourcesSearchParams } from '../search-internal-resources/search-internal-resources.slice';
-import { Status } from 'yti-common-ui/interfaces/status.interface';
 import ResourceList, { ResultType } from '../resource-list';
 import { DetachedPagination } from 'yti-common-ui/pagination';
 import { compareLocales } from '@app/common/utils/compare-locals';
+import { Status } from '@app/common/interfaces/status.interface';
 
 interface MultiColumnSearchProps {
   primaryColumnName: string;
@@ -144,8 +144,8 @@ export default function MultiColumnSearch({
       const setStatuses =
         value !== '-1'
           ? value === 'in-use'
-            ? (['VALID', 'DRAFT'] as Status[])
-            : (['INCOMPLETE', 'INVALID', 'RETIRED', 'SUPERSEDED'] as Status[])
+            ? (['VALID', 'SUGGESTED'] as Status[])
+            : (['INCOMPLETE', 'DRAFT', 'RETIRED', 'SUPERSEDED'] as Status[])
           : [];
 
       setSearchParams({

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -31,7 +31,7 @@ export function initialSearchData(
 ): InternalResourcesSearchParams {
   return {
     query: '',
-    status: ['VALID', 'DRAFT'],
+    status: ['VALID', 'SUGGESTED'],
     groups: [],
     sortLang: sortLang,
     pageSize: 50,

--- a/datamodel-ui/src/common/components/search-models/search-models.slice.tsx
+++ b/datamodel-ui/src/common/components/search-models/search-models.slice.tsx
@@ -33,7 +33,7 @@ function getUrl(urlState: UrlState, lang?: string) {
       ? urlState.types.map((type) => type.toUpperCase())
       : [],
     ...(urlState.status.length === 0
-      ? { status: ['VALID', 'DRAFT'] }
+      ? { status: ['VALID', 'SUGGESTED'] }
       : { status: urlState.status }),
   }).filter(
     (item) =>

--- a/datamodel-ui/src/common/interfaces/code.ts
+++ b/datamodel-ui/src/common/interfaces/code.ts
@@ -1,4 +1,4 @@
-import { Status } from 'yti-common-ui/interfaces/status.interface';
+import { Status } from './status.interface';
 
 export interface CodeType {
   id: string;

--- a/datamodel-ui/src/common/interfaces/status.interface.ts
+++ b/datamodel-ui/src/common/interfaces/status.interface.ts
@@ -1,7 +1,7 @@
 export type Status =
   | 'DRAFT'
   | 'INCOMPLETE'
-  | 'INVALID'
+  | 'SUGGESTED'
   | 'RETIRED'
   | 'SUPERSEDED'
   | 'VALID';

--- a/datamodel-ui/src/modules/front-page/front-page-filter.tsx
+++ b/datamodel-ui/src/modules/front-page/front-page-filter.tsx
@@ -93,10 +93,10 @@ export default function FrontPageFilter({
         title={t('show')}
         items={[
           {
-            value: 'VALID,DRAFT',
+            value: 'VALID,SUGGESTED',
             label: t('datamodels-in-use'),
             hintText: `${translateStatus('VALID', t)}, ${translateStatus(
-              'DRAFT',
+              'SUGGESTED',
               t
             )}`,
           },
@@ -109,7 +109,7 @@ export default function FrontPageFilter({
             )}, ${translateStatus('INVALID', t)}`,
           },
           {
-            value: 'VALID,DRAFT,RETIRED,SUPERSEDED,INVALID',
+            value: 'VALID,SUGGESTED,RETIRED,SUPERSEDED,DRAFT',
             label: t('datamodels-all'),
           },
         ]}

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -10,7 +10,7 @@ import {
 import SearchResults, {
   SearchResultData,
 } from 'yti-common-ui/search-results/search-results';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { useGetSearchModelsQuery } from '@app/common/components/search-models/search-models.slice';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';

--- a/datamodel-ui/src/modules/model-form/index.tsx
+++ b/datamodel-ui/src/modules/model-form/index.tsx
@@ -39,6 +39,7 @@ interface ModelFormProps {
   disabled?: boolean;
   errors?: FormErrors | FormUpdateErrors;
   editMode?: boolean;
+  oldVersion?: boolean;
 }
 
 export default function ModelForm({
@@ -48,6 +49,7 @@ export default function ModelForm({
   disabled,
   errors,
   editMode,
+  oldVersion = true,
 }: ModelFormProps) {
   const { t, i18n } = useTranslation('admin');
   const { data: serviceCategoriesData } = useGetServiceCategoriesQuery(
@@ -56,6 +58,8 @@ export default function ModelForm({
   const { data: organizationsData } = useGetOrganizationsQuery(i18n.language);
   const { data: languages, isSuccess } = useGetLanguagesQuery();
   const [languageList, setLanguageList] = useState<LanguageBlockType[]>([]);
+
+  const [initialStatus, setInitialStatus] = useState(formData.status);
 
   const serviceCategories = useMemo(() => {
     if (!serviceCategoriesData) {
@@ -270,34 +274,38 @@ export default function ModelForm({
               smallScreen
             >{`http://uri.suomi.fi/datamodel/ns/${formData.prefix}`}</Text>
           </div>
-
-          <Dropdown
-            labelText={t('status')}
-            defaultValue={formData.status ?? ''}
-            onChange={(e) =>
-              setFormData({
-                ...formData,
-                status: e as Status | undefined,
-              })
-            }
-            id="status-dropdown"
-          >
-            <DropdownItem value={'DRAFT'}>
-              {t('statuses.draft', { ns: 'common' })}
-            </DropdownItem>
-            <DropdownItem value={'VALID'}>
-              {t('statuses.valid', { ns: 'common' })}
-            </DropdownItem>
-            <DropdownItem value={'SUPERSEDED'}>
-              {t('statuses.superseded', { ns: 'common' })}
-            </DropdownItem>
-            <DropdownItem value={'RETIRED'}>
-              {t('statuses.retired', { ns: 'common' })}
-            </DropdownItem>
-            <DropdownItem value={'INVALID'}>
-              {t('statuses.invalid', { ns: 'common' })}
-            </DropdownItem>
-          </Dropdown>
+          {oldVersion &&
+            (formData.status === 'SUGGESTED' ||
+              formData.status === 'VALID') && (
+              <Dropdown
+                labelText={t('status')}
+                defaultValue={formData.status ?? ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    status: e as Status | undefined,
+                  })
+                }
+                id="status-dropdown"
+              >
+                {initialStatus === 'SUGGESTED' ? (
+                  <DropdownItem value={'SUGGESTED'}>
+                    {t('statuses.suggested', { ns: 'common' })}
+                  </DropdownItem>
+                ) : (
+                  <></>
+                )}
+                <DropdownItem value={'VALID'}>
+                  {t('statuses.valid', { ns: 'common' })}
+                </DropdownItem>
+                <DropdownItem value={'SUPERSEDED'}>
+                  {t('statuses.superseded', { ns: 'common' })}
+                </DropdownItem>
+                <DropdownItem value={'RETIRED'}>
+                  {t('statuses.retired', { ns: 'common' })}
+                </DropdownItem>
+              </Dropdown>
+            )}
         </div>
       );
     }

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -29,7 +29,6 @@ import {
 } from 'suomifi-ui-components';
 import DrawerContent from 'yti-common-ui/drawer/drawer-content-wrapper';
 import StaticHeader from 'yti-common-ui/drawer/static-header';
-import { Status } from 'yti-common-ui/interfaces/status.interface';
 import { FormWrapper, LanguageVersionedWrapper } from './resource-form.styles';
 import validateForm from './validate-form';
 import { ConceptType } from '@app/common/interfaces/concept-interface';
@@ -55,6 +54,7 @@ import { setNotification } from '@app/common/components/notifications/notificati
 import { TEXT_AREA_MAX, TEXT_INPUT_MAX } from 'yti-common-ui/utils/constants';
 import { HeaderRow, StyledSpinner } from '@app/common/components/header';
 import { UriData } from '@app/common/interfaces/uri.interface';
+import { Status } from '@app/common/interfaces/status.interface';
 
 interface ResourceFormProps {
   modelId: string;


### PR DESCRIPTION
Changelog:
- DRAFT and SUGGESTED use warningBase color
- VALID uses successBase color instead of manually defined
- Change status interface import on some files to match same ones in datamodel
- Default search is now VALID, SUGGESTED
- DRAFT shows only for authorized users and is hidden by default