### PR TITLE
YTI-3388 Fix search by status

### DIFF
--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -144,8 +144,8 @@ export default function MultiColumnSearch({
       const setStatuses =
         value !== '-1'
           ? value === 'in-use'
-            ? (['VALID', 'SUGGESTED'] as Status[])
-            : (['INCOMPLETE', 'DRAFT', 'RETIRED', 'SUPERSEDED'] as Status[])
+            ? (['VALID', 'SUGGESTED', 'DRAFT'] as Status[])
+            : (['RETIRED', 'SUPERSEDED'] as Status[])
           : [];
 
       setSearchParams({

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -33,7 +33,7 @@ export function initialSearchData(
 ): InternalResourcesSearchParams {
   return {
     query: '',
-    status: ['VALID', 'SUGGESTED'],
+    status: ['VALID', 'SUGGESTED', 'DRAFT'],
     groups: [],
     sortLang: sortLang,
     pageSize: 50,

--- a/datamodel-ui/src/common/interfaces/status.interface.ts
+++ b/datamodel-ui/src/common/interfaces/status.interface.ts
@@ -1,7 +1,1 @@
-export type Status =
-  | 'DRAFT'
-  | 'INCOMPLETE'
-  | 'SUGGESTED'
-  | 'RETIRED'
-  | 'SUPERSEDED'
-  | 'VALID';
+export type Status = 'DRAFT' | 'SUGGESTED' | 'RETIRED' | 'SUPERSEDED' | 'VALID';

--- a/datamodel-ui/src/common/utils/status-list.ts
+++ b/datamodel-ui/src/common/utils/status-list.ts
@@ -2,9 +2,8 @@ import { Status } from '../interfaces/status.interface';
 
 export const statusList: Status[] = [
   'DRAFT',
-  'INCOMPLETE',
-  'INVALID',
   'RETIRED',
+  'SUGGESTED',
   'SUPERSEDED',
   'VALID',
 ];

--- a/datamodel-ui/src/common/utils/translation-helpers.ts
+++ b/datamodel-ui/src/common/utils/translation-helpers.ts
@@ -75,10 +75,6 @@ export function translateStatus(status: string, t: TFunction) {
   switch (status) {
     case 'DRAFT':
       return t('statuses.draft', { ns: 'common' });
-    case 'INCOMPLETE':
-      return t('statuses.incomplete', { ns: 'common' });
-    case 'INVALID':
-      return t('statuses.invalid', { ns: 'common' });
     case 'RETIRED':
       return t('statuses.retired', { ns: 'common' });
     case 'SUGGESTED':

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -17,7 +17,7 @@ import ConceptBlock from '../concept-block';
 import { ClassFormType } from '@app/common/interfaces/class-form.interface';
 import { ClassFormErrors, validateClassForm } from './utils';
 import FormFooterAlert from 'yti-common-ui/form-footer-alert';
-import { statusList } from 'yti-common-ui/utils/status-list';
+import { statusList } from '@app/common/utils/status-list';
 import {
   translateClassFormErrors,
   translateStatus,

--- a/datamodel-ui/src/modules/code-list-modal/filter-block.tsx
+++ b/datamodel-ui/src/modules/code-list-modal/filter-block.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, DropdownItem, TextInput } from 'suomifi-ui-components';
 import { FilterBlockWrapper } from './code-list-modal.styles';
-import { statusList } from 'yti-common-ui/utils/status-list';
+import { statusList } from '@app/common/utils/status-list';
 import { useTranslation } from 'next-i18next';
 import { translateStatus } from 'yti-common-ui/utils/translation-helpers';
 import { TEXT_INPUT_MAX } from 'yti-common-ui/utils/constants';
@@ -105,7 +105,7 @@ export default function FilterBlock({
           }}
           id="status-dropdown"
         >
-          {statuses.map((status) => (
+          {['VALID', 'DRAFT', 'SUPERSEDED', 'RETIRED'].map((status) => (
             <DropdownItem key={`status-${status}`} value={status}>
               {status !== 'all-statuses'
                 ? translateStatus(status, t)

--- a/datamodel-ui/src/modules/front-page/front-page-filter.tsx
+++ b/datamodel-ui/src/modules/front-page/front-page-filter.tsx
@@ -93,20 +93,20 @@ export default function FrontPageFilter({
         title={t('show')}
         items={[
           {
-            value: 'VALID,SUGGESTED',
+            value: 'VALID,SUGGESTED,DRAFT',
             label: t('datamodels-in-use'),
             hintText: `${translateStatus('VALID', t)}, ${translateStatus(
               'SUGGESTED',
               t
-            )}`,
+            )}, ${translateStatus('DRAFT', t)}`,
           },
           {
-            value: 'RETIRED,SUPERSEDED,INVALID',
+            value: 'RETIRED,SUPERSEDED',
             label: t('datamodels-unused'),
             hintText: `${translateStatus('RETIRED', t)}, ${translateStatus(
               'SUPERSEDED',
               t
-            )}, ${translateStatus('INVALID', t)}`,
+            )}`,
           },
           {
             value: 'VALID,SUGGESTED,RETIRED,SUPERSEDED,DRAFT',

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -33,7 +33,7 @@ import { FormWrapper, LanguageVersionedWrapper } from './resource-form.styles';
 import validateForm from './validate-form';
 import { ConceptType } from '@app/common/interfaces/concept-interface';
 import { translateStatus } from 'yti-common-ui/utils/translation-helpers';
-import { statusList } from 'yti-common-ui/utils/status-list';
+import { statusList } from '@app/common/utils/status-list';
 import FormFooterAlert from 'yti-common-ui/form-footer-alert';
 import {
   selectHasChanges,


### PR DESCRIPTION
- remove old statuses (INCOMPLETE, INVALID) from the list
- fix grouping statuses to 'in use' and 'not in use'
- move status-list to datamodel-ui folder, since it's datamodel specific after adding SUGGESTED 