### PR TITLE
YTI-3398: fix null error on modals

### DIFF
--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -52,7 +52,7 @@ export default function MultiColumnSearch({
     isSuccess: serviceCategoriesIsSuccess,
   } = useGetServiceCategoriesQuery(i18n.language);
   const [currentPage, setCurrentPage] = useState(1);
-  const [dataModelType] = useState<SingleSelectData[]>([
+  const dataModelType: SingleSelectData[] = [
     {
       labelText: t('data-models-added-to-this-model'),
       uniqueItemId: 'self',
@@ -61,12 +61,12 @@ export default function MultiColumnSearch({
       labelText: t('datamodels-all', { ns: 'common' }),
       uniqueItemId: 'all',
     },
-  ]);
-  const [languages] = useState<SingleSelectData[]>([
+  ];
+  const languages: SingleSelectData[] = [
     { labelText: translateLanguage('fi', t), uniqueItemId: 'fi' },
     { labelText: translateLanguage('sv', t), uniqueItemId: 'sv' },
     { labelText: translateLanguage('en', t), uniqueItemId: 'en' },
-  ]);
+  ];
 
   const statuses: SingleSelectData[] = [
     {
@@ -84,10 +84,6 @@ export default function MultiColumnSearch({
   ];
 
   const serviceCategories: SingleSelectData[] = useMemo(() => {
-    if (!serviceCategoriesIsSuccess) {
-      return [];
-    }
-
     const returnValue = [
       {
         labelText: t('information-domains-all'),
@@ -95,13 +91,17 @@ export default function MultiColumnSearch({
       },
     ];
 
+    if (!serviceCategoriesIsSuccess) {
+      return returnValue;
+    }
+
     return returnValue.concat(
-      serviceCategoriesResult.map((result) => ({
+      serviceCategoriesResult.map((category) => ({
         labelText: getLanguageVersion({
-          data: result.label,
+          data: category.label,
           lang: i18n.language,
         }),
-        uniqueItemId: result.identifier,
+        uniqueItemId: category.identifier,
       }))
     );
   }, [serviceCategoriesResult, serviceCategoriesIsSuccess, t, i18n.language]);
@@ -277,9 +277,7 @@ export default function MultiColumnSearch({
                 ]
           }
           noItemsText=""
-          ariaOptionsAvailableText={
-            t('information-domains-available') as string
-          }
+          ariaOptionsAvailableText={t('information-domains-available')}
           ariaOptionChipRemovedText=""
           ariaSelectedAmountTextFunction={() => ''}
           onItemSelectionsChange={(values) => {

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -277,6 +277,8 @@ export default function MultiColumnSearch({
                 ]
           }
           noItemsText=""
+          itemAdditionHelpText=""
+          allowItemAddition={false}
           ariaOptionsAvailableText={t('information-domains-available')}
           ariaOptionChipRemovedText=""
           ariaSelectedAmountTextFunction={() => ''}

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -277,8 +277,9 @@ export default function MultiColumnSearch({
                 ]
           }
           noItemsText=""
-          allowItemAddition={false}
-          ariaOptionsAvailableText={t('information-domains-available')}
+          ariaOptionsAvailableText={
+            t('information-domains-available') as string
+          }
           ariaOptionChipRemovedText=""
           ariaSelectedAmountTextFunction={() => ''}
           onItemSelectionsChange={(values) => {

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -277,7 +277,6 @@ export default function MultiColumnSearch({
                 ]
           }
           noItemsText=""
-          itemAdditionHelpText=""
           allowItemAddition={false}
           ariaOptionsAvailableText={t('information-domains-available')}
           ariaOptionChipRemovedText=""


### PR DESCRIPTION
Changelog: 
- Service categoeries will always have "All categories" option even if the service category query fails
  - This fixes null error since the dropdown menu will not be empty now'
 - Minor fixes
   - Remove some unnecessary useState calls and just save to constant.
   - Rename variable in mapping loop for clarity
   - Remove unnecessary casting to string