### PR TITLE
don't attempt to list concepts if model has no linked terminologies

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -229,6 +229,7 @@
   "namespace-missing-info": "If you didn't find the namespace you need, please contact the administrator",
   "namespace-with-examples": "Namespace (URI, URN etc.)",
   "no-terminologies-available": "No terminologies available",
+  "no-terminologies-linked-to-data-model": "No terminologies linked to data model",
   "no-work-group-comment": "No work group comment",
   "not-in-use": "Not in use",
   "optional": "optional",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -229,6 +229,7 @@
   "namespace-missing-info": "Mikäli et löydä tarvitsemaasi tietomallia, ota yhteyttä ylläpitoon",
   "namespace-with-examples": "Nimiavaruus (URI, URN tms.)",
   "no-terminologies-available": "Sanastoja ei saatavilla",
+  "no-terminologies-linked-to-data-model": "Ei linkitettyjä sanastoja",
   "no-work-group-comment": "Ei työryhmän sisäistä kommenttia",
   "not-in-use": "Ei käytössä",
   "optional": "valinnainen",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -229,6 +229,7 @@
   "namespace-missing-info": "",
   "namespace-with-examples": "",
   "no-terminologies-available": "",
+  "no-terminologies-linked-to-data-model": "",
   "no-work-group-comment": "",
   "not-in-use": "",
   "optional": "",


### PR DESCRIPTION
Previously this would cause all concepts from all terminologies listed, since an API call was made with an empty list of terminologies.