### PR TITLE
check for all-whitespace in string validation

### DIFF
--- a/datamodel-ui/src/modules/class-form/utils.ts
+++ b/datamodel-ui/src/modules/class-form/utils.ts
@@ -55,13 +55,13 @@ export function validateClassForm(data: ClassFormType): ClassFormErrors {
   };
 
   if (
-    Object.values(data.label).filter((value) => value || value !== '').length >
-    0
+    Object.values(data.label).filter((value) => value.trim().length > 0)
+      .length > 0
   ) {
     returnErrors.label = false;
   }
 
-  if (data.identifier !== '') {
+  if (data.identifier.trim() !== '') {
     returnErrors.identifier = false;
   } else {
     return {
@@ -76,7 +76,7 @@ export function validateClassForm(data: ClassFormType): ClassFormErrors {
     returnErrors.identifierLength = false;
   }
 
-  if (/^[^0-9]/.test(data.identifier) || data.identifier === '') {
+  if (/^[^0-9]/.test(data.identifier) || data.identifier.trim() === '') {
     returnErrors.identifierInitChar = false;
   }
 

--- a/datamodel-ui/src/modules/model-form/validate-form.tsx
+++ b/datamodel-ui/src/modules/model-form/validate-form.tsx
@@ -34,25 +34,23 @@ export function validateForm(data: ModelFormType) {
   // All selected languages should have a title
   if (
     selectedLanguages.filter(
-      (lang) => !lang.title || lang.title === '' || lang.title.length < 1
+      (lang) => !lang.title || lang.title.trim().length < 1
     ).length > 0
   ) {
     const langsWithError = selectedLanguages
-      .filter(
-        (lang) => !lang.title || lang.title === '' || lang.title.length < 1
-      )
+      .filter((lang) => !lang.title || lang.title.trim().length < 1)
       .map((lang) => lang.uniqueItemId);
 
     errors.titleAmount = langsWithError ?? [];
   }
 
   // Prefix should be defined
-  if (!data.prefix || data.prefix.length < 1 || data.prefix === '') {
+  if (!data.prefix || data.prefix.trim().length < 1) {
     errors.prefix = true;
   }
 
   // Prefix should not start with a digit
-  if (data.prefix && data.prefix !== '' && /^[0-9]/.test(data.prefix)) {
+  if (data.prefix && data.prefix.trim() !== '' && /^[0-9]/.test(data.prefix)) {
     errors.prefixInitChar = true;
   }
 

--- a/datamodel-ui/src/modules/model/validate-form-update.tsx
+++ b/datamodel-ui/src/modules/model/validate-form-update.tsx
@@ -33,13 +33,11 @@ export function validateFormUpdate(data: ModelFormType) {
   // All selected languages should have a title
   if (
     selectedLanguages.filter(
-      (lang) => !lang.title || lang.title === '' || lang.title.length < 1
+      (lang) => !lang.title || lang.title.trim().length < 1
     ).length > 0
   ) {
     const langsWithError = selectedLanguages
-      .filter(
-        (lang) => !lang.title || lang.title === '' || lang.title.length < 1
-      )
+      .filter((lang) => !lang.title || lang.title.trim().length < 1)
       .map((lang) => lang.uniqueItemId);
 
     errors.titleAmount = langsWithError ?? [];
@@ -64,7 +62,11 @@ export function validateFormUpdate(data: ModelFormType) {
   if (
     data.links.length > 0 &&
     data.links.some(
-      (link) => !link.name || link.name === '' || !link.uri || link.uri === ''
+      (link) =>
+        !link.name ||
+        link.name.trim() === '' ||
+        !link.uri ||
+        link.uri.trim() === ''
     )
   ) {
     errors.linksMissingInfo = true;

--- a/datamodel-ui/src/modules/resource/resource-form/validate-form.ts
+++ b/datamodel-ui/src/modules/resource/resource-form/validate-form.ts
@@ -37,12 +37,13 @@ export default function validateForm(data: ResourceFormType): CommonFormErrors {
   if (
     data.label &&
     Object.keys(data.label).length > 0 &&
-    Object.values(data.label).filter((val) => val && val !== '').length > 0
+    Object.values(data.label).filter((val) => val && val.trim() !== '').length >
+      0
   ) {
     errors.label = false;
   }
 
-  if (data.identifier !== '') {
+  if (data.identifier.trim() !== '') {
     errors.identifier = false;
   } else {
     return validateNumeric(data, {


### PR DESCRIPTION
Previously validations would pass strings with only whitespaces (e.g. " "), and the validation would then fail from the backend.

To make error cases consistent, validations for empty strings are now done with an additional .trim() call.