### PR TITLE
prevent deleting owl:DatatypeProperty in UI

### DIFF
--- a/datamodel-ui/src/common/components/inline-list/index.tsx
+++ b/datamodel-ui/src/common/components/inline-list/index.tsx
@@ -43,8 +43,9 @@ export default function InlineList({
             </ExternalLink>
           </div>
 
-          {Array.isArray(deleteDisabled) &&
-          deleteDisabled.includes(item.uri) ? (
+          {(Array.isArray(deleteDisabled) &&
+            deleteDisabled.includes(item.uri)) ||
+          deleteDisabled === true ? (
             <></>
           ) : (
             <Button

--- a/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
@@ -115,6 +115,7 @@ export default function RangeAndDomain({
                 defaultSelected={data.path?.uri}
               />
             }
+            deleteDisabled={true}
             handleRemoval={() => null}
             items={data.path ? [data.path] : []}
             label={`${t('target-attribute')} (owl:DatatypeProperty)`}


### PR DESCRIPTION
This selection can't be removed, only changed to another one.

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/25614946/0ba4bfb8-690b-4dfc-9e3a-6364eeab7382)

To achieve this, the InlineList now accepts deleteDisabled=true as an argument to completely disable deletion.  Previously it only allowed "false" or an array of strings.