### PR TITLE
YTI-3202 version control release

### DIFF
--- a/common-ui/components/search-results/result-card.tsx
+++ b/common-ui/components/search-results/result-card.tsx
@@ -25,6 +25,8 @@ interface ResultCardProps {
   noDescriptionText: string;
   partOfText?: string;
   partOf?: string[];
+  identifier?: string;
+  version?: string;
   status?: string;
   title: string;
   titleLink: string;
@@ -39,6 +41,8 @@ export default function ResultCard({
   noChip = false,
   noDescriptionText,
   partOf,
+  version,
+  identifier,
   partOfText,
   status,
   title,
@@ -69,6 +73,20 @@ export default function ResultCard({
       </Link>
       <Subtitle id="card-subtitle">
         <span>{type}</span>
+        {identifier && (
+          <>
+            <span aria-hidden={true}>&middot;</span>
+            <span style={{ textTransform: 'uppercase' }}>{identifier}</span>
+          </>
+        )}
+        {version && (
+          <>
+            <span aria-hidden={true}>&middot;</span>
+            <span style={{ textTransform: 'uppercase' }}>{`${t(
+              'version'
+            )} ${version}`}</span>
+          </>
+        )}
         {status && renderStatus()}
       </Subtitle>
       <Description id="card-description">

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -13,6 +13,8 @@ export interface SearchResultData {
   icon?: ReactNode;
   status?: string;
   partOf?: string[];
+  identifier?: string;
+  version?: string;
   title: string;
   titleLink: string;
   type: string;
@@ -101,6 +103,8 @@ export default function SearchResults({
               icon={d.icon}
               status={d.status}
               partOf={d.partOf}
+              version={d.version}
+              identifier={d.identifier}
               partOfText={partOfText}
               noDescriptionText={noDescriptionText}
               noChip={noChip}

--- a/common-ui/components/title-block/badge-bar.tsx
+++ b/common-ui/components/title-block/badge-bar.tsx
@@ -17,7 +17,7 @@ export default function BadgeBar({
     <BadgeBarWrapper $larger={larger} $smBottom={smBottom} {...rest}>
       {React.Children.map(children, (child, i) => (
         <>
-          {i > 0 && ' \u00b7 '}
+          {child && i > 0 && ' \u00b7 '}
           {child}
         </>
       ))}

--- a/common-ui/components/title-block/index.ts
+++ b/common-ui/components/title-block/index.ts
@@ -1,3 +1,3 @@
 export { default as MainTitle } from './main-title';
 export { default as BadgeBar } from './badge-bar';
-export { SubTitle, Badge } from './title-block.styles';
+export { SubTitle } from './title-block.styles';

--- a/common-ui/components/title-block/title-block.styles.tsx
+++ b/common-ui/components/title-block/title-block.styles.tsx
@@ -40,16 +40,3 @@ export const BadgeBarWrapper = styled.div<{
     width: 20px !important;
   }
 `;
-
-export const Badge = styled.span<{ $isValid?: boolean }>`
-  line-height: 18px;
-  border-radius: 10px;
-  padding: 0 5px;
-  background-color: ${(props) =>
-    props.$isValid
-      ? props.theme.suomifi.colors.successBase
-      : props.theme.suomifi.colors.depthDark2};
-  color: white;
-  height: 18px;
-  display: inline-block;
-`;

--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -83,6 +83,7 @@
   "codelist": "Code list",
   "codelist-contents": "Code list contents",
   "codelist-delete-warning": "Are you sure you want to delete codelist {{name}}. Codes in codelist will also be removed from other fields.",
+  "commentable-version": "commentable version",
   "common-form": {
     "add-equivalent-association": "Add equivelant association",
     "add-equivalent-attribute": "Add equivalent attribute",
@@ -131,8 +132,11 @@
   "create-new-sub-association-for-selected": "Create new sub-association for selected",
   "create-new-sub-attribute-for-selected": "Create new sub-attribute for selected",
   "create-prefix-automatically": "Create prefix automatically",
+  "create-release": "Create release of data model",
+  "create-release-status": "Choose the status of release version",
   "create-subclass-for-selected": "Create subclass for selected",
   "creating-model": "Adding model",
+  "creating-release": "Creating release",
   "data-model": "Data model",
   "data-model-name": "Data model name",
   "data-models-added-to-this-model": "Data models added to this model",
@@ -242,6 +246,9 @@
   "range": "Range",
   "reference-data-counts_one": "{{count}} reference data",
   "reference-data-counts_other": "{{count}} reference data",
+  "release": "Release",
+  "release-version-number": "Release version number",
+  "release-version-number-hint": "Write version number for the release in format x.y.z (for example 1.1.0)",
   "remove": "Remove",
   "remove-reference": "Remove reference",
   "remove-reference-description-association": "Do you want to remove the reference to the association restriction {{name}} from this class?",
@@ -306,6 +313,8 @@
   "uri-preview": "URI preview",
   "use-codelist-values": "Use codelist values",
   "utilizes-class-restriction": "Utilizes class restriction",
+  "version-number-error": "Version number is not in format x.y.z",
   "work-group-comment": "Work group comment",
+  "write-version-number": "Write version number",
   "you-have-unsaved-changes": "You have unsaved changes."
 }

--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -268,6 +268,7 @@
   "uri": "URI",
   "utilizes-class-restriction": "Utilizes class restriction",
   "value-is-not-allowed": "\"{{value}}\" is not allowed",
+  "version": "Version",
   "vocabulary-filter-items": "items",
   "vocabulary-filter-show-only": "",
   "vocabulary-info-en": "",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -83,6 +83,7 @@
   "codelist": "Koodisto",
   "codelist-contents": "Koodiston sisältö",
   "codelist-delete-warning": "Haluatko poistaa koodiston {{name}}. Koodistosta valitut arvot poistetaan myös muista kentistä.",
+  "commentable-version": "Kommentoitava versio",
   "common-form": {
     "add-equivalent-association": "Lisää vastaava assosiaatio",
     "add-equivalent-attribute": "Lisää vastaava attribuutti",
@@ -131,8 +132,11 @@
   "create-new-sub-association-for-selected": "Luo valitulle uusi ala-assosiaatio",
   "create-new-sub-attribute-for-selected": "Luo valitulle uusi ala-attribuutti",
   "create-prefix-automatically": "Luo tunnus automaattisesti",
+  "create-release": "Julkaise versio tietomallista",
+  "create-release-status": "Valitse julkaistavan version tila",
   "create-subclass-for-selected": "Luo valitulle alaluokka",
   "creating-model": "Luodaan tietomallia",
+  "creating-release": "Julkaistaan",
   "data-model": "Tietomalli",
   "data-model-name": "Tietomallin nimi",
   "data-models-added-to-this-model": "Tähän tietomalliin lisätyt tietomallit",
@@ -242,6 +246,9 @@
   "range": "Tietotyyppi",
   "reference-data-counts_one": "{{count}} koodisto",
   "reference-data-counts_other": "{{count}} koodistoa",
+  "release": "Julkaise",
+  "release-version-number": "Tietomallin versionumero",
+  "release-version-number-hint": "Kirjoita versionumero mouodossa x.y.z (esimerkiksi 1.1.0)",
   "remove": "Poista",
   "remove-reference": "Poista viittaus",
   "remove-reference-description-association": "Haluatko poistaa viittauksen assosiaatiorajoitteeseen {{name}} tästä luokasta?",
@@ -306,6 +313,8 @@
   "uri-preview": "URI:n esikatselu",
   "use-codelist-values": "Käytä koodiston arvoja",
   "utilizes-class-restriction": "Hyödyntää luokkarajoitetta",
+  "version-number-error": "Versionumero ei ole muodossa x.y.z",
   "work-group-comment": "Työryhmän sisäinen kommentti",
+  "write-version-number": "Kirjoita versionumero",
   "you-have-unsaved-changes": "Sinulla on tallentamattomia muutoksia."
 }

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -268,6 +268,7 @@
   "uri": "URI",
   "utilizes-class-restriction": "Hyödyntää luokkarajoitetta",
   "value-is-not-allowed": "\"{{value}}\" ei sallittu",
+  "version": "Versio",
   "vocabulary-filter-items": "kpl",
   "vocabulary-filter-show-only": "",
   "vocabulary-info-en": "",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -83,6 +83,7 @@
   "codelist": "",
   "codelist-contents": "",
   "codelist-delete-warning": "",
+  "commentable-version": "",
   "common-form": {
     "add-equivalent-association": "",
     "add-equivalent-attribute": "",
@@ -131,8 +132,11 @@
   "create-new-sub-association-for-selected": "",
   "create-new-sub-attribute-for-selected": "",
   "create-prefix-automatically": "",
+  "create-release": "",
+  "create-release-status": "",
   "create-subclass-for-selected": "",
   "creating-model": "",
+  "creating-release": "",
   "data-model": "",
   "data-model-name": "",
   "data-models-added-to-this-model": "",
@@ -242,6 +246,9 @@
   "range": "",
   "reference-data-counts_one": "",
   "reference-data-counts_other": "",
+  "release": "",
+  "release-version-number": "",
+  "release-version-number-hint": "",
   "remove": "",
   "remove-reference": "",
   "remove-reference-description-association": "",
@@ -306,6 +313,8 @@
   "uri-preview": "",
   "use-codelist-values": "",
   "utilizes-class-restriction": "",
+  "version-number-error": "",
   "work-group-comment": "",
+  "write-version-number": "",
   "you-have-unsaved-changes": ""
 }

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -268,6 +268,7 @@
   "uri": "",
   "utilizes-class-restriction": "",
   "value-is-not-allowed": "",
+  "version": "",
   "vocabulary-filter-items": "",
   "vocabulary-filter-show-only": "",
   "vocabulary-info-en": "",

--- a/datamodel-ui/src/common/components/class/class.slice.tsx
+++ b/datamodel-ui/src/common/components/class/class.slice.tsx
@@ -59,12 +59,22 @@ export const classApi = createApi({
     }),
     getClass: builder.query<
       ClassType,
-      { modelId: string; classId: string; applicationProfile?: boolean }
+      {
+        modelId: string;
+        version?: string;
+        classId: string;
+        applicationProfile?: boolean;
+      }
     >({
       query: (value) => ({
         url: `/class/${pathForModelType(value.applicationProfile)}${
           value.modelId
         }/${value.classId}`,
+        params: {
+          ...(value.version && {
+            version: value.version,
+          }),
+        },
         method: 'GET',
       }),
     }),

--- a/datamodel-ui/src/common/components/model-tools/download-picture.tsx
+++ b/datamodel-ui/src/common/components/model-tools/download-picture.tsx
@@ -1,7 +1,6 @@
 import { toPng } from 'html-to-image';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 import { Button, IconDownload } from 'suomifi-ui-components';
-import { useGetModelQuery } from '../model/model.slice';
 
 function downloadImg(dataUrl: string, fileName: string) {
   const a = document.createElement('a');
@@ -12,7 +11,6 @@ function downloadImg(dataUrl: string, fileName: string) {
 
 export default function DownloadPicture({ modelId }: { modelId: string }) {
   const { getNodes } = useReactFlow();
-  const { data } = useGetModelQuery(modelId);
 
   const handleClick = () => {
     const el = document
@@ -33,7 +31,6 @@ export default function DownloadPicture({ modelId }: { modelId: string }) {
       0.5,
       2
     );
-    const fileName = data?.prefix ?? 'model';
 
     toPng(el, {
       backgroundColor: 'white',
@@ -44,7 +41,7 @@ export default function DownloadPicture({ modelId }: { modelId: string }) {
         height: imgHeight.toString(),
         transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})})`,
       },
-    }).then((dataUrl) => downloadImg(dataUrl, fileName));
+    }).then((dataUrl) => downloadImg(dataUrl, modelId));
   };
 
   return <Button icon={<IconDownload />} onClick={() => handleClick()} />;

--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -38,9 +38,11 @@ import DownloadPicture from './download-picture';
 
 export default function ModelTools({
   modelId,
+  version,
   applicationProfile,
 }: {
   modelId: string;
+  version?: string;
   applicationProfile: boolean;
 }) {
   const { t } = useTranslation('common');
@@ -126,7 +128,7 @@ export default function ModelTools({
 
           <DownloadPicture modelId={modelId} />
 
-          {hasPermission && (
+          {hasPermission && !version && (
             <Button
               icon={<IconSave />}
               onClick={() => dispatch(setSavePosition(true))}

--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -27,9 +27,14 @@ export const modelApi = createApi({
         data: value,
       }),
     }),
-    getModel: builder.query<ModelType, string>({
-      query: (modelId) => ({
-        url: `/model/${modelId}`,
+    getModel: builder.query<ModelType, { modelId: string; version?: string }>({
+      query: (value) => ({
+        url: `/model/${value.modelId}`,
+        params: {
+          ...(value.version && {
+            version: value.version,
+          }),
+        },
         method: 'GET',
       }),
     }),
@@ -55,6 +60,19 @@ export const modelApi = createApi({
         method: 'DELETE',
       }),
     }),
+    createRelease: builder.mutation<
+      string,
+      { modelId: string; version: string; status: string }
+    >({
+      query: (value) => ({
+        url: `/model/${value.modelId}/release`,
+        params: {
+          status: value.status,
+          version: value.version,
+        },
+        method: 'POST',
+      }),
+    }),
   }),
 });
 
@@ -63,11 +81,17 @@ export const {
   useGetModelQuery,
   useUpdateModelMutation,
   useDeleteModelMutation,
+  useCreateReleaseMutation,
   util: { getRunningQueriesThunk },
 } = modelApi;
 
-export const { createModel, getModel, updateModel, deleteModel } =
-  modelApi.endpoints;
+export const {
+  createModel,
+  getModel,
+  updateModel,
+  deleteModel,
+  createRelease,
+} = modelApi.endpoints;
 
 // Slice setup below
 

--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -58,12 +58,16 @@ export const resourceApi = createApi({
         modelId: string;
         resourceIdentifier: string;
         applicationProfile?: boolean;
+        version?: string;
       }
     >({
       query: (value) => ({
         url: `/resource/${pathForModelType(value.applicationProfile)}${
           value.modelId
         }/${value.resourceIdentifier}`,
+        params: {
+          ...(value.version && { version: value.version }),
+        },
         method: 'GET',
       }),
     }),

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -21,13 +21,15 @@ export interface InternalResourcesSearchParams {
   pageFrom?: number;
   limitToModelType?: Type;
   extend?: boolean;
+  fromVersion?: string;
 }
 
 export function initialSearchData(
   sortLang: string,
   modelId: string,
   type: ResourceType,
-  limitToModelType?: 'LIBRARY' | 'PROFILE'
+  limitToModelType?: 'LIBRARY' | 'PROFILE',
+  fromVersion?: string
 ): InternalResourcesSearchParams {
   return {
     query: '',
@@ -40,6 +42,7 @@ export function initialSearchData(
     limitToModelType: limitToModelType ?? 'LIBRARY',
     fromAddedNamespaces: true,
     resourceTypes: [type],
+    fromVersion: fromVersion,
   };
 }
 
@@ -84,6 +87,10 @@ function createUrl(obj: InternalResourcesSearchParams): string {
 
   if (obj.limitToModelType) {
     baseQuery = baseQuery.concat(`&limitToModelType=${obj.limitToModelType}`);
+  }
+
+  if (obj.fromVersion) {
+    baseQuery = baseQuery.concat(`&fromVersion=${obj.fromVersion}`);
   }
 
   return baseQuery;

--- a/datamodel-ui/src/common/components/visualization/visualization.slice.tsx
+++ b/datamodel-ui/src/common/components/visualization/visualization.slice.tsx
@@ -16,9 +16,17 @@ export const visualizationApi = createApi({
     }
   },
   endpoints: (builder) => ({
-    getVisualization: builder.query<VisualizationResult, string>({
-      query: (modelId) => ({
-        url: `/visualization/${modelId}`,
+    getVisualization: builder.query<
+      VisualizationResult,
+      { modelid: string; version?: string }
+    >({
+      query: (value) => ({
+        url: `/visualization/${value.modelid}`,
+        params: {
+          ...(value.version && {
+            version: value.version,
+          }),
+        },
         method: 'GET',
       }),
     }),

--- a/datamodel-ui/src/common/interfaces/datamodel.interface.ts
+++ b/datamodel-ui/src/common/interfaces/datamodel.interface.ts
@@ -21,4 +21,7 @@ export interface DataModel {
   prefix: string;
   status: Status;
   type: Type;
+  version?: string;
+  versionIri?: string;
+  uri: string;
 }

--- a/datamodel-ui/src/common/interfaces/model.interface.ts
+++ b/datamodel-ui/src/common/interfaces/model.interface.ts
@@ -30,6 +30,8 @@ export interface ModelType {
     id: string;
     name: string;
   };
+  version?: string;
+  versionIri?: string;
 }
 
 export interface InternalNamespace {

--- a/datamodel-ui/src/common/utils/hooks/use-set-view.tsx
+++ b/datamodel-ui/src/common/utils/hooks/use-set-view.tsx
@@ -21,10 +21,15 @@ export default function useSetView() {
       return;
     }
 
+    const query = {
+      ...(router.query.lang && { lang: router.query.lang }),
+      ...(router.query.ver && { ver: router.query.ver }),
+    };
+
     if (key === 'info' || !subkey || subkey === 'list') {
       router.replace({
         pathname: `${modelId}/${key}`,
-        query: router.query.lang && { lang: router.query.lang },
+        query: query,
       });
       return;
     }
@@ -44,7 +49,7 @@ export default function useSetView() {
 
     router.replace({
       pathname: `${modelId}/${type}/${id}`,
-      query: router.query.lang && { lang: router.query.lang },
+      query: query,
     });
   };
 

--- a/datamodel-ui/src/common/utils/parse-slug.ts
+++ b/datamodel-ui/src/common/utils/parse-slug.ts
@@ -1,4 +1,4 @@
-export function getModelId(slug?: string | string[]): string | undefined {
+export function getSlugAsString(slug?: string | string[]): string | undefined {
   if (!slug) {
     return;
   }

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -45,6 +45,7 @@ import { SimpleResource } from '@app/common/interfaces/simple-resource.interface
 
 interface ClassViewProps {
   modelId: string;
+  version?: string;
   languages: string[];
   terminologies: string[];
   applicationProfile?: boolean;
@@ -52,6 +53,7 @@ interface ClassViewProps {
 
 export default function ClassView({
   modelId,
+  version,
   languages,
   terminologies,
   applicationProfile,
@@ -84,6 +86,7 @@ export default function ClassView({
     pageSize: 20,
     pageFrom: (currentPage - 1) * 20,
     resourceTypes: [ResourceType.CLASS],
+    fromVersion: version,
   });
 
   const {
@@ -91,7 +94,12 @@ export default function ClassView({
     isSuccess,
     refetch: refetchData,
   } = useGetClassQuery(
-    { modelId: modelId, classId: globalSelected.id ?? '', applicationProfile },
+    {
+      modelId: modelId,
+      version: version,
+      classId: globalSelected.id ?? '',
+      applicationProfile,
+    },
     { skip: globalSelected.type !== 'classes' }
   );
 

--- a/datamodel-ui/src/modules/create-release-modal/index.tsx
+++ b/datamodel-ui/src/modules/create-release-modal/index.tsx
@@ -64,7 +64,6 @@ export default function CreateReleaseModal({
 
   const handleClose = useCallback(() => {
     setReleaseStatus('VALID');
-    setReleaseVersion('');
     setUserPosted(false);
     setVersionError(false);
     hide();
@@ -72,7 +71,10 @@ export default function CreateReleaseModal({
 
   useEffect(() => {
     if (createReleaseResult.isSuccess) {
-      router.push(`/model/${modelId}?version=${releaseVersion}`);
+      router.push({
+        pathname: `/model/${modelId}`,
+        query: { ver: releaseVersion },
+      });
       handleClose();
     }
 

--- a/datamodel-ui/src/modules/create-release-modal/index.tsx
+++ b/datamodel-ui/src/modules/create-release-modal/index.tsx
@@ -1,0 +1,142 @@
+import { useBreakpoints } from 'yti-common-ui/media-query';
+import {
+  ButtonFooter,
+  NarrowModal,
+  SimpleModalContent,
+} from '../as-file-modal/as-file-modal.styles';
+import {
+  Button,
+  InlineAlert,
+  ModalTitle,
+  RadioButton,
+  RadioButtonGroup,
+  TextInput,
+} from 'suomifi-ui-components';
+import { useTranslation } from 'next-i18next';
+import { translateStatus } from 'yti-common-ui/utils/translation-helpers';
+import { useCallback, useEffect, useState } from 'react';
+import SaveSpinner from 'yti-common-ui/save-spinner';
+import { TEXT_INPUT_MAX } from 'yti-common-ui/utils/constants';
+import { useCreateReleaseMutation } from '@app/common/components/model/model.slice';
+import { useRouter } from 'next/router';
+import getApiError from '@app/common/utils/get-api-errors';
+
+interface CreateReleaseModalProps {
+  hide: () => void;
+  visible: boolean;
+  modelId: string;
+}
+
+export default function CreateReleaseModal({
+  hide,
+  visible,
+  modelId,
+}: CreateReleaseModalProps) {
+  const { isSmall } = useBreakpoints();
+  const { t } = useTranslation('admin');
+  const router = useRouter();
+  const [releaseStatus, setReleaseStatus] = useState('VALID');
+  const [releaseVersion, setReleaseVersion] = useState('');
+  const [userPosted, setUserPosted] = useState(false);
+  const [versionError, setVersionError] = useState(false);
+  const [createRelease, createReleaseResult] = useCreateReleaseMutation();
+
+  const handleReleaseVersionChange = (e: string) => {
+    if (e.match(/[0-9]+\.[0-9]+\.[0-9]+/)) {
+      setVersionError(false);
+    }
+    setReleaseVersion(e);
+  };
+
+  const handleCreateRelease = () => {
+    if (!releaseVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/)) {
+      setVersionError(true);
+      return;
+    }
+
+    setUserPosted(true);
+    createRelease({
+      modelId: modelId,
+      status: releaseStatus,
+      version: releaseVersion,
+    });
+  };
+
+  const handleClose = useCallback(() => {
+    setReleaseStatus('VALID');
+    setReleaseVersion('');
+    setUserPosted(false);
+    setVersionError(false);
+    hide();
+  }, [hide]);
+
+  useEffect(() => {
+    if (createReleaseResult.isSuccess) {
+      router.push(`/model/${modelId}?version=${releaseVersion}`);
+      handleClose();
+    }
+
+    if (createReleaseResult.isError) {
+      setUserPosted(false);
+    }
+  }, [createReleaseResult, handleClose, router, modelId, releaseVersion]);
+
+  return (
+    <NarrowModal
+      appElementId="__next"
+      visible={visible}
+      variant={isSmall ? 'smallScreen' : 'default'}
+      onEscKeyDown={() => handleClose()}
+    >
+      <SimpleModalContent>
+        <ModalTitle>{t('create-release')}</ModalTitle>
+        <RadioButtonGroup
+          name="create-release-status"
+          labelText={t('create-release-status')}
+          onChange={(e) => setReleaseStatus(e)}
+          id="create-release-status-field"
+          defaultValue="VALID"
+        >
+          <RadioButton value="VALID">{translateStatus('VALID', t)}</RadioButton>
+          <RadioButton value="SUGGESTED">
+            {`${translateStatus('SUGGESTED', t)} (${t('commentable-version')})`}
+          </RadioButton>
+        </RadioButtonGroup>
+        <TextInput
+          labelText={t('release-version-number')}
+          hintText={t('release-version-number-hint')}
+          placeholder={t('write-version-number')}
+          onChange={(e) => handleReleaseVersionChange(e?.toString() ?? '')}
+          id="release-version-number-field"
+          maxLength={TEXT_INPUT_MAX}
+          fullWidth
+          status={versionError ? 'error' : 'default'}
+          statusText={versionError ? t('version-number-error') : ''}
+        />
+        {createReleaseResult.isError && (
+          <InlineAlert status="error">
+            {getApiError(createReleaseResult.error)[0]}
+          </InlineAlert>
+        )}
+        <ButtonFooter>
+          <Button
+            disabled={userPosted || !releaseVersion || versionError}
+            onClick={handleCreateRelease}
+            id="release-button"
+          >
+            {t('release')}
+          </Button>
+          <Button
+            disabled={userPosted}
+            variant="secondary"
+            onClick={handleClose}
+            id="cancel-button"
+          >
+            {t('cancel-variant')}
+          </Button>
+          {userPosted && <SaveSpinner text={t('creating-release')} />}
+        </ButtonFooter>
+      </SimpleModalContent>
+    </NarrowModal>
+  );
+}

--- a/datamodel-ui/src/modules/documentation/index.tsx
+++ b/datamodel-ui/src/modules/documentation/index.tsx
@@ -54,9 +54,11 @@ import { IconBold, IconItalics, IconQuotes } from 'suomifi-icons';
 
 export default function Documentation({
   modelId,
+  version,
   languages,
 }: {
   modelId: string;
+  version?: string;
   languages: string[];
 }) {
   const { t, i18n } = useTranslation('admin');
@@ -81,7 +83,10 @@ export default function Documentation({
     end: 0,
   });
 
-  const { data: modelData, refetch } = useGetModelQuery(modelId);
+  const { data: modelData, refetch } = useGetModelQuery({
+    modelId: modelId,
+    version: version,
+  });
   const [updateModel, result] = useUpdateModelMutation();
 
   const validImgUrl = (url: string): boolean => {

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -144,12 +144,16 @@ export default function FrontPage() {
           object.type === 'PROFILE' ? <IconApplicationProfile /> : <IconGrid />,
         status: object.status,
         partOf: partOf,
+        version: object.version,
+        identifier: object.prefix,
         title: getLanguageVersion({
           data: object.label,
           lang: i18n.language,
           appendLocale: true,
         }),
-        titleLink: `/model/${object.prefix}`,
+        titleLink: `/model/${object.prefix}${
+          object.version ? `?ver=${object.version}` : ''
+        }`,
         type: translateModelType(object.type, t),
       };
     });

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -48,12 +48,14 @@ import { ClassNodeDataType } from '@app/common/interfaces/graph.interface';
 
 interface GraphProps {
   modelId: string;
+  version?: string;
   applicationProfile?: boolean;
   children: JSX.Element[];
 }
 
 const GraphContent = ({
   modelId,
+  version,
   applicationProfile,
   children,
 }: GraphProps) => {
@@ -83,7 +85,10 @@ const GraphContent = ({
     }),
     []
   );
-  const { data, isSuccess, refetch } = useGetVisualizationQuery(modelId);
+  const { data, isSuccess, refetch } = useGetVisualizationQuery({
+    modelid: modelId,
+    version: version,
+  });
   const [putPositions, result] = usePutPositionsMutation();
 
   const deleteNodeById = useCallback(
@@ -367,13 +372,18 @@ const GraphContent = ({
 
 export default function Graph({
   modelId,
+  version,
   applicationProfile,
   children,
 }: GraphProps) {
   return (
     <>
       <ReactFlowProvider>
-        <GraphContent modelId={modelId} applicationProfile={applicationProfile}>
+        <GraphContent
+          modelId={modelId}
+          version={version}
+          applicationProfile={applicationProfile}
+        >
           {children}
         </GraphContent>
       </ReactFlowProvider>

--- a/datamodel-ui/src/modules/linked-data-view/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-view/index.tsx
@@ -17,9 +17,11 @@ import { HeaderRow } from '@app/common/components/header';
 
 export default function LinkedDataView({
   modelId,
+  version,
   isApplicationProfile,
 }: {
   modelId: string;
+  version?: string;
   isApplicationProfile: boolean;
 }) {
   const { t, i18n } = useTranslation('common');
@@ -29,7 +31,10 @@ export default function LinkedDataView({
   });
   const [headerHeight, setHeaderHeight] = useState(0);
   const [renderForm, setRenderForm] = useState(false);
-  const { data, refetch } = useGetModelQuery(modelId);
+  const { data, refetch } = useGetModelQuery({
+    modelId: modelId,
+    version: version,
+  });
 
   const handleShowForm = () => {
     setRenderForm(true);

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -137,6 +137,7 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
         component: (
           <ResourceView
             modelId={modelId}
+            version={version}
             type={ResourceType.ASSOCIATION}
             languages={languages}
             applicationProfile={modelInfo?.type === 'PROFILE'}
@@ -188,11 +189,13 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
       <ContentWrapper>
         <Graph
           modelId={modelId}
+          version={version}
           applicationProfile={modelInfo?.type === 'PROFILE'}
         >
           <Drawer views={views} />
           <ModelTools
             modelId={modelId}
+            version={version}
             applicationProfile={modelInfo?.type === 'PROFILE'}
           />
         </Graph>

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -5,7 +5,7 @@ import SearchView from './search-view';
 import ClassView from '../class-view';
 import { useTranslation } from 'next-i18next';
 import { useGetModelQuery } from '@app/common/components/model/model.slice';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Graph from '../graph';
 import LinkedDataView from '../linked-data-view';
 import { compareLocales } from '@app/common/utils/compare-locals';
@@ -29,6 +29,7 @@ import Notification from '../notification';
 import { useRouter } from 'next/router';
 import { useStoreDispatch } from '@app/store';
 import { setNotification } from '@app/common/components/notifications/notifications.slice';
+import { getSlugAsString } from '@app/common/utils/parse-slug';
 
 interface ModelProps {
   modelId: string;
@@ -39,10 +40,14 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
   const { t } = useTranslation('common');
   const dispatch = useStoreDispatch();
   const router = useRouter();
+  const [version] = useState(getSlugAsString(router.query.ver));
   const hasPermission = HasPermission({
     actions: 'EDIT_DATA_MODEL',
   });
-  const { data: modelInfo } = useGetModelQuery(modelId);
+  const { data: modelInfo } = useGetModelQuery({
+    modelId: modelId,
+    version: version,
+  });
 
   const languages: string[] = useMemo(() => {
     if (!modelInfo) {
@@ -78,6 +83,7 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
         component: (
           <LinkedDataView
             modelId={modelId}
+            version={version}
             isApplicationProfile={modelInfo?.type === 'PROFILE'}
           />
         ),
@@ -93,6 +99,7 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
         component: (
           <ClassView
             modelId={modelId}
+            version={version}
             languages={languages}
             applicationProfile={modelInfo?.type === 'PROFILE'}
             terminologies={modelInfo?.terminologies.map((t) => t.uri) ?? []}
@@ -146,13 +153,19 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
           id: 'documentation',
           icon: <IconRegisters />,
           buttonLabel: t('documentation-fitted', { ns: 'admin' }),
-          component: <Documentation modelId={modelId} languages={languages} />,
+          component: (
+            <Documentation
+              modelId={modelId}
+              version={version}
+              languages={languages}
+            />
+          ),
         },
       ] as ViewType[];
     }
 
     return v as ViewType[];
-  }, [hasPermission, languages, modelId, modelInfo, t]);
+  }, [hasPermission, languages, modelId, version, modelInfo, t]);
 
   useEffect(() => {
     if (router.query.new) {

--- a/datamodel-ui/src/modules/model/model-header.tsx
+++ b/datamodel-ui/src/modules/model/model-header.tsx
@@ -1,4 +1,4 @@
-import { MainTitle, BadgeBar, Badge } from 'yti-common-ui/title-block';
+import { MainTitle, BadgeBar } from 'yti-common-ui/title-block';
 import { LanguagePickerWrapper, TitleWrapper } from './model.styles';
 import { Breadcrumb, BreadcrumbLink } from 'yti-common-ui/breadcrumb';
 import {
@@ -24,6 +24,7 @@ import {
 import { useStoreDispatch } from '@app/store';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import { useRouter } from 'next/router';
+import { Status } from 'yti-common-ui/search-results/result-card.styles';
 
 export default function ModelHeader({ modelInfo }: { modelInfo?: ModelType }) {
   const { t, i18n } = useTranslation('common');
@@ -53,6 +54,8 @@ export default function ModelHeader({ modelInfo }: { modelInfo?: ModelType }) {
       query: { ...query, lang: lang },
     });
   };
+
+  console.log(modelInfo);
 
   if (!model) {
     return <></>;
@@ -84,10 +87,11 @@ export default function ModelHeader({ modelInfo }: { modelInfo?: ModelType }) {
             )}{' '}
             {translateModelType(getType(modelInfo), t)}
           </div>
+          {modelInfo?.version && <span>{modelInfo?.version}</span>}
           <span>{modelInfo?.prefix}</span>
-          <Badge $isValid={model.status === 'VALID'}>
+          <Status status={model.status}>
             {translateStatus(getStatus(modelInfo), t)}
-          </Badge>
+          </Status>
         </BadgeBar>
       </div>
 

--- a/datamodel-ui/src/modules/model/model-header.tsx
+++ b/datamodel-ui/src/modules/model/model-header.tsx
@@ -55,8 +55,6 @@ export default function ModelHeader({ modelInfo }: { modelInfo?: ModelType }) {
     });
   };
 
-  console.log(modelInfo);
-
   if (!model) {
     return <></>;
   }

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -46,6 +46,7 @@ import { UriData } from '@app/common/interfaces/uri.interface';
 
 interface ResourceViewProps {
   modelId: string;
+  version?: string;
   type: ResourceType;
   languages: string[];
   terminologies: string[];
@@ -54,6 +55,7 @@ interface ResourceViewProps {
 
 export default function ResourceView({
   modelId,
+  version,
   type,
   languages,
   terminologies,
@@ -83,6 +85,7 @@ export default function ResourceView({
     pageSize: 20,
     pageFrom: (currentPage - 1) * 20,
     resourceTypes: [type],
+    fromVersion: version,
   });
 
   const { data: resourceData, refetch: refetchResource } = useGetResourceQuery(
@@ -90,6 +93,7 @@ export default function ResourceView({
       modelId: globalSelected.modelId ?? modelId,
       resourceIdentifier: globalSelected.id ?? '',
       applicationProfile,
+      version: version,
     },
     {
       skip:

--- a/datamodel-ui/src/pages/model/[...slug].tsx
+++ b/datamodel-ui/src/pages/model/[...slug].tsx
@@ -36,7 +36,7 @@ import {
   getVisualization,
   getRunningQueriesThunk as getVisualizationRunningQueriesThunk,
 } from '@app/common/components/visualization/visualization.slice';
-import { getModelId } from '@app/common/utils/parse-slug';
+import { getSlugAsString } from '@app/common/utils/parse-slug';
 import {
   getClass,
   getRunningQueriesThunk as getClassRunningQueriesThunk,
@@ -48,6 +48,7 @@ import {
 import { ModelType } from '@app/common/interfaces/model.interface';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import { useSelector } from 'react-redux';
+import { useRouter } from 'next/router';
 
 interface IndexPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
@@ -55,7 +56,12 @@ interface IndexPageProps extends CommonContextState {
 }
 
 export default function ModelPage(props: IndexPageProps) {
-  const { data } = useGetModelQuery(props.modelId);
+  const { query } = useRouter();
+  const version = getSlugAsString(query.ver);
+  const { data } = useGetModelQuery({
+    modelId: props.modelId,
+    version: version,
+  });
   const fullScreen = useSelector(selectFullScreen());
 
   return (
@@ -81,13 +87,14 @@ export const getServerSideProps = createCommonGetServerSideProps(
       throw new Error('Missing query for page');
     }
 
-    const modelId = getModelId(query.slug);
+    const modelId = getSlugAsString(query.slug);
+    const version = getSlugAsString(query.ver);
 
     if (!modelId) {
       throw new Error('Missing id for page');
     }
 
-    store.dispatch(getModel.initiate(modelId));
+    store.dispatch(getModel.initiate({ modelId: modelId, version: version }));
     store.dispatch(getServiceCategories.initiate(locale ?? 'fi'));
     store.dispatch(getOrganizations.initiate(locale ?? 'fi'));
     store.dispatch(

--- a/datamodel-ui/src/pages/model/[...slug].tsx
+++ b/datamodel-ui/src/pages/model/[...slug].tsx
@@ -133,7 +133,9 @@ export const getServerSideProps = createCommonGetServerSideProps(
         resourceTypes: [],
       })
     );
-    store.dispatch(getVisualization.initiate(modelId));
+    store.dispatch(
+      getVisualization.initiate({ modelid: modelId, version: version })
+    );
 
     await Promise.all(store.dispatch(getRunningQueriesThunk()));
     await Promise.all(store.dispatch(getServiceQueriesThunk()));


### PR DESCRIPTION
Changelog:
- ResultCard shows version
- Model header shows version
- get certain version of resource or datamodel depending on query in url
- hide deletion option on datamodel, mvp version does not allow delete
- Use same status chip as in result card for modal header
- download picture does not need to get datamodel info, just use the prefix supplied already
