### PR TITLE
fix errors sometimes showing up empty

### DIFF
--- a/datamodel-ui/src/common/utils/get-api-errors.test.ts
+++ b/datamodel-ui/src/common/utils/get-api-errors.test.ts
@@ -1,0 +1,50 @@
+import getApiError from './get-api-errors';
+
+describe('getApiError', () => {
+  it('should handle Internal Server Error', () => {
+    const error500 = {
+      status: 500,
+      data: {
+        timestamp: '2023-10-30T10:42:13.106+00:00',
+        status: 500,
+        error: 'Internal Server Error',
+        path: '/datamodel-api/v2/model/profile/foo',
+      },
+    };
+    const result = getApiError(error500);
+    expect(result).toStrictEqual(['500: Internal Server Error']);
+  });
+
+  it('should handle validation error', () => {
+    const validationError = {
+      status: 400,
+      data: {
+        status: 'BAD_REQUEST',
+        timestamp: '31-10-2023 09:27:58',
+        message: 'Object validation failed',
+        details: [
+          {
+            field: 'identifier',
+            rejectedValue: 'bar',
+            message: 'should-have-value',
+          },
+        ],
+      },
+    };
+    const result = getApiError(validationError);
+    expect(result).toStrictEqual([
+      'VALIDATION ERROR: Field: IDENTIFIER | Error: should-have-value',
+    ]);
+  });
+
+  it('should handle unknown errors', () => {
+    const validationError = {
+      status: 123,
+      data: {
+        foobar: 4,
+      },
+    };
+    const result = getApiError(validationError);
+    expect(result).toStrictEqual(['GENERAL_ERROR: Unexpected error occured']);
+  });
+});

--- a/datamodel-ui/src/common/utils/get-api-errors.ts
+++ b/datamodel-ui/src/common/utils/get-api-errors.ts
@@ -34,11 +34,25 @@ export default function getApiError(
       ];
     }
 
+    // defaults
+    errorStatus = 'GENERAL_ERROR';
+    errorMessage = 'Unexpected error occured';
+
     if ('status' in error.data && typeof error.data.status === 'string') {
       errorStatus = error.data.status ?? 'GENERAL_ERROR';
+    } else if (
+      'status' in error.data &&
+      typeof error.data.status === 'number'
+    ) {
+      errorStatus = error.data.status.toString() ?? 'GENERAL_ERROR';
+      errorStatus = `${errorStatus}`;
     }
+
     if ('message' in error.data && typeof error.data.message === 'string') {
       errorMessage = error.data.message ?? 'Unexpected error occured';
+    } else if ('error' in error.data && typeof error.data.error === 'string') {
+      errorMessage = error.data.error ?? 'Unexpected error occured';
+      errorMessage = `${errorMessage}`;
     }
 
     return [`${errorStatus}: ${errorMessage}`];

--- a/datamodel-ui/src/modules/class-form/index.tsx
+++ b/datamodel-ui/src/modules/class-form/index.tsx
@@ -331,40 +331,35 @@ export default function ClassForm({
     }
 
     let backendErrorFields: string[] = [];
+
+    const handleError = (error: AxiosQueryError): void => {
+      if (error?.status === 401) {
+        setErrors({
+          ...validateClassForm(data),
+          unauthorized: true,
+        });
+        return;
+      }
+      if (error.data.details) {
+        const asFields = (error as AxiosQueryErrorFields).data.details;
+        backendErrorFields = Array.isArray(asFields)
+          ? asFields.map((d) => d.field)
+          : [];
+      }
+    };
+
     if (
       createResult.isError &&
       createResult.error &&
       'data' in createResult.error
     ) {
-      if (createResult.error?.status === 401) {
-        setErrors({
-          ...validateClassForm(data),
-          unauthorized: true,
-        });
-        return;
-      }
-      const asFields = (createResult.error as AxiosQueryErrorFields).data
-        ?.details;
-      backendErrorFields = Array.isArray(asFields)
-        ? asFields.map((d) => d.field)
-        : [];
+      handleError(createResult.error);
     } else if (
       updateResult.isError &&
       updateResult.error &&
       'data' in updateResult.error
     ) {
-      if (updateResult.error?.status === 401) {
-        setErrors({
-          ...validateClassForm(data),
-          unauthorized: true,
-        });
-        return;
-      }
-      const asFields = (updateResult.error as AxiosQueryErrorFields).data
-        ?.details;
-      backendErrorFields = Array.isArray(asFields)
-        ? asFields.map((d) => d.field)
-        : [];
+      handleError(updateResult.error);
     }
 
     if (backendErrorFields.length > 0) {


### PR DESCRIPTION
In some cases, the error message in UI would only display " : ".

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/25614946/345bde41-c160-4dd6-bf4f-f0020309cdc8)

These changes should make sure there's always at least some error message, even though the error handling itself is not yet very expressive.

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/25614946/bbbe58ba-92aa-4775-95a4-b216a361f577)

Additionally some unit tests have been added for getApiError, but it's still probably missing some error cases.