### PR TITLE
don't show some identifier validation errors as unexpected

### DIFF
--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -457,11 +457,19 @@ export default function ClassForm({
           <div>
             <FormFooterAlert
               labelText={
-                Object.keys(errors).filter(
-                  (key) =>
-                    ['label', 'identifier'].includes(key) &&
+                Object.keys(errors).filter((key) => {
+                  const l: Array<keyof typeof errors> = [
+                    'identifier',
+                    'identifierInitChar',
+                    'identifierLength',
+                    'identifierCharacters',
+                    'label',
+                  ];
+                  return (
+                    (l as string[]).includes(key) &&
                     errors[key as keyof typeof errors] === true
-                ).length > 0
+                  );
+                }).length > 0
                   ? t('missing-information-title')
                   : t('unexpected-error-title')
               }

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -407,11 +407,27 @@ export default function ResourceForm({
           <div>
             <FormFooterAlert
               labelText={
-                Object.keys(errors).filter(
-                  (key) =>
-                    ['label', 'identifier'].includes(key) &&
+                Object.keys(errors).filter((key) => {
+                  const l: Array<keyof typeof errors> = [
+                    'label',
+                    'identifier',
+                    'identifierInitChar',
+                    'identifierLength',
+                    'identifierCharacters',
+                    'maxCount',
+                    'maxExclusive',
+                    'maxInclusive',
+                    'maxLength',
+                    'minCount',
+                    'minExclusive',
+                    'minInclusive',
+                    'minLength',
+                  ];
+                  return (
+                    (l as string[]).includes(key) &&
                     errors[key as keyof typeof errors] === true
-                ).length > 0
+                  );
+                }).length > 0
                   ? t('missing-information-title')
                   : t('unexpected-error-title')
               }


### PR DESCRIPTION
Some identifier validation errors were shown as "unexpected-error-title".

This change adds more errors as known errors, so they will be translated with "missing-information-title".