### PR TITLE
YTI-3231: encode uri component for passing values

### DIFF
--- a/common-ui/components/login-modal/index.tsx
+++ b/common-ui/components/login-modal/index.tsx
@@ -72,6 +72,6 @@ export default function LoginModalView({
     e.preventDefault();
     window.location.href = `/api/auth/login?target=/${
       i18n.language ?? 'fi'
-    }${asPath}`;
+    }${encodeURIComponent(asPath)}`;
   }
 }

--- a/common-ui/utils/generate-impersonate.ts
+++ b/common-ui/utils/generate-impersonate.ts
@@ -31,5 +31,5 @@ function generateImpersonate(email: string, language: string): () => string {
   return () =>
     (window.location.href = `/api/auth/fake-login?fake.login.mail=${encodeURIComponent(
       email
-    )}&target=/${language ?? 'fi'}${asPath}`);
+    )}&target=/${language ?? 'fi'}${encodeURIComponent(asPath)}`);
 }


### PR DESCRIPTION
Changelog:
Encode `target` param, if not encoded the params do not work as & is seen as a separate param from `target`

`target=/fi/?status=VALID&STATUS=DRAFT`
is seen as 
target: `/fi/?status=VALID` 
status: `STATUS`