### PR TITLE
YTI-3407: choose default status filter for datamodels

### DIFF
--- a/common-ui/components/filter/status-filter-radio.tsx
+++ b/common-ui/components/filter/status-filter-radio.tsx
@@ -4,12 +4,14 @@ import RadioButtonFilter, { Item } from './radio-button-filter';
 export interface StatusFilterRadioProps {
   title: string;
   items: Item[];
+  defaultValue?: string;
   isModal?: boolean;
 }
 
 export default function StatusFilterRadio({
   title,
   items,
+  defaultValue,
   isModal,
 }: StatusFilterRadioProps) {
   const { urlState, patchUrlState } = useUrlState();
@@ -20,13 +22,15 @@ export default function StatusFilterRadio({
       items={items}
       onChange={(status) => {
         patchUrlState({
-          status: status === 'VALID,DRAFT' ? [] : status.split(','),
+          status: status.split(','),
           page: initialUrlState.page,
         });
       }}
       radioButtonVariant={isModal ? 'large' : 'small'}
       selectedItem={
-        urlState.status.length < 1 ? 'VALID,DRAFT' : urlState.status.join(',')
+        urlState.status.length < 1
+          ? defaultValue ?? 'VALID,DRAFT'
+          : urlState.status.join(',')
       }
     />
   );

--- a/common-ui/components/search-results/search-count-tags.tsx
+++ b/common-ui/components/search-results/search-count-tags.tsx
@@ -27,6 +27,7 @@ interface SearchCountTagsProps {
     id: string;
   }[];
   renderQBeforeStatus?: boolean;
+  withDefaultStatuses?: string[];
 }
 
 export default function SearchCountTags({
@@ -36,6 +37,7 @@ export default function SearchCountTags({
   types = [],
   renderQBeforeStatus = false,
   hiddenTitle,
+  withDefaultStatuses,
 }: SearchCountTagsProps) {
   const { t } = useTranslation('common');
   const { urlState, patchUrlState } = useUrlState();
@@ -55,7 +57,7 @@ export default function SearchCountTags({
         {renderStatusTags()}
         {!renderQBeforeStatus && renderQTag()}
         {renderDomainTags()}
-        {renderNoActiveFilters()}
+        {!withDefaultStatuses && renderNoActiveFilters()}
       </ChipWrapper>
     </CountWrapper>
   );
@@ -99,6 +101,33 @@ export default function SearchCountTags({
   }
 
   function renderStatusTags() {
+    if (
+      urlState.status.length === 0 &&
+      withDefaultStatuses &&
+      withDefaultStatuses.length > 0
+    ) {
+      return (
+        <>
+          {withDefaultStatuses.map((status) => {
+            return (
+              <Tag
+                key={status}
+                onRemove={() => {
+                  patchUrlState({
+                    status: withDefaultStatuses.filter(
+                      (s) => s !== status && s !== status.toUpperCase()
+                    ),
+                  });
+                }}
+              >
+                {translateStatus(status, t)}
+              </Tag>
+            );
+          })}
+        </>
+      );
+    }
+
     return ['valid', 'draft', 'retired', 'superseded', 'invalid', 'suggested']
       .map((status) => {
         if (

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -39,6 +39,7 @@ interface SearchResultsProps {
   noChip?: boolean;
   tagsTitle: string;
   tagsHiddenTitle: string;
+  withDefaultStatuses?: string[];
   extra?:
     | {
         expander: {
@@ -73,6 +74,7 @@ export default function SearchResults({
   noChip,
   tagsTitle,
   tagsHiddenTitle,
+  withDefaultStatuses,
   extra,
 }: SearchResultsProps) {
   const { isSmall } = useBreakpoints();
@@ -88,6 +90,7 @@ export default function SearchResults({
         hiddenTitle={tagsHiddenTitle}
         organizations={organizations}
         types={types}
+        withDefaultStatuses={withDefaultStatuses}
         domains={domains}
       />
       <ResultWrapper $isSmall={isSmall} id="search-results">

--- a/datamodel-ui/src/common/components/counts/counts.slice.tsx
+++ b/datamodel-ui/src/common/components/counts/counts.slice.tsx
@@ -3,6 +3,7 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
 import { CountsType } from '@app/common/interfaces/counts.interface';
 import { UrlState } from 'yti-common-ui/utils/hooks/use-url-state';
+import { inUseStatusList } from '@app/common/utils/status-list';
 
 function getUrl(urlState: UrlState) {
   const validEntries = Object.entries({
@@ -14,7 +15,7 @@ function getUrl(urlState: UrlState) {
       ? urlState.types.map((type) => type.toUpperCase())
       : [],
     ...(urlState.status.length === 0
-      ? { status: ['VALID', 'SUGGESTED'] }
+      ? { status: inUseStatusList }
       : { status: urlState.status }),
   }).filter(
     (item) =>

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -17,6 +17,10 @@ import ResourceList, { ResultType } from '../resource-list';
 import { DetachedPagination } from 'yti-common-ui/pagination';
 import { compareLocales } from '@app/common/utils/compare-locals';
 import { Status } from '@app/common/interfaces/status.interface';
+import {
+  inUseStatusList,
+  notInUseStatusList,
+} from '@app/common/utils/status-list';
 
 interface MultiColumnSearchProps {
   primaryColumnName: string;
@@ -144,8 +148,8 @@ export default function MultiColumnSearch({
       const setStatuses =
         value !== '-1'
           ? value === 'in-use'
-            ? (['VALID', 'SUGGESTED', 'DRAFT'] as Status[])
-            : (['RETIRED', 'SUPERSEDED'] as Status[])
+            ? inUseStatusList
+            : notInUseStatusList
           : [];
 
       setSearchParams({

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -8,6 +8,7 @@ import {
 } from '@app/common/interfaces/search-internal-classes.interface';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { Type } from '@app/common/interfaces/type.interface';
+import { inUseStatusList } from '@app/common/utils/status-list';
 
 export interface InternalResourcesSearchParams {
   query: string;
@@ -33,7 +34,7 @@ export function initialSearchData(
 ): InternalResourcesSearchParams {
   return {
     query: '',
-    status: ['VALID', 'SUGGESTED', 'DRAFT'],
+    status: inUseStatusList,
     groups: [],
     sortLang: sortLang,
     pageSize: 50,

--- a/datamodel-ui/src/common/components/search-models/search-models.slice.tsx
+++ b/datamodel-ui/src/common/components/search-models/search-models.slice.tsx
@@ -3,6 +3,7 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
 import { SearchModels } from '@app/common/interfaces/search-models.interface';
 import { UrlState } from 'yti-common-ui/utils/hooks/use-url-state';
+import { inUseStatusList } from '@app/common/utils/status-list';
 
 /*
   Drops keys with "empty" values in urlState
@@ -33,7 +34,7 @@ function getUrl(urlState: UrlState, lang?: string) {
       ? urlState.types.map((type) => type.toUpperCase())
       : [],
     ...(urlState.status.length === 0
-      ? { status: ['VALID', 'SUGGESTED'] }
+      ? { status: inUseStatusList }
       : { status: urlState.status }),
   }).filter(
     (item) =>

--- a/datamodel-ui/src/common/utils/status-list.ts
+++ b/datamodel-ui/src/common/utils/status-list.ts
@@ -7,3 +7,7 @@ export const statusList: Status[] = [
   'SUPERSEDED',
   'VALID',
 ];
+
+export const inUseStatusList: Status[] = ['DRAFT', 'SUGGESTED', 'VALID'];
+
+export const notInUseStatusList: Status[] = ['RETIRED', 'SUPERSEDED'];

--- a/datamodel-ui/src/modules/front-page/front-page-filter.tsx
+++ b/datamodel-ui/src/modules/front-page/front-page-filter.tsx
@@ -2,6 +2,11 @@ import { useGetCountQuery } from '@app/common/components/counts/counts.slice';
 import { Organization } from '@app/common/interfaces/organizations.interface';
 import { ServiceCategory } from '@app/common/interfaces/service-categories.interface';
 import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import {
+  inUseStatusList,
+  notInUseStatusList,
+  statusList,
+} from '@app/common/utils/status-list';
 import { useTranslation } from 'next-i18next';
 import { SingleSelectData } from 'suomifi-ui-components';
 import Filter, {
@@ -91,25 +96,24 @@ export default function FrontPageFilter({
       <Separator />
       <StatusFilterRadio
         title={t('show')}
+        defaultValue={inUseStatusList.join(',')}
         items={[
           {
-            value: 'VALID,SUGGESTED,DRAFT',
+            value: inUseStatusList.join(','),
             label: t('datamodels-in-use'),
-            hintText: `${translateStatus('VALID', t)}, ${translateStatus(
-              'SUGGESTED',
-              t
-            )}, ${translateStatus('DRAFT', t)}`,
+            hintText: inUseStatusList
+              .map((s) => translateStatus(s, t))
+              .join(', '),
           },
           {
-            value: 'RETIRED,SUPERSEDED',
+            value: notInUseStatusList.join(','),
             label: t('datamodels-unused'),
-            hintText: `${translateStatus('RETIRED', t)}, ${translateStatus(
-              'SUPERSEDED',
-              t
-            )}`,
+            hintText: notInUseStatusList
+              .map((s) => translateStatus(s, t))
+              .join(', '),
           },
           {
-            value: 'VALID,SUGGESTED,RETIRED,SUPERSEDED,DRAFT',
+            value: statusList.join(','),
             label: t('datamodels-all'),
           },
         ]}

--- a/datamodel-ui/src/modules/front-page/index.tsx
+++ b/datamodel-ui/src/modules/front-page/index.tsx
@@ -34,6 +34,7 @@ import { translateModelType } from '@app/common/utils/translation-helpers';
 import ModelFormModal from '../model-form/model-form-modal';
 import { useGetLanguagesQuery } from '@app/common/components/code/code.slice';
 import { useGetCountQuery } from '@app/common/components/counts/counts.slice';
+import { inUseStatusList } from '@app/common/utils/status-list';
 
 export default function FrontPage() {
   const { t, i18n } = useTranslation('common');
@@ -246,6 +247,7 @@ export default function FrontPage() {
             tagsTitle={t('results-with-current', {
               count: searchModels?.totalHitCount ?? 0,
             })}
+            withDefaultStatuses={inUseStatusList}
           />
           <Pagination
             maxPages={Math.ceil((searchModels?.totalHitCount ?? 1) / 50)}


### PR DESCRIPTION
Changelog:
- custom default value for front page filter with valid and draft as fallback
- if search results has default status filters, show them when no status filters set
- use global variable for status lists instead of manually defining in multiple places