### PR TITLE
YTI-3204: add edit restrictions to datamodels

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -5,6 +5,7 @@ import { NewModel } from '@app/common/interfaces/new-model.interface';
 import {
   ModelType,
   ModelUpdatePayload,
+  VersionedModelUpdatePayload,
 } from '@app/common/interfaces/model.interface';
 import { createSlice } from '@reduxjs/toolkit';
 import { AppState, AppThunk } from '@app/store';
@@ -92,6 +93,23 @@ export const modelApi = createApi({
         method: 'GET',
       }),
     }),
+    updateVersionedModel: builder.mutation<
+      string,
+      {
+        payload: VersionedModelUpdatePayload;
+        modelId: string;
+        version: string;
+      }
+    >({
+      query: (value) => ({
+        url: `/model/${value.modelId}/version`,
+        params: {
+          version: value.version,
+        },
+        data: value.payload,
+        method: 'PUT',
+      }),
+    }),
   }),
 });
 
@@ -102,6 +120,7 @@ export const {
   useDeleteModelMutation,
   useCreateReleaseMutation,
   useGetPriorVersionsQuery,
+  useUpdateVersionedModelMutation,
   util: { getRunningQueriesThunk },
 } = modelApi;
 

--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -99,9 +99,15 @@ export const resourceApi = createApi({
         method: 'GET',
       }),
     }),
-    getResourceActive: builder.query<boolean, { prefix: string; uri: string }>({
+    getResourceActive: builder.query<
+      boolean,
+      { prefix: string; uri: string; version?: string }
+    >({
       query: (props) => ({
         url: `/resource/profile/${props.prefix}/active?uri=${props.uri}`,
+        params: {
+          ...(props.version && { version: props.version }),
+        },
         method: 'GET',
       }),
     }),

--- a/datamodel-ui/src/common/interfaces/model-form.interface.tsx
+++ b/datamodel-ui/src/common/interfaces/model-form.interface.tsx
@@ -23,7 +23,7 @@ export interface ModelFormType {
   organizations: MultiSelectData[];
   prefix: string;
   serviceCategories: MultiSelectData[];
-  status?: Status;
+  status: Status;
   type: ModelType['type'];
   terminologies: ModelTerminology[];
   codeLists: ModelCodeList[];

--- a/datamodel-ui/src/common/interfaces/model.interface.ts
+++ b/datamodel-ui/src/common/interfaces/model.interface.ts
@@ -102,7 +102,6 @@ export interface LangObject {
 }
 
 export interface ModelUpdatePayload {
-  status: string;
   label: { [key: string]: string };
   description: { [key: string]: string };
   languages: string[];
@@ -123,4 +122,19 @@ export interface ModelUpdatePayload {
     name: string;
     uri: string;
   }[];
+}
+
+export interface VersionedModelUpdatePayload {
+  label: { [key: string]: string };
+  description: { [key: string]: string };
+  organizations: string[];
+  groups: string[];
+  contact: string;
+  documentation: { [key: string]: string };
+  links: {
+    description: string;
+    name: string;
+    uri: string;
+  }[];
+  status: Status;
 }

--- a/datamodel-ui/src/common/utils/hooks/use-initial-model-form.tsx
+++ b/datamodel-ui/src/common/utils/hooks/use-initial-model-form.tsx
@@ -8,6 +8,7 @@ export function useInitialModelForm(): ModelFormType {
     prefix: '',
     serviceCategories: [],
     type: 'profile' as ModelFormType['type'],
+    status: 'DRAFT',
     terminologies: [],
     externalNamespaces: [],
     internalNamespaces: [],

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -47,7 +47,8 @@ interface ClassInfoProps {
   terminologies: string[];
   handleReturn: () => void;
   handleEdit: () => void;
-  handleRefecth: () => void;
+  handleRefetch: () => void;
+  disableEdit?: boolean;
 }
 
 export default function ClassInfo({
@@ -58,7 +59,8 @@ export default function ClassInfo({
   terminologies,
   handleReturn,
   handleEdit,
-  handleRefecth,
+  handleRefetch,
+  disableEdit,
 }: ClassInfoProps) {
   const { t, i18n } = useTranslation('common');
   const hasPermission = HasPermission({ actions: ['EDIT_CLASS'] });
@@ -97,9 +99,9 @@ export default function ClassInfo({
 
   useEffect(() => {
     if (addReferenceResult.isSuccess) {
-      handleRefecth();
+      handleRefetch();
     }
-  }, [addReferenceResult, handleRefecth]);
+  }, [addReferenceResult, handleRefetch]);
 
   useEffect(() => {
     if (ref.current) {
@@ -210,7 +212,7 @@ export default function ClassInfo({
           >
             {t('back')}
           </Button>
-          {hasPermission && data && (
+          {!disableEdit && hasPermission && data && (
             <div>
               <Button
                 variant="secondary"
@@ -322,8 +324,9 @@ export default function ClassInfo({
                     classId={data.identifier}
                     hasPermission={hasPermission}
                     applicationProfile={applicationProfile}
-                    handlePropertyDelete={handleRefecth}
+                    handlePropertyDelete={handleRefetch}
                     attribute
+                    disableEdit={disableEdit}
                   />
                 ))}
               </ExpanderGroup>
@@ -332,7 +335,7 @@ export default function ClassInfo({
             )}
           </BasicBlock>
 
-          {hasPermission ? (
+          {!disableEdit && hasPermission ? (
             <div style={{ display: 'flex', marginTop: '10px', gap: '10px' }}>
               <ResourceModal
                 modelId={modelId}
@@ -368,8 +371,9 @@ export default function ClassInfo({
                     modelId={modelId}
                     classId={data.identifier}
                     hasPermission={hasPermission}
-                    handlePropertyDelete={handleRefecth}
+                    handlePropertyDelete={handleRefetch}
                     applicationProfile={applicationProfile}
+                    disableEdit={disableEdit}
                   />
                 ))}
               </ExpanderGroup>
@@ -378,7 +382,7 @@ export default function ClassInfo({
             )}
           </BasicBlock>
 
-          {hasPermission ? (
+          {!disableEdit && hasPermission ? (
             <div style={{ display: 'flex', marginTop: '10px', gap: '10px' }}>
               <ResourceModal
                 modelId={modelId}

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -248,7 +248,7 @@ export default function ClassView({
             <Text variant="bold">
               {t('classes', { count: data?.totalHitCount ?? 0 })}
             </Text>
-            {hasPermission && (
+            {!version && hasPermission && (
               <>
                 <ClassModal
                   modelId={modelId}
@@ -350,7 +350,8 @@ export default function ClassView({
         applicationProfile={applicationProfile}
         handleReturn={handleReturn}
         handleEdit={handleEdit}
-        handleRefecth={refetchData}
+        handleRefetch={refetchData}
+        disableEdit={version ? true : false}
       />
     );
   }

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -36,6 +36,7 @@ interface ResourceInfoProps {
   applicationProfile?: boolean;
   attribute?: boolean;
   handlePropertyDelete: () => void;
+  disableEdit?: boolean;
 }
 
 export default function ResourceInfo({
@@ -46,6 +47,7 @@ export default function ResourceInfo({
   classId,
   hasPermission,
   handlePropertyDelete,
+  disableEdit,
 }: ResourceInfoProps) {
   const { t, i18n } = useTranslation('common');
   const [open, setOpen] = useState(false);
@@ -115,54 +117,56 @@ export default function ResourceInfo({
   function renderActions() {
     return (
       <>
-        {hasPermission && (!applicationProfile || modelId === data.modelId) && (
-          <div>
-            <Button
-              variant="secondary"
-              iconRight={<IconOptionsVertical />}
-              onClick={() => setShowTooltip(!showTooltip)}
-            >
-              {t('actions')}
-            </Button>
-            <TooltipWrapper id="actions-tooltip">
-              <Tooltip
-                ariaCloseButtonLabelText=""
-                ariaToggleButtonLabelText=""
-                open={showTooltip}
-                onCloseButtonClick={() => setShowTooltip(false)}
+        {!disableEdit &&
+          hasPermission &&
+          (!applicationProfile || modelId === data.modelId) && (
+            <div>
+              <Button
+                variant="secondary"
+                iconRight={<IconOptionsVertical />}
+                onClick={() => setShowTooltip(!showTooltip)}
               >
-                {modelId === data.modelId && (
-                  <Button
-                    variant="secondaryNoBorder"
-                    onClick={handleEdit}
-                    id="edit-reference-button"
-                  >
-                    {t('edit', { ns: 'admin' })}
-                  </Button>
-                )}
-                {(!data.fromShNode || !applicationProfile) && (
-                  <RemoveReferenceModal
-                    modelId={modelId}
-                    classId={classId}
-                    uri={data.uri}
-                    handleReturn={handlePropertyDelete}
-                    name={getLanguageVersion({
-                      data: data.label,
-                      lang: i18n.language,
-                      appendLocale: true,
-                    })}
-                    applicationProfile={applicationProfile}
-                    resourceType={
-                      attribute
-                        ? ResourceType.ATTRIBUTE
-                        : ResourceType.ASSOCIATION
-                    }
-                  />
-                )}
-              </Tooltip>
-            </TooltipWrapper>
-          </div>
-        )}
+                {t('actions')}
+              </Button>
+              <TooltipWrapper id="actions-tooltip">
+                <Tooltip
+                  ariaCloseButtonLabelText=""
+                  ariaToggleButtonLabelText=""
+                  open={showTooltip}
+                  onCloseButtonClick={() => setShowTooltip(false)}
+                >
+                  {modelId === data.modelId && (
+                    <Button
+                      variant="secondaryNoBorder"
+                      onClick={handleEdit}
+                      id="edit-reference-button"
+                    >
+                      {t('edit', { ns: 'admin' })}
+                    </Button>
+                  )}
+                  {(!data.fromShNode || !applicationProfile) && (
+                    <RemoveReferenceModal
+                      modelId={modelId}
+                      classId={classId}
+                      uri={data.uri}
+                      handleReturn={handlePropertyDelete}
+                      name={getLanguageVersion({
+                        data: data.label,
+                        lang: i18n.language,
+                        appendLocale: true,
+                      })}
+                      applicationProfile={applicationProfile}
+                      resourceType={
+                        attribute
+                          ? ResourceType.ATTRIBUTE
+                          : ResourceType.ASSOCIATION
+                      }
+                    />
+                  )}
+                </Tooltip>
+              </TooltipWrapper>
+            </div>
+          )}
       </>
     );
   }

--- a/datamodel-ui/src/modules/linked-data-form/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-form/index.tsx
@@ -16,7 +16,7 @@ import {
   setHasChanges,
   useUpdateModelMutation,
 } from '@app/common/components/model/model.slice';
-import generatePayload from '../model/generate-payload';
+import generatePayloadUpdate from '../model/generate-payload';
 import CodeListModal from '../code-list-modal';
 import LinkedModel from '../linked-model';
 import LinkedItem from './linked-item';
@@ -65,7 +65,7 @@ export default function LinkedDataForm({
     disableConfirmation();
     dispatch(setHasChanges(false));
 
-    const payload = generatePayload({
+    const payload = generatePayloadUpdate({
       ...model,
       codeLists: data.codeLists,
       externalNamespaces: data.externalNamespaces,

--- a/datamodel-ui/src/modules/linked-data-view/index.tsx
+++ b/datamodel-ui/src/modules/linked-data-view/index.tsx
@@ -66,7 +66,7 @@ export default function LinkedDataView({
       <StaticHeader ref={ref}>
         <HeaderRow>
           <Text variant="bold">{t('links')}</Text>
-          {hasPermission && (
+          {!version && hasPermission && (
             <Button
               variant="secondary"
               onClick={() => handleShowForm()}

--- a/datamodel-ui/src/modules/model/generate-payload.tsx
+++ b/datamodel-ui/src/modules/model/generate-payload.tsx
@@ -2,15 +2,59 @@ import { ModelFormType } from '@app/common/interfaces/model-form.interface';
 import {
   ModelType,
   ModelUpdatePayload,
+  VersionedModelUpdatePayload,
 } from '@app/common/interfaces/model.interface';
 import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 
-export default function generatePayload(
+export function generatePayloadVersionedUpdate(
+  data: ModelFormType | ModelType
+): VersionedModelUpdatePayload {
+  if ('description' in data) {
+    return {
+      label: data.label,
+      description: data.description,
+      organizations: data.organizations.map((o) => o.id) ?? [],
+      groups: data.groups.map((g) => g.identifier) ?? [],
+      documentation: data.documentation ?? {},
+      contact: data.contact !== '' ? data.contact : '',
+      links: data.links,
+      status: data.status,
+    };
+  } else {
+    return {
+      label: data.languages
+        .filter((l) => l.selected)
+        .reduce(
+          (obj, l) => ({
+            ...obj,
+            [l.uniqueItemId]: l.title,
+          }),
+          {}
+        ),
+      description: data.languages
+        .filter((l) => l.selected && l.description && l.description !== '')
+        .reduce(
+          (obj, l) => ({
+            ...obj,
+            [l.uniqueItemId]: l.description,
+          }),
+          {}
+        ),
+      organizations: data.organizations.map((o) => o.uniqueItemId),
+      groups: data.serviceCategories.map((s) => s.uniqueItemId),
+      documentation: data.documentation ?? {},
+      contact: data.contact !== '' ? data.contact : '',
+      links: data.links,
+      status: data.status,
+    };
+  }
+}
+
+export default function generatePayloadUpdate(
   data: ModelFormType | ModelType
 ): ModelUpdatePayload {
   if ('description' in data) {
     return {
-      status: data.status ?? 'DRAFT',
       label: data.label,
       description: data.description,
       languages: data.languages,
@@ -26,7 +70,6 @@ export default function generatePayload(
     };
   } else {
     return {
-      status: data.status ?? 'DRAFT',
       label: data.languages
         .filter((l) => l.selected)
         .reduce(

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -118,6 +118,7 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
         component: (
           <ResourceView
             modelId={modelId}
+            version={version}
             type={ResourceType.ATTRIBUTE}
             languages={languages}
             applicationProfile={modelInfo?.type === 'PROFILE'}

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import {
   Button,
-  ExpanderGroup,
   ExternalLink,
   IconOptionsVertical,
   Text,
@@ -170,29 +169,26 @@ export default function ModelInfoView() {
                 open={showTooltip}
                 onCloseButtonClick={() => setShowTooltip(false)}
               >
-                {
-                  //TODO in the future you should be allowed to modify the status of a versioned model
-                  hasPermission && !version && (
-                    <>
-                      <Button
-                        variant="secondaryNoBorder"
-                        onClick={() => handleEditViewItemClick(setShowEditView)}
-                        disabled={!formData}
-                        id="edit-button"
-                      >
-                        {t('edit', { ns: 'admin' })}
-                      </Button>
-                      <Button
-                        variant="secondaryNoBorder"
-                        onClick={() => handleModalChange('createRelease', true)}
-                        disabled={!formData}
-                        id="create-release-button"
-                      >
-                        {t('create-release', { ns: 'admin' })}
-                      </Button>
-                    </>
-                  )
-                }
+                {hasPermission && (
+                  <>
+                    <Button
+                      variant="secondaryNoBorder"
+                      onClick={() => handleEditViewItemClick(setShowEditView)}
+                      disabled={!formData}
+                      id="edit-button"
+                    >
+                      {t('edit', { ns: 'admin' })}
+                    </Button>
+                    <Button
+                      variant="secondaryNoBorder"
+                      onClick={() => handleModalChange('createRelease', true)}
+                      disabled={!formData}
+                      id="create-release-button"
+                    >
+                      {t('create-release', { ns: 'admin' })}
+                    </Button>
+                  </>
+                )}
                 <Button
                   variant="secondaryNoBorder"
                   onClick={() => handleModalChange('showAsFile', true)}
@@ -209,13 +205,17 @@ export default function ModelInfoView() {
                 </Button>
                 {hasPermission && (
                   <>
-                    <Button
-                      variant="secondaryNoBorder"
-                      onClick={() => handleModalChange('updateStatuses', true)}
-                      id="update-statuses-button"
-                    >
-                      {t('update-models-resources-statuses', { ns: 'admin' })}
-                    </Button>
+                    {!version && (
+                      <Button
+                        variant="secondaryNoBorder"
+                        onClick={() =>
+                          handleModalChange('updateStatuses', true)
+                        }
+                        id="update-statuses-button"
+                      >
+                        {t('update-models-resources-statuses', { ns: 'admin' })}
+                      </Button>
+                    )}
                     <Button
                       variant="secondaryNoBorder"
                       onClick={() => handleModalChange('copyModel', true)}

--- a/datamodel-ui/src/modules/model/prior-versions.tsx
+++ b/datamodel-ui/src/modules/model/prior-versions.tsx
@@ -28,30 +28,32 @@ export default function PriorVersions({
   );
 
   function renderPriorVersions() {
-    return (
-      priorVersions?.map((version) => {
-        return (
-          <div key={version.version}>
-            <ExternalLink
-              labelNewWindow=""
-              href={`/model/${modelId}?ver=${version.version}`}
-            >
-              {getLanguageVersion({
-                data: version.label,
-                lang: i18n.language,
-                appendLocale: true,
-              })}
-            </ExternalLink>
-            <PriorVersionsDetails>
-              {`${t('version')} ${version.version}`}
-              <Status status={version.status}>
-                {translateStatus(version.status, t)}
-              </Status>
-            </PriorVersionsDetails>
-          </div>
-        );
-      }) ?? <>{t('no-prior-versions')}</>
-    );
+    if (!priorVersions || priorVersions?.length === 0) {
+      return <>{t('no-prior-versions')}</>;
+    }
+
+    return priorVersions.map((version) => {
+      return (
+        <div key={version.version}>
+          <ExternalLink
+            labelNewWindow=""
+            href={`/model/${modelId}?ver=${version.version}`}
+          >
+            {getLanguageVersion({
+              data: version.label,
+              lang: i18n.language,
+              appendLocale: true,
+            })}
+          </ExternalLink>
+          <PriorVersionsDetails>
+            {`${t('version')} ${version.version}`}
+            <Status status={version.status}>
+              {translateStatus(version.status, t)}
+            </Status>
+          </PriorVersionsDetails>
+        </div>
+      );
+    });
   }
 
   return (

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -106,6 +106,7 @@ export default function ResourceView({
     {
       prefix: modelId,
       uri: `http://uri.suomi.fi/datamodel/ns/${globalSelected.modelId}/${globalSelected.id}`,
+      version: version,
     },
     {
       skip: !globalSelected.id || !globalSelected.modelId,
@@ -231,7 +232,7 @@ export default function ResourceView({
               {translateResourceCountTitle(type, t, data?.totalHitCount)}
             </Text>
 
-            {hasPermission && (
+            {!version && hasPermission && (
               <ResourceModal
                 modelId={modelId}
                 type={type}
@@ -341,6 +342,7 @@ export default function ResourceView({
         currentModelId={
           globalSelected.modelId !== modelId ? modelId : undefined
         }
+        disableEdit={version ? true : false}
       />
     );
   }

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -41,6 +41,7 @@ interface CommonViewProps {
   isPartOfCurrentModel: boolean;
   applicationProfile?: boolean;
   currentModelId?: string;
+  disableEdit?: boolean;
 }
 
 export default function ResourceInfo({
@@ -54,6 +55,7 @@ export default function ResourceInfo({
   isPartOfCurrentModel,
   applicationProfile,
   currentModelId,
+  disableEdit,
 }: CommonViewProps) {
   const { t, i18n } = useTranslation('common');
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -110,7 +112,7 @@ export default function ResourceInfo({
           >
             {data ? translateCommonForm('return', data.type, t) : t('back')}
           </Button>
-          {hasPermission && data && !externalEdit && (
+          {!disableEdit && hasPermission && data && !externalEdit && (
             <div>
               <Button
                 variant="secondary"


### PR DESCRIPTION
Changelog:
- new endpoint for editing versioned models
- get resource active now takes version parameter
- restrict editing of resources and links of versioned  datamodel.
- editing of versioned model metadata is allowed