### PR TITLE
Graph generation bugfixes

### DIFF
--- a/datamodel-ui/package.json
+++ b/datamodel-ui/package.json
@@ -30,7 +30,7 @@
     "react-dom": "17.0.2",
     "react-markdown": "^8.0.7",
     "react-redux": "^8.0.2",
-    "reactflow": "^11.4.2",
+    "reactflow": "^11.8.3",
     "redux-devtools-extension": "^2.13.9",
     "remark-gfm": "^3.0.1",
     "suomifi-icons": "^7.1.0",

--- a/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
+++ b/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 
 export const ToolsTooltip = styled.div`
   width: 295px;
-  height: 327px;
+  min-height: 200px;
+  height: max-content;
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   border: 1px solid ${(props) => props.theme.suomifi.colors.depthBase};
   border-radius: 2px;

--- a/datamodel-ui/src/common/interfaces/graph.interface.ts
+++ b/datamodel-ui/src/common/interfaces/graph.interface.ts
@@ -1,0 +1,31 @@
+import { ResourceType } from './resource-type.interface';
+
+export interface ClassNodeDataType {
+  applicationProfile?: boolean;
+  identifier: string;
+  label: { [key: string]: string };
+  modelId: string;
+  resources: {
+    identifier: string;
+    label: { [key: string]: string };
+    type: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE;
+    codeLists?: string[];
+    dataType?: string | null;
+    maxCount?: number | null;
+    minCount?: number | null;
+  }[];
+  refetch?: () => void;
+}
+
+export interface CornerNodeDataType {
+  applicationProfile?: boolean;
+  handleNodeDelete: (id: string) => void;
+}
+
+export interface EdgeDataType {
+  identifier?: string;
+  label?: { [key: string]: string };
+  applicationProfile?: boolean;
+  offsetSource?: number;
+  offsetTarget?: number;
+}

--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -13,7 +13,7 @@ export interface VisualizationType {
   associations: {
     identifier: string;
     label: { [key: string]: string };
-    referenceTarget?: string;
+    referenceTarget: string;
   }[];
 }
 

--- a/datamodel-ui/src/modules/graph/edges/edge.tsx
+++ b/datamodel-ui/src/modules/graph/edges/edge.tsx
@@ -18,6 +18,7 @@ import {
 import getEdgeParams from '../utils/get-edge-params';
 import { EdgeContent, HoveredPath } from './edge.styles';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import { EdgeDataType } from '@app/common/interfaces/graph.interface';
 
 export default function DefaultEdge({
   id,
@@ -26,7 +27,7 @@ export default function DefaultEdge({
   target,
   markerEnd,
   style,
-}: EdgeProps) {
+}: EdgeProps<EdgeDataType>) {
   const { i18n } = useTranslation('common');
   const dispatch = useStoreDispatch();
   const globalSelected = useSelector(selectSelected());
@@ -42,7 +43,7 @@ export default function DefaultEdge({
   const { sx, sy, tx, ty } = getEdgeParams(
     sourceNode,
     targetNode,
-    data.offsetSource
+    data?.offsetSource
   );
 
   const [edgePath, labelX, labelY] = getStraightPath({
@@ -53,7 +54,7 @@ export default function DefaultEdge({
   });
 
   const handleHover = (value?: boolean) => {
-    if (value) {
+    if (value && data?.identifier) {
       dispatch(setHovered(data.identifier, 'associations'));
       return;
     }
@@ -79,26 +80,29 @@ export default function DefaultEdge({
         onMouseOver={() => handleHover(true)}
       />
 
-      {getLabel(data.label) && (
+      {getLabel(data?.label) && (
         <EdgeLabelRenderer key={`edge-label-${source}-${target}`}>
           <EdgeContent
             className="nopan"
-            $applicationProfile={data.applicationProfile}
+            $applicationProfile={data ? data.applicationProfile : false}
             $labelX={labelX}
             $labelY={labelY}
             $highlight={
               globalSelected.type === 'associations' &&
+              data &&
               globalSelected.id === data.identifier
+                ? true
+                : false
             }
           >
-            <div>{getLabel(data.label)}</div>
+            <div>{getLabel(data?.label)}</div>
           </EdgeContent>
         </EdgeLabelRenderer>
       )}
     </>
   );
 
-  function getLabel(label: { [key: string]: string }) {
+  function getLabel(label?: { [key: string]: string }) {
     if (!label || Object.keys(label).length < 1) {
       return undefined;
     }

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -84,10 +84,6 @@ const GraphContent = ({
   const { data, isSuccess, refetch } = useGetVisualizationQuery(modelId);
   const [putPositions, result] = usePutPositionsMutation();
 
-  console.log('data', data);
-  console.log('nodes', nodes);
-  console.log('edges', edges);
-
   const deleteNodeById = useCallback(
     (id: string) => {
       handleCornerNodeDelete(id, setNodes, setEdges, applicationProfile);

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -107,8 +107,8 @@ const GraphContent = ({
             position: project({ x: x - left - 20 * getZoom(), y: y - top }),
             referenceTarget: target,
           },
-          applicationProfile,
-          deleteNodeById
+          deleteNodeById,
+          applicationProfile
         ),
       ]);
 
@@ -244,9 +244,9 @@ const GraphContent = ({
           data.nodes,
           data.hiddenNodes,
           modelId,
+          deleteNodeById,
           applicationProfile,
-          applicationProfile ? refetch : undefined,
-          deleteNodeById
+          applicationProfile ? refetch : undefined
         )
       );
       setEdges(
@@ -304,7 +304,6 @@ const GraphContent = ({
   }, [cleanUnusedCorners, edges, nodes, setNodes]);
 
   console.log('data', data);
-
   console.log('nodes', nodes);
   console.log('edges', edges);
 

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -84,6 +84,10 @@ const GraphContent = ({
   const { data, isSuccess, refetch } = useGetVisualizationQuery(modelId);
   const [putPositions, result] = usePutPositionsMutation();
 
+  console.log('data', data);
+  console.log('nodes', nodes);
+  console.log('edges', edges);
+
   const deleteNodeById = useCallback(
     (id: string) => {
       handleCornerNodeDelete(id, setNodes, setEdges, applicationProfile);

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -303,6 +303,11 @@ const GraphContent = ({
     }
   }, [cleanUnusedCorners, edges, nodes, setNodes]);
 
+  console.log('data', data);
+
+  console.log('nodes', nodes);
+  console.log('edges', edges);
+
   return (
     <div ref={reactFlowWrapper} style={{ height: '100%', width: '100%' }}>
       <ModelFlow

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -303,10 +303,6 @@ const GraphContent = ({
     }
   }, [cleanUnusedCorners, edges, nodes, setNodes]);
 
-  console.log('data', data);
-  console.log('nodes', nodes);
-  console.log('edges', edges);
-
   return (
     <div ref={reactFlowWrapper} style={{ height: '100%', width: '100%' }}>
       <ModelFlow

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -39,26 +39,11 @@ import { useAddNodeShapePropertyReferenceMutation } from '@app/common/components
 import ResourceModal from '@app/modules/class-view/resource-modal';
 import getConnectedElements from '../utils/get-connected-elements';
 import { UriData } from '@app/common/interfaces/uri.interface';
+import { ClassNodeDataType } from '@app/common/interfaces/graph.interface';
 
 interface ClassNodeProps {
   id: string;
-  data: {
-    identifier: string;
-    label: { [key: string]: string };
-    resources: {
-      label: { [key: string]: string };
-      identifier: string;
-      type: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE;
-      codeLists?: string[];
-      dataType?: string | null;
-      maxCount?: number | null;
-      minCount?: number | null;
-    }[];
-    modelId?: string;
-    resourceType?: 'association' | 'attribute';
-    applicationProfile?: boolean;
-    refetch?: () => void;
-  };
+  data: ClassNodeDataType;
   selected: boolean;
 }
 

--- a/datamodel-ui/src/modules/graph/nodes/corner-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/corner-node.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { Handle, Position } from 'reactflow';
 import { CornerNodeWrapper } from './node.styles';
 import { IconClose } from 'suomifi-icons';
+import { CornerNodeDataType } from '@app/common/interfaces/graph.interface';
 
 export default function CornerNode({
   id,
@@ -13,10 +14,7 @@ export default function CornerNode({
 }: {
   id: string;
   selected: boolean;
-  data: {
-    handleNodeDelete: (id: string) => void;
-    applicationProfile?: boolean;
-  };
+  data: CornerNodeDataType;
 }) {
   const highlighted = useSelector(selectHighlighted());
 

--- a/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
@@ -197,8 +197,8 @@ export const Resource = styled.div<{ $highlight?: boolean }>`
   }
 
   .fi-icon {
-    height: 16px;
-    width: 16px;
+    height: 17px;
+    width: 17px;
   }
 
   ${(props) =>

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -63,8 +63,8 @@ export default function convertToEdges(
             params: {
               source: node.identifier,
               sourceHandle: node.identifier,
-              target: assoc.referenceTarget,
-              targetHandle: assoc.referenceTarget,
+              target: assoc.referenceTarget as string,
+              targetHandle: assoc.referenceTarget as string,
               id: `reactflow__edge-${node.identifier}-${assoc.referenceTarget}`,
             },
             applicationProfile: applicationProfile,
@@ -77,7 +77,6 @@ export default function convertToEdges(
       ...node.parentClasses
         .filter((parent) => nodes.find((n) => n.identifier === parent))
         .flatMap((parent) => {
-          console.log('should be here');
           const parentNode = nodes.find(
             (n) => n.identifier === parent
           ) as VisualizationType;

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -13,7 +13,9 @@ export default function convertToEdges(
   if (
     !nodes ||
     nodes.length < 1 ||
-    nodes.filter((node) => node.associations.length > 0).length < 1
+    nodes.filter(
+      (node) => node.associations.length > 0 || node.parentClasses.length > 0
+    ).length < 1
   ) {
     return [];
   }
@@ -75,6 +77,7 @@ export default function convertToEdges(
       ...node.parentClasses
         .filter((parent) => nodes.find((n) => n.identifier === parent))
         .flatMap((parent) => {
+          console.log('should be here');
           const parentNode = nodes.find(
             (n) => n.identifier === parent
           ) as VisualizationType;

--- a/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-edges/index.ts
@@ -83,11 +83,11 @@ export default function convertToEdges(
             label: parentNode?.label,
             identifier: parent,
             params: {
-              source: parent,
-              sourceHandle: parent,
-              target: node.identifier,
-              targetHandle: node.identifier,
-              id: `reactflow__edge-${parent}-${node.identifier}`,
+              source: node.identifier,
+              sourceHandle: node.identifier,
+              target: parent,
+              targetHandle: parent,
+              id: `reactflow__edge-${node.identifier}-${parent}`,
             },
             applicationProfile,
           });

--- a/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.data.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.data.ts
@@ -138,87 +138,95 @@ export const convertedExpected = [
   },
 ];
 
-export const convertedWithHiddenExpected = [
-  {
-    id: '1',
-    position: {
-      x: 0,
-      y: 0,
-    },
-    data: {
-      identifier: '1',
-      label: {
-        fi: 'label-1-fi',
-        en: 'label-1-en',
+export function convertedWithHiddenExpected(
+  handleNodeDelete: (value: string) => void
+) {
+  return [
+    {
+      id: '1',
+      position: {
+        x: 0,
+        y: 0,
       },
-      modelId: 'modelId',
-      resources: [],
-    },
-    type: 'classNode',
-  },
-  {
-    id: '2',
-    position: {
-      x: 0,
-      y: 0,
-    },
-    data: {
-      identifier: '2',
-      label: {
-        en: 'label-2-en',
-      },
-      modelId: 'modelId',
-      resources: [],
-    },
-    type: 'classNode',
-  },
-  {
-    id: '3',
-    position: {
-      x: 0,
-      y: 0,
-    },
-    data: {
-      identifier: '3',
-      label: {
-        fi: 'label-3-fi',
-        en: 'label-3-en',
-        sv: 'label-3-sv',
-      },
-      modelId: 'modelId',
-      resources: [
-        {
-          identifier: '3-1',
-          label: {
-            fi: 'attr-1-fi',
-            en: 'attr-1-en',
-            sv: 'attr-1-sv',
-          },
-          type: 'ATTRIBUTE',
+      data: {
+        identifier: '1',
+        label: {
+          fi: 'label-1-fi',
+          en: 'label-1-en',
         },
-      ],
+        modelId: 'modelId',
+        resources: [],
+      },
+      type: 'classNode',
     },
-    type: 'classNode',
-  },
-  {
-    id: '#corner-1',
-    position: {
-      x: 0,
-      y: 0,
+    {
+      id: '2',
+      position: {
+        x: 0,
+        y: 0,
+      },
+      data: {
+        identifier: '2',
+        label: {
+          en: 'label-2-en',
+        },
+        modelId: 'modelId',
+        resources: [],
+      },
+      type: 'classNode',
     },
-    data: {},
-    type: 'cornerNode',
-  },
-  {
-    id: '#corner-2',
-    position: {
-      x: 0,
-      y: 0,
+    {
+      id: '3',
+      position: {
+        x: 0,
+        y: 0,
+      },
+      data: {
+        identifier: '3',
+        label: {
+          fi: 'label-3-fi',
+          en: 'label-3-en',
+          sv: 'label-3-sv',
+        },
+        modelId: 'modelId',
+        resources: [
+          {
+            identifier: '3-1',
+            label: {
+              fi: 'attr-1-fi',
+              en: 'attr-1-en',
+              sv: 'attr-1-sv',
+            },
+            type: 'ATTRIBUTE',
+          },
+        ],
+      },
+      type: 'classNode',
     },
-    data: {},
-    type: 'cornerNode',
-  },
-];
+    {
+      id: '#corner-1',
+      position: {
+        x: 0,
+        y: 0,
+      },
+      data: {
+        handleNodeDelete: handleNodeDelete,
+      },
+      type: 'cornerNode',
+    },
+    {
+      id: '#corner-2',
+      position: {
+        x: 0,
+        y: 0,
+      },
+      data: {
+        handleNodeDelete: handleNodeDelete,
+      },
+      type: 'cornerNode',
+    },
+  ];
+}
 
 export const visualizationHiddenTypeArray: VisualizationHiddenNode[] = [
   {

--- a/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.ts
@@ -8,27 +8,38 @@ import {
 
 describe('convert-to-nodes', () => {
   it('should return an empty array if given an empty array', () => {
-    const returned = convertToNodes([], [], 'modelId');
+    const handleNodeDeleteMock = jest.fn();
+
+    const returned = convertToNodes([], [], 'modelId', handleNodeDeleteMock);
 
     expect(returned).toStrictEqual([]);
   });
 
   it('should convert VisualizationType[] to a Node[]', () => {
+    const handleNodeDeleteMock = jest.fn();
+
     const input = visualizationTypeArray;
 
     const expected = convertedExpected;
 
-    const returned = convertToNodes(input, [], 'modelId');
+    const returned = convertToNodes(input, [], 'modelId', handleNodeDeleteMock);
     expect(returned).toStrictEqual(expected);
   });
 
   it('should convert VisualizationType[] and VisualizationHiddenNode[] to a Node[]', () => {
+    const handleNodeDeleteMock = jest.fn();
+
     const input = visualizationTypeArray;
     const inputHidden = visualizationHiddenTypeArray;
 
     const expected = convertedWithHiddenExpected;
 
-    const returned = convertToNodes(input, inputHidden, 'modelId');
+    const returned = convertToNodes(
+      input,
+      inputHidden,
+      'modelId',
+      handleNodeDeleteMock
+    );
     expect(returned).toStrictEqual(expected);
   });
 });

--- a/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-nodes/convert-to-nodes.test.ts
@@ -32,7 +32,7 @@ describe('convert-to-nodes', () => {
     const input = visualizationTypeArray;
     const inputHidden = visualizationHiddenTypeArray;
 
-    const expected = convertedWithHiddenExpected;
+    const expected = convertedWithHiddenExpected(handleNodeDeleteMock);
 
     const returned = convertToNodes(
       input,

--- a/datamodel-ui/src/modules/graph/utils/convert-to-nodes/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/convert-to-nodes/index.ts
@@ -11,9 +11,9 @@ export default function convertToNodes(
   nodes: VisualizationType[],
   hiddenNodes: VisualizationHiddenNode[],
   modelId: string,
+  handleNodeDelete: (id: string) => void,
   applicationProfile?: boolean,
-  refetch?: () => void,
-  handleNodeDelete?: (id: string) => void
+  refetch?: () => void
 ): Node[] {
   if (!nodes || nodes.length < 1) {
     return [];
@@ -34,7 +34,7 @@ export default function convertToNodes(
         : createExternalNode(node, applicationProfile);
     }),
     ...hiddenNodes.map((node) =>
-      createCornerNode(node, applicationProfile, handleNodeDelete)
+      createCornerNode(node, handleNodeDelete, applicationProfile)
     ),
   ];
 }

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/create-class-node.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/create-class-node.test.ts
@@ -77,18 +77,21 @@ describe('create-class-node', () => {
             label: {
               fi: 'assoc-1-fi',
             },
+            referenceTarget: 'id-2',
           },
           {
             identifier: 'assoc-2',
             label: {
               fi: 'assoc-2-fi',
             },
+            referenceTarget: 'id-3',
           },
           {
             identifier: 'assoc-3',
             label: {
               fi: 'assoc-3-fi',
             },
+            referenceTarget: 'id-4',
           },
         ],
       },

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
@@ -1,3 +1,4 @@
+import { ClassNodeDataType } from '@app/common/interfaces/graph.interface';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { VisualizationType } from '@app/common/interfaces/visualization.interface';
 import { Node } from 'reactflow';
@@ -7,7 +8,7 @@ export default function createClassNode(
   modelId: string,
   applicationProfile?: boolean,
   refetch?: () => void
-): Node {
+): Node<ClassNodeDataType> {
   return {
     id: node.identifier,
     position: { x: node.position.x, y: node.position.y },
@@ -21,12 +22,12 @@ export default function createClassNode(
       resources: [
         ...node.attributes.map((a) => ({
           ...a,
-          type: ResourceType.ATTRIBUTE,
+          type: ResourceType.ATTRIBUTE as ResourceType.ATTRIBUTE,
         })),
         ...(applicationProfile
           ? node.associations.map((a) => ({
               ...a,
-              type: ResourceType.ASSOCIATION,
+              type: ResourceType.ASSOCIATION as ResourceType.ASSOCIATION,
             }))
           : []),
       ],

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
@@ -25,10 +25,14 @@ export default function createClassNode(
           type: ResourceType.ATTRIBUTE as ResourceType.ATTRIBUTE,
         })),
         ...(applicationProfile
-          ? node.associations.map((a) => ({
-              ...a,
-              type: ResourceType.ASSOCIATION as ResourceType.ASSOCIATION,
-            }))
+          ? node.associations.map((a) => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const { referenceTarget, ...rest } = a;
+              return {
+                ...rest,
+                type: ResourceType.ASSOCIATION as ResourceType.ASSOCIATION,
+              };
+            })
           : []),
       ],
       ...(refetch ? { refetch: refetch } : {}),

--- a/datamodel-ui/src/modules/graph/utils/create-corner-node/create-corner-node.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-corner-node/create-corner-node.test.ts
@@ -1,15 +1,19 @@
-import createCornerNode, { createNewCornerNode } from '.';
+import createCornerNode from '.';
 
 describe('create-corner-node', () => {
   it('should create a corner node', () => {
-    const returned = createCornerNode({
-      identifier: 'corner-1',
-      position: {
-        x: 100,
-        y: 250,
+    const handleNodeDeleteMock = jest.fn();
+    const returned = createCornerNode(
+      {
+        identifier: 'corner-1',
+        position: {
+          x: 100,
+          y: 250,
+        },
+        referenceTarget: 'target-1',
       },
-      referenceTarget: 'target-1',
-    });
+      handleNodeDeleteMock
+    );
 
     expect(returned).toStrictEqual({
       id: '#corner-1',
@@ -17,20 +21,6 @@ describe('create-corner-node', () => {
       position: {
         x: 100,
         y: 250,
-      },
-      type: 'cornerNode',
-    });
-  });
-
-  it('should create a new corner node', () => {
-    const returned = createNewCornerNode('corner-1', { x: 0, y: 100 });
-
-    expect(returned).toStrictEqual({
-      id: '#corner-1',
-      data: {},
-      position: {
-        x: 0,
-        y: 100,
       },
       type: 'cornerNode',
     });

--- a/datamodel-ui/src/modules/graph/utils/create-corner-node/create-corner-node.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-corner-node/create-corner-node.test.ts
@@ -17,7 +17,9 @@ describe('create-corner-node', () => {
 
     expect(returned).toStrictEqual({
       id: '#corner-1',
-      data: {},
+      data: {
+        handleNodeDelete: handleNodeDeleteMock,
+      },
       position: {
         x: 100,
         y: 250,

--- a/datamodel-ui/src/modules/graph/utils/create-corner-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-corner-node/index.ts
@@ -1,31 +1,21 @@
+import { CornerNodeDataType } from '@app/common/interfaces/graph.interface';
 import { VisualizationHiddenNode } from '@app/common/interfaces/visualization.interface';
-import { Node, XYPosition } from 'reactflow';
+import { Node } from 'reactflow';
 
 export default function createCornerNode(
   node: VisualizationHiddenNode,
-  applicationProfile?: boolean,
-  handleNodeDelete?: (id: string) => void
-): Node {
+  handleNodeDelete: (id: string) => void,
+  applicationProfile?: boolean
+): Node<CornerNodeDataType> {
   return {
     id: node.identifier.startsWith('#corner')
       ? node.identifier
       : `#${node.identifier}`,
     data: {
+      handleNodeDelete: handleNodeDelete,
       ...(applicationProfile ? { applicationProfile: true } : {}),
-      ...(handleNodeDelete ? { handleNodeDelete: handleNodeDelete } : {}),
     },
     position: node.position,
-    type: 'cornerNode',
-  };
-}
-
-export function createNewCornerNode(id: string, position: XYPosition): Node {
-  const nodeId = id.startsWith('#') ? id : `#${id}`;
-
-  return {
-    id: nodeId,
-    data: {},
-    position: position,
     type: 'cornerNode',
   };
 }

--- a/datamodel-ui/src/modules/graph/utils/create-edge/index.tsx
+++ b/datamodel-ui/src/modules/graph/utils/create-edge/index.tsx
@@ -1,8 +1,14 @@
+import { EdgeDataType } from '@app/common/interfaces/graph.interface';
 import { Edge, MarkerType } from 'reactflow';
 
 interface CreateEdgeProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: any;
+  params: {
+    id: string;
+    source: string;
+    sourceHandle: string;
+    target: string;
+    targetHandle: string;
+  };
   applicationProfile?: boolean;
   identifier?: string;
   isCorner?: boolean;
@@ -17,13 +23,12 @@ export default function createEdge({
   isCorner,
   label,
   offsetSource,
-}: CreateEdgeProps): Edge {
+}: CreateEdgeProps): Edge<EdgeDataType> {
   return {
     ...params,
     type: 'generalEdge',
     markerEnd: getMarkerEnd(applicationProfile, isCorner),
     data: {
-      ...params?.data,
       ...(label ? { label: label } : {}),
       ...(identifier ? { identifier: identifier } : {}),
       ...(offsetSource ? { offsetSource: offsetSource } : {}),

--- a/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
@@ -8,11 +8,18 @@ describe('generate-positions-payload', () => {
   });
 
   it('should generate a payload for positions', () => {
+    const handleNodeDelete = jest.fn();
+
     const returned = generatePositionsPayload(
       [
         {
           id: 'node-1',
-          data: {},
+          data: {
+            identifier: 'node-1',
+            label: {},
+            modelId: 'model-1',
+            resources: [],
+          },
           position: {
             x: 0,
             y: 0,
@@ -20,7 +27,12 @@ describe('generate-positions-payload', () => {
         },
         {
           id: 'node-2',
-          data: {},
+          data: {
+            identifier: 'node-2',
+            label: {},
+            modelId: 'model-1',
+            resources: [],
+          },
           position: {
             x: 50,
             y: 0,
@@ -28,7 +40,12 @@ describe('generate-positions-payload', () => {
         },
         {
           id: 'node-3',
-          data: {},
+          data: {
+            identifier: 'node-3',
+            label: {},
+            modelId: 'model-1',
+            resources: [],
+          },
           position: {
             x: 50,
             y: 50,
@@ -36,7 +53,9 @@ describe('generate-positions-payload', () => {
         },
         {
           id: '#corner-1',
-          data: {},
+          data: {
+            handleNodeDelete: handleNodeDelete,
+          },
           position: {
             x: 25,
             y: 25,

--- a/datamodel-ui/src/modules/graph/utils/generate-positions-payload/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/generate-positions-payload/index.ts
@@ -1,11 +1,14 @@
+import {
+  ClassNodeDataType,
+  CornerNodeDataType,
+  EdgeDataType,
+} from '@app/common/interfaces/graph.interface';
 import { VisualizationPutType } from '@app/common/interfaces/visualization.interface';
 import { Edge, Node } from 'reactflow';
 
 export default function generatePositionsPayload(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  nodes: Node<any>[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  edges: Edge<any>[]
+  nodes: Node<ClassNodeDataType | CornerNodeDataType>[],
+  edges: Edge<EdgeDataType>[]
 ): VisualizationPutType[] {
   if (!nodes || nodes.length < 1) {
     return [];

--- a/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
@@ -23,10 +23,11 @@ export default function getConnectedElements(
     if (
       node &&
       node.type === 'classNode' &&
-      !edges.find(
+      (!edges.find(
         (e) =>
           e[direction === 'target' ? 'source' : 'target'] === begin[direction]
-      )
+      ) ||
+        nodes.find((n) => n.id === begin[direction])?.type === 'classNode')
     ) {
       return [begin.id, begin[direction]];
     }

--- a/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/get-connected-elements/index.ts
@@ -13,6 +13,14 @@ export default function getConnectedElements(
     const node = nodes.find((n) => n.id === begin[direction]);
 
     if (
+      direction === 'target'
+        ? begin.source === begin[direction]
+        : begin.target === begin[direction]
+    ) {
+      return [begin.id];
+    }
+
+    if (
       node &&
       node.type === 'classNode' &&
       !edges.find(
@@ -33,6 +41,10 @@ export default function getConnectedElements(
     }
 
     return [begin.id, begin[direction], ...getConnected(newNode, direction)];
+  }
+
+  if (edges.length < 1) {
+    return [];
   }
 
   if (start.type === 'cornerNode') {

--- a/datamodel-ui/src/modules/graph/utils/handle-corner-node-delete/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/handle-corner-node-delete/index.ts
@@ -39,16 +39,16 @@ export default function handleCornerNodeDelete(
     }
 
     const newEdge = createEdge({
-      params: {},
+      params: {
+        source: sourceNode,
+        sourceHandle: sourceNode,
+        target: targetNode,
+        targetHandle: targetNode,
+        id: `reactflow__edge-${sourceNode}-${targetNode}`,
+      },
       isCorner: true,
       applicationProfile: applicationProfile ? true : false,
     });
-
-    newEdge.source = sourceNode;
-    newEdge.sourceHandle = sourceNode;
-    newEdge.target = targetNode;
-    newEdge.targetHandle = targetNode;
-    newEdge.id = `reactflow__edge-${sourceNode}-${targetNode}`;
 
     return [
       ...edges.filter((edge) => edge.target !== id && edge.source !== id),

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "react-dom": "17.0.2",
         "react-markdown": "^8.0.7",
         "react-redux": "^8.0.2",
-        "reactflow": "^11.4.2",
+        "reactflow": "^11.8.3",
         "redux-devtools-extension": "^2.13.9",
         "remark-gfm": "^3.0.1",
         "suomifi-icons": "^7.1.0",
@@ -3504,12 +3504,13 @@
       }
     },
     "node_modules/@reactflow/background": {
-      "version": "11.1.2",
-      "license": "MIT",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.2.8.tgz",
+      "integrity": "sha512-5o41N2LygiNC2/Pk8Ak2rIJjXbKHfQ23/Y9LFsnAlufqwdzFqKA8txExpsMoPVHHlbAdA/xpQaMuoChGPqmyDw==",
       "dependencies": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "classcat": "^5.0.3",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -3517,11 +3518,13 @@
       }
     },
     "node_modules/@reactflow/controls": {
-      "version": "11.1.2",
-      "license": "MIT",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.1.19.tgz",
+      "integrity": "sha512-Vo0LFfAYjiSRMLEII/aeBo+1MT2a0Yc7iLVnkuRTLzChC0EX+A2Fa+JlzeOEYKxXlN4qcDxckRNGR7092v1HOQ==",
       "dependencies": {
-        "@reactflow/core": "11.4.2",
-        "classcat": "^5.0.3"
+        "@reactflow/core": "11.8.3",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -3529,8 +3532,9 @@
       }
     },
     "node_modules/@reactflow/core": {
-      "version": "11.4.2",
-      "license": "MIT",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.8.3.tgz",
+      "integrity": "sha512-y6DN8Wy4V4KQBGHFqlj9zWRjLJU6CgdnVwWaEA/PdDg/YUkFBMpZnXqTs60czinoA2rAcvsz50syLTPsj5e+Wg==",
       "dependencies": {
         "@types/d3": "^7.4.0",
         "@types/d3-drag": "^3.0.1",
@@ -3540,7 +3544,7 @@
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -3548,16 +3552,33 @@
       }
     },
     "node_modules/@reactflow/minimap": {
-      "version": "11.3.2",
-      "license": "MIT",
+      "version": "11.6.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.6.3.tgz",
+      "integrity": "sha512-PSA28dk09RnBHOA1zb45fjQXz3UozSJZmsIpgq49O3trfVFlSgRapxNdGsughWLs7/emg2M5jmi6Vc+ejcfjvQ==",
       "dependencies": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "@types/d3-selection": "^3.0.3",
         "@types/d3-zoom": "^3.0.1",
         "classcat": "^5.0.3",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.1.5.tgz",
+      "integrity": "sha512-z/hJlsptd2vTx13wKouqvN/Kln08qbkA+YTJLohc2aJ6rx3oGn9yX4E4IqNxhA7zNqYEdrnc1JTEA//ifh9z3w==",
+      "dependencies": {
+        "@reactflow/core": "11.8.3",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -3565,12 +3586,13 @@
       }
     },
     "node_modules/@reactflow/node-toolbar": {
-      "version": "1.1.2",
-      "license": "MIT",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.2.7.tgz",
+      "integrity": "sha512-vs+Wg1tjy3SuD7eoeTqEtscBfE9RY+APqC28urVvftkrtsN7KlnoQjqDG6aE45jWP4z+8bvFizRWjAhxysNLkg==",
       "dependencies": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "classcat": "^5.0.3",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -4166,7 +4188,8 @@
     },
     "node_modules/@types/d3": {
       "version": "7.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
       "dependencies": {
         "@types/d3-array": "*",
         "@types/d3-axis": "*",
@@ -4201,34 +4224,40 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.0.4",
-      "license": "MIT"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.7.tgz",
+      "integrity": "sha512-4/Q0FckQ8TBjsB0VdGFemJOG8BLXUB2KKlL0VmZ+eOYeOnTb/wDRQqYWpBmQ6IlvWkXwkYiot+n9Px2aTJ7zGQ=="
     },
     "node_modules/@types/d3-axis": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.3.tgz",
+      "integrity": "sha512-SE3x/pLO/+GIHH17mvs1uUVPkZ3bHquGzvZpPAh4yadRy71J93MJBpgK/xY8l9gT28yTN1g9v3HfGSFeBMmwZw==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-brush": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.3.tgz",
+      "integrity": "sha512-MQ1/M/B5ifTScHSe5koNkhxn2mhUPqXjGuKjjVYckplAPjP9t2I2sZafb/YVHDwhoXWZoSav+Q726eIbN3qprA==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-chord": {
-      "version": "3.0.2",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.3.tgz",
+      "integrity": "sha512-keuSRwO02c7PBV3JMWuctIfdeJrVFI7RpzouehvBWL4/GGUB3PBNg/9ZKPZAgJphzmS2v2+7vr7BGDQw1CAulw=="
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
     },
     "node_modules/@types/d3-contour": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.3.tgz",
+      "integrity": "sha512-x7G/tdDZt4m09XZnG2SutbIuQqmkNYqR9uhDMdPlpJbcwepkEjEWG29euFcgVA1k6cn92CHdDL9Z+fOnxnbVQw==",
       "dependencies": {
         "@types/d3-array": "*",
         "@types/geojson": "*"
@@ -4236,120 +4265,144 @@
     },
     "node_modules/@types/d3-delaunay": {
       "version": "6.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
     },
     "node_modules/@types/d3-dispatch": {
-      "version": "3.0.2",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.3.tgz",
+      "integrity": "sha512-Df7KW3Re7G6cIpIhQtqHin8yUxUHYAqiE41ffopbmU5+FifYUNV7RVyTg8rQdkEagg83m14QtS8InvNb95Zqug=="
     },
     "node_modules/@types/d3-drag": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.3.tgz",
+      "integrity": "sha512-82AuQMpBQjuXeIX4tjCYfWjpm3g7aGCfx6dFlxX2JlRaiME/QWcHzBsINl7gbHCODA2anPYlL31/Trj/UnjK9A==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-dsv": {
-      "version": "3.0.1",
-      "license": "MIT"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.2.tgz",
+      "integrity": "sha512-DooW5AOkj4AGmseVvbwHvwM/Ltu0Ks0WrhG6r5FG9riHT5oUUTHz6xHsHqJSVU8ZmPkOqlUEY2obS5C9oCIi2g=="
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
     },
     "node_modules/@types/d3-fetch": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.3.tgz",
+      "integrity": "sha512-/EsDKRiQkby3Z/8/AiZq8bsuLDo/tYHnNIZkUpSeEHWV7fHUl6QFBjvMPbhkKGk9jZutzfOkGygCV7eR/MkcXA==",
       "dependencies": {
         "@types/d3-dsv": "*"
       }
     },
     "node_modules/@types/d3-force": {
-      "version": "3.0.4",
-      "license": "MIT"
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.5.tgz",
+      "integrity": "sha512-EGG+IWx93ESSXBwfh/5uPuR9Hp8M6o6qEGU7bBQslxCvrdUBQZha/EFpu/VMdLU4B0y4Oe4h175nSm7p9uqFug=="
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
     },
     "node_modules/@types/d3-geo": {
-      "version": "3.0.3",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.4.tgz",
+      "integrity": "sha512-kmUK8rVVIBPKJ1/v36bk2aSgwRj2N/ZkjDT+FkMT5pgedZoPlyhaG62J+9EgNIgUXE6IIL0b7bkLxCzhE6U4VQ==",
       "dependencies": {
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.1",
-      "license": "MIT"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.3.tgz",
+      "integrity": "sha512-GpSK308Xj+HeLvogfEc7QsCOcIxkDwLhFYnOoohosEzOqv7/agxwvJER1v/kTC+CY1nfazR0F7gnHo7GE41/fw=="
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
       "dependencies": {
         "@types/d3-color": "*"
       }
     },
     "node_modules/@types/d3-path": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
     },
     "node_modules/@types/d3-polygon": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw=="
     },
     "node_modules/@types/d3-quadtree": {
       "version": "3.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw=="
     },
     "node_modules/@types/d3-random": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.3",
-      "license": "MIT",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.4.tgz",
+      "integrity": "sha512-eq1ZeTj0yr72L8MQk6N6heP603ubnywSDRfNpi5enouR112HzGLS6RIvExCzZTraFF4HdzNpJMwA/zGiMoHUUw==",
       "dependencies": {
         "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-scale-chromatic": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw=="
     },
     "node_modules/@types/d3-selection": {
-      "version": "3.0.4",
-      "license": "MIT"
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.6.tgz",
+      "integrity": "sha512-2ACr96USZVjXR9KMD9IWi1Epo4rSDKnUtYn6q2SPhYxykvXTw9vR77lkFNruXVg4i1tzQtBxeDMx0oNvJWbF1w=="
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.2.tgz",
+      "integrity": "sha512-NN4CXr3qeOUNyK5WasVUV8NCSAx/CRVcwcb0BuuS1PiTqwIm6ABi1SyasLZ/vsVCFDArF+W4QiGzSry1eKYQ7w==",
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
     },
     "node_modules/@types/d3-time-format": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw=="
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/d3-transition": {
-      "version": "3.0.3",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.4.tgz",
+      "integrity": "sha512-512a4uCOjUzsebydItSXsHrPeQblCVk8IKjqCUmrlvBWkkVh3donTTxmURDo1YPwIVDh5YVwCAO6gR4sgimCPQ==",
       "dependencies": {
         "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/d3-zoom": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.4.tgz",
+      "integrity": "sha512-cqkuY1ah9ZQre2POqjSLcM8g40UVya/qwEUrNYP2/rCVljbmqKCVcv+ebvwhlI5azIbSEL7m+os6n+WlYA43aA==",
       "dependencies": {
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
@@ -4404,7 +4457,8 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -6243,7 +6297,8 @@
     },
     "node_modules/classcat": {
       "version": "5.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
+      "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g=="
     },
     "node_modules/classnames": {
       "version": "2.3.1",
@@ -7108,21 +7163,24 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -7133,14 +7191,16 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -7150,21 +7210,24 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -7181,7 +7244,8 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -15956,14 +16020,16 @@
       "license": "MIT"
     },
     "node_modules/reactflow": {
-      "version": "11.4.2",
-      "license": "MIT",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.8.3.tgz",
+      "integrity": "sha512-wuVxJOFqi1vhA4WAEJLK0JWx2TsTiWpxTXTRp/wvpqKInQgQcB49I2QNyNYsKJCQ6jjXektS7H+LXoaVK/pG4A==",
       "dependencies": {
-        "@reactflow/background": "11.1.2",
-        "@reactflow/controls": "11.1.2",
-        "@reactflow/core": "11.4.2",
-        "@reactflow/minimap": "11.3.2",
-        "@reactflow/node-toolbar": "1.1.2"
+        "@reactflow/background": "11.2.8",
+        "@reactflow/controls": "11.1.19",
+        "@reactflow/core": "11.8.3",
+        "@reactflow/minimap": "11.6.3",
+        "@reactflow/node-resizer": "2.1.5",
+        "@reactflow/node-toolbar": "1.2.7"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -19848,8 +19914,9 @@
       "link": true
     },
     "node_modules/zustand": {
-      "version": "4.3.1",
-      "license": "MIT",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -19857,10 +19924,14 @@
         "node": ">=12.7.0"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
         "immer": ">=9.0",
         "react": ">=16.8"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
         "immer": {
           "optional": true
         },
@@ -21822,22 +21893,29 @@
       }
     },
     "@reactflow/background": {
-      "version": "11.1.2",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.2.8.tgz",
+      "integrity": "sha512-5o41N2LygiNC2/Pk8Ak2rIJjXbKHfQ23/Y9LFsnAlufqwdzFqKA8txExpsMoPVHHlbAdA/xpQaMuoChGPqmyDw==",
       "requires": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "classcat": "^5.0.3",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       }
     },
     "@reactflow/controls": {
-      "version": "11.1.2",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.1.19.tgz",
+      "integrity": "sha512-Vo0LFfAYjiSRMLEII/aeBo+1MT2a0Yc7iLVnkuRTLzChC0EX+A2Fa+JlzeOEYKxXlN4qcDxckRNGR7092v1HOQ==",
       "requires": {
-        "@reactflow/core": "11.4.2",
-        "classcat": "^5.0.3"
+        "@reactflow/core": "11.8.3",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
       }
     },
     "@reactflow/core": {
-      "version": "11.4.2",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.8.3.tgz",
+      "integrity": "sha512-y6DN8Wy4V4KQBGHFqlj9zWRjLJU6CgdnVwWaEA/PdDg/YUkFBMpZnXqTs60czinoA2rAcvsz50syLTPsj5e+Wg==",
       "requires": {
         "@types/d3": "^7.4.0",
         "@types/d3-drag": "^3.0.1",
@@ -21847,27 +21925,43 @@
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       }
     },
     "@reactflow/minimap": {
-      "version": "11.3.2",
+      "version": "11.6.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.6.3.tgz",
+      "integrity": "sha512-PSA28dk09RnBHOA1zb45fjQXz3UozSJZmsIpgq49O3trfVFlSgRapxNdGsughWLs7/emg2M5jmi6Vc+ejcfjvQ==",
       "requires": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "@types/d3-selection": "^3.0.3",
         "@types/d3-zoom": "^3.0.1",
         "classcat": "^5.0.3",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
+      }
+    },
+    "@reactflow/node-resizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.1.5.tgz",
+      "integrity": "sha512-z/hJlsptd2vTx13wKouqvN/Kln08qbkA+YTJLohc2aJ6rx3oGn9yX4E4IqNxhA7zNqYEdrnc1JTEA//ifh9z3w==",
+      "requires": {
+        "@reactflow/core": "11.8.3",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
       }
     },
     "@reactflow/node-toolbar": {
-      "version": "1.1.2",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.2.7.tgz",
+      "integrity": "sha512-vs+Wg1tjy3SuD7eoeTqEtscBfE9RY+APqC28urVvftkrtsN7KlnoQjqDG6aE45jWP4z+8bvFizRWjAhxysNLkg==",
       "requires": {
-        "@reactflow/core": "11.4.2",
+        "@reactflow/core": "11.8.3",
         "classcat": "^5.0.3",
-        "zustand": "^4.3.1"
+        "zustand": "^4.4.1"
       }
     },
     "@reduxjs/toolkit": {
@@ -22217,6 +22311,8 @@
     },
     "@types/d3": {
       "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
       "requires": {
         "@types/d3-array": "*",
         "@types/d3-axis": "*",
@@ -22251,125 +22347,185 @@
       }
     },
     "@types/d3-array": {
-      "version": "3.0.4"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.7.tgz",
+      "integrity": "sha512-4/Q0FckQ8TBjsB0VdGFemJOG8BLXUB2KKlL0VmZ+eOYeOnTb/wDRQqYWpBmQ6IlvWkXwkYiot+n9Px2aTJ7zGQ=="
     },
     "@types/d3-axis": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.3.tgz",
+      "integrity": "sha512-SE3x/pLO/+GIHH17mvs1uUVPkZ3bHquGzvZpPAh4yadRy71J93MJBpgK/xY8l9gT28yTN1g9v3HfGSFeBMmwZw==",
       "requires": {
         "@types/d3-selection": "*"
       }
     },
     "@types/d3-brush": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.3.tgz",
+      "integrity": "sha512-MQ1/M/B5ifTScHSe5koNkhxn2mhUPqXjGuKjjVYckplAPjP9t2I2sZafb/YVHDwhoXWZoSav+Q726eIbN3qprA==",
       "requires": {
         "@types/d3-selection": "*"
       }
     },
     "@types/d3-chord": {
-      "version": "3.0.2"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.3.tgz",
+      "integrity": "sha512-keuSRwO02c7PBV3JMWuctIfdeJrVFI7RpzouehvBWL4/GGUB3PBNg/9ZKPZAgJphzmS2v2+7vr7BGDQw1CAulw=="
     },
     "@types/d3-color": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
     },
     "@types/d3-contour": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.3.tgz",
+      "integrity": "sha512-x7G/tdDZt4m09XZnG2SutbIuQqmkNYqR9uhDMdPlpJbcwepkEjEWG29euFcgVA1k6cn92CHdDL9Z+fOnxnbVQw==",
       "requires": {
         "@types/d3-array": "*",
         "@types/geojson": "*"
       }
     },
     "@types/d3-delaunay": {
-      "version": "6.0.1"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
     },
     "@types/d3-dispatch": {
-      "version": "3.0.2"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.3.tgz",
+      "integrity": "sha512-Df7KW3Re7G6cIpIhQtqHin8yUxUHYAqiE41ffopbmU5+FifYUNV7RVyTg8rQdkEagg83m14QtS8InvNb95Zqug=="
     },
     "@types/d3-drag": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.3.tgz",
+      "integrity": "sha512-82AuQMpBQjuXeIX4tjCYfWjpm3g7aGCfx6dFlxX2JlRaiME/QWcHzBsINl7gbHCODA2anPYlL31/Trj/UnjK9A==",
       "requires": {
         "@types/d3-selection": "*"
       }
     },
     "@types/d3-dsv": {
-      "version": "3.0.1"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.2.tgz",
+      "integrity": "sha512-DooW5AOkj4AGmseVvbwHvwM/Ltu0Ks0WrhG6r5FG9riHT5oUUTHz6xHsHqJSVU8ZmPkOqlUEY2obS5C9oCIi2g=="
     },
     "@types/d3-ease": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
     },
     "@types/d3-fetch": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.3.tgz",
+      "integrity": "sha512-/EsDKRiQkby3Z/8/AiZq8bsuLDo/tYHnNIZkUpSeEHWV7fHUl6QFBjvMPbhkKGk9jZutzfOkGygCV7eR/MkcXA==",
       "requires": {
         "@types/d3-dsv": "*"
       }
     },
     "@types/d3-force": {
-      "version": "3.0.4"
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.5.tgz",
+      "integrity": "sha512-EGG+IWx93ESSXBwfh/5uPuR9Hp8M6o6qEGU7bBQslxCvrdUBQZha/EFpu/VMdLU4B0y4Oe4h175nSm7p9uqFug=="
     },
     "@types/d3-format": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
     },
     "@types/d3-geo": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.4.tgz",
+      "integrity": "sha512-kmUK8rVVIBPKJ1/v36bk2aSgwRj2N/ZkjDT+FkMT5pgedZoPlyhaG62J+9EgNIgUXE6IIL0b7bkLxCzhE6U4VQ==",
       "requires": {
         "@types/geojson": "*"
       }
     },
     "@types/d3-hierarchy": {
-      "version": "3.1.1"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.3.tgz",
+      "integrity": "sha512-GpSK308Xj+HeLvogfEc7QsCOcIxkDwLhFYnOoohosEzOqv7/agxwvJER1v/kTC+CY1nfazR0F7gnHo7GE41/fw=="
     },
     "@types/d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
       "requires": {
         "@types/d3-color": "*"
       }
     },
     "@types/d3-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
     },
     "@types/d3-polygon": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw=="
     },
     "@types/d3-quadtree": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw=="
     },
     "@types/d3-random": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ=="
     },
     "@types/d3-scale": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.4.tgz",
+      "integrity": "sha512-eq1ZeTj0yr72L8MQk6N6heP603ubnywSDRfNpi5enouR112HzGLS6RIvExCzZTraFF4HdzNpJMwA/zGiMoHUUw==",
       "requires": {
         "@types/d3-time": "*"
       }
     },
     "@types/d3-scale-chromatic": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw=="
     },
     "@types/d3-selection": {
-      "version": "3.0.4"
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.6.tgz",
+      "integrity": "sha512-2ACr96USZVjXR9KMD9IWi1Epo4rSDKnUtYn6q2SPhYxykvXTw9vR77lkFNruXVg4i1tzQtBxeDMx0oNvJWbF1w=="
     },
     "@types/d3-shape": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.2.tgz",
+      "integrity": "sha512-NN4CXr3qeOUNyK5WasVUV8NCSAx/CRVcwcb0BuuS1PiTqwIm6ABi1SyasLZ/vsVCFDArF+W4QiGzSry1eKYQ7w==",
       "requires": {
         "@types/d3-path": "*"
       }
     },
     "@types/d3-time": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
     },
     "@types/d3-time-format": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw=="
     },
     "@types/d3-timer": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/d3-transition": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.4.tgz",
+      "integrity": "sha512-512a4uCOjUzsebydItSXsHrPeQblCVk8IKjqCUmrlvBWkkVh3donTTxmURDo1YPwIVDh5YVwCAO6gR4sgimCPQ==",
       "requires": {
         "@types/d3-selection": "*"
       }
     },
     "@types/d3-zoom": {
-      "version": "3.0.2",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.4.tgz",
+      "integrity": "sha512-cqkuY1ah9ZQre2POqjSLcM8g40UVya/qwEUrNYP2/rCVljbmqKCVcv+ebvwhlI5azIbSEL7m+os6n+WlYA43aA==",
       "requires": {
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
@@ -22418,7 +22574,9 @@
       }
     },
     "@types/geojson": {
-      "version": "7946.0.10"
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -23618,7 +23776,9 @@
       "version": "1.2.2"
     },
     "classcat": {
-      "version": "5.0.4"
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
+      "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g=="
     },
     "classnames": {
       "version": "2.3.1"
@@ -24145,35 +24305,51 @@
       "version": "3.1.1"
     },
     "d3-color": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-dispatch": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
     },
     "d3-drag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
       }
     },
     "d3-ease": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "requires": {
         "d3-color": "1 - 3"
       }
     },
     "d3-selection": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-timer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
     },
     "d3-transition": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "requires": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -24184,6 +24360,8 @@
     },
     "d3-zoom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -29455,13 +29633,16 @@
       }
     },
     "reactflow": {
-      "version": "11.4.2",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.8.3.tgz",
+      "integrity": "sha512-wuVxJOFqi1vhA4WAEJLK0JWx2TsTiWpxTXTRp/wvpqKInQgQcB49I2QNyNYsKJCQ6jjXektS7H+LXoaVK/pG4A==",
       "requires": {
-        "@reactflow/background": "11.1.2",
-        "@reactflow/controls": "11.1.2",
-        "@reactflow/core": "11.4.2",
-        "@reactflow/minimap": "11.3.2",
-        "@reactflow/node-toolbar": "1.1.2"
+        "@reactflow/background": "11.2.8",
+        "@reactflow/controls": "11.1.19",
+        "@reactflow/core": "11.8.3",
+        "@reactflow/minimap": "11.6.3",
+        "@reactflow/node-resizer": "2.1.5",
+        "@reactflow/node-toolbar": "1.2.7"
       }
     },
     "read-cache": {
@@ -32046,7 +32227,7 @@
         "react-markdown": "^8.0.7",
         "react-redux": "^8.0.2",
         "react-test-renderer": "^17.0.2",
-        "reactflow": "^11.4.2",
+        "reactflow": "^11.8.3",
         "redux-devtools-extension": "^2.13.9",
         "remark-gfm": "^3.0.1",
         "suomifi-icons": "^7.1.0",
@@ -32173,7 +32354,9 @@
       }
     },
     "zustand": {
-      "version": "4.3.1",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
       "requires": {
         "use-sync-external-store": "1.2.0"
       }


### PR DESCRIPTION
Changes in this PR:
- Updated React Flow to version `11.8.3` from `11.4.2`
- Improved `Node` and `Edge` typing and removed all `any` types related to graph
- Partial support for generating edges from `parentClasses`. Todo comment in code explains more in detail
- `getConnected()` improved to stop parsing edges when first class node occurs
- Fixed `UpperClass` arrow direction in edge
- Removed `createNewCornerNode()` as unused