### PR TITLE
graph tools panel tweaks

### DIFF
--- a/datamodel-ui/src/common/components/model-tools/index.tsx
+++ b/datamodel-ui/src/common/components/model-tools/index.tsx
@@ -187,6 +187,7 @@ export default function ModelTools({
               >
                 {t('show-associations')}
               </ToggleButton>
+              {/*
               <ToggleButton
                 checked={tools.showDomainRange}
                 onClick={() =>
@@ -197,6 +198,7 @@ export default function ModelTools({
               >
                 {t('show-domain-range-references')}
               </ToggleButton>
+              */}
 
               <ToggleButton
                 checked={tools.showClassHighlights}

--- a/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
+++ b/datamodel-ui/src/common/components/model-tools/model-tools.styles.ts
@@ -1,9 +1,7 @@
 import { Panel } from 'reactflow';
 import styled from 'styled-components';
 
-export const ToolsPanel = styled(Panel)`
-  pointer-events: none !important;
-`;
+export const ToolsPanel = styled(Panel)``;
 
 export const ToolsTooltip = styled.div`
   width: 295px;

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -278,6 +278,10 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
   }
 
   function renderClassLabel() {
+    if (tools.showById) {
+      return `${data.modelId}:${data.identifier}`;
+    }
+
     if (!data.applicationProfile) {
       return getLanguageVersion({
         data: data.label,
@@ -300,6 +304,14 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
   function renderResourceLabel(
     resource: ClassNodeProps['data']['resources'][0]
   ) {
+    if (tools.showById) {
+      return (
+        <>
+          {[getMinMax(resource)]} {getIdentifier(resource)}
+        </>
+      );
+    }
+
     if (!data.applicationProfile) {
       return getLanguageVersion({
         data: resource.label,


### PR DESCRIPTION
* disable unused showDomainRange for now
* remove pointer-events css since it was causing mouse clicks to go through the panel
* show class & resource ids if showById is set