### PR TITLE
allow removing concept from model

### DIFF
--- a/datamodel-ui/public/locales/en/admin.json
+++ b/datamodel-ui/public/locales/en/admin.json
@@ -146,6 +146,7 @@
   "datamodel-type": "Data Model type",
   "default-value": "Default value",
   "delete-codelist": "Remove codelist",
+  "delete-concept": "Remove concept",
   "delete-modal": {
     "association-description": "Remove association {{targetName}}?",
     "association-error": "An error occurred while removing association {{targetName}}",

--- a/datamodel-ui/public/locales/fi/admin.json
+++ b/datamodel-ui/public/locales/fi/admin.json
@@ -146,6 +146,7 @@
   "datamodel-type": "Tietomallin tyyppi",
   "default-value": "Oletusarvo",
   "delete-codelist": "Poista koodisto",
+  "delete-concept": "Poista käsite",
   "delete-modal": {
     "association-description": "Haluatko poistaa assosiaation {{targetName}}?",
     "association-error": "Assosiaation {{targetName}} poistamisessa ilmeni ongelma",

--- a/datamodel-ui/public/locales/sv/admin.json
+++ b/datamodel-ui/public/locales/sv/admin.json
@@ -146,6 +146,7 @@
   "datamodel-type": "",
   "default-value": "",
   "delete-codelist": "",
+  "delete-concept": "",
   "delete-modal": {
     "association-description": "",
     "association-error": "",

--- a/datamodel-ui/src/modules/concept-block/index.tsx
+++ b/datamodel-ui/src/modules/concept-block/index.tsx
@@ -130,15 +130,34 @@ export default function ConceptBlock({
         ) : (
           <ConceptView data={concept} />
         )}
-        <Button
-          variant="secondary"
-          style={{ width: 'min-content', whiteSpace: 'nowrap' }}
-          onClick={() => handleOpen()}
-          id="select-concept-button"
-        >
-          {t('select-concept')}
-        </Button>
-
+        <div>
+          <Button
+            variant="secondary"
+            style={{
+              width: 'min-content',
+              marginLeft: '1px',
+              whiteSpace: 'nowrap',
+            }}
+            onClick={() => handleOpen()}
+            id="select-concept-button"
+          >
+            {t('select-concept')}
+          </Button>
+          {concept && (
+            <Button
+              variant="secondary"
+              style={{
+                width: 'min-content',
+                marginLeft: '10px',
+                whiteSpace: 'nowrap',
+              }}
+              onClick={() => setConcept(undefined)}
+              id="delete-concept-button"
+            >
+              {t('delete-concept')}
+            </Button>
+          )}
+        </div>
         <Modal
           appElementId="__next"
           visible={visible}


### PR DESCRIPTION
Added a button to model editing form to allow unselecting the concept.

This has some manual adjustments of button positions with `marginLeft` to get them to line up nicely.

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/25614946/21865543-256e-4175-b261-732237102987)
