### PR TITLE
YTI-3574 use UriData to handle attribute's data type

### DIFF
--- a/datamodel-ui/src/common/components/datatypes/datatypes.slice.ts
+++ b/datamodel-ui/src/common/components/datatypes/datatypes.slice.ts
@@ -1,6 +1,7 @@
 import { HYDRATE } from 'next-redux-wrapper';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
+import { UriData } from '@app/common/interfaces/uri.interface';
 
 export const datatypesApi = createApi({
   reducerPath: 'datatypesApi',
@@ -15,7 +16,7 @@ export const datatypesApi = createApi({
     }
   },
   endpoints: (builder) => ({
-    getDatatypes: builder.query<string[], void>({
+    getDatatypes: builder.query<UriData[], void>({
       query: () => ({
         url: '/frontend/data-types',
         method: 'GET',

--- a/datamodel-ui/src/common/components/resource/resource-utils-data.ts
+++ b/datamodel-ui/src/common/components/resource/resource-utils-data.ts
@@ -164,7 +164,11 @@ export const applicationProfileAttribute: ResourceFormType = {
     curie: 'class-type',
   },
   type: ResourceType.ATTRIBUTE,
-  dataType: { id: 'data-type', label: 'data-type' },
+  dataType: {
+    uri: 'data-type',
+    curie: 'data-type',
+    label: { fi: 'data-type' },
+  },
   allowedValues: [
     { id: 'allowed-1', label: 'allowed-1' },
     { id: 'allowed-2', label: 'allowed-2' },
@@ -201,7 +205,11 @@ export const applicationProfileAssociation: ResourceFormType = {
     curie: 'class-type',
   },
   type: ResourceType.ASSOCIATION,
-  dataType: { id: 'data-type', label: 'data-type' },
+  dataType: {
+    uri: 'data-type',
+    curie: 'data-type',
+    label: { fi: 'data-type' },
+  },
   allowedValues: [
     { id: 'allowed-1', label: 'allowed-1' },
     { id: 'allowed-2', label: 'allowed-2' },

--- a/datamodel-ui/src/common/components/resource/utils.ts
+++ b/datamodel-ui/src/common/components/resource/utils.ts
@@ -96,13 +96,10 @@ export function convertToPayload(
           e[0] === 'range' ||
           e[0] === 'domain' ||
           e[0] === 'classType' ||
-          e[0] === 'path'
+          e[0] === 'path' ||
+          e[0] === 'dataType'
         ) {
           return [e[0], e[1].uri];
-        }
-
-        if (e[0] === 'dataType') {
-          return [e[0], e[1].id];
         }
 
         if (e[0] === 'subResourceOf' || e[0] === 'equivalentResource') {

--- a/datamodel-ui/src/common/interfaces/resource-form.interface.ts
+++ b/datamodel-ui/src/common/interfaces/resource-form.interface.ts
@@ -15,10 +15,7 @@ export interface ResourceFormType {
     status: Status;
   }[];
   concept?: ConceptType;
-  dataType?: {
-    id: string;
-    label: string;
-  };
+  dataType?: UriData;
   defaultValue?: string;
   domain?: UriData;
   editorialNote?: string;
@@ -98,5 +95,9 @@ export const initialAppAttribute: ResourceFormType = {
   note: {},
   status: 'DRAFT',
   type: ResourceType.ATTRIBUTE,
-  dataType: { id: 'rdfs:Literal', label: 'rdfs:Literal' },
+  dataType: {
+    uri: 'http://www.w3.org/2000/01/rdf-schema#Literal',
+    curie: 'rdfs:Literal',
+    label: {},
+  },
 };

--- a/datamodel-ui/src/common/interfaces/resource.interface.ts
+++ b/datamodel-ui/src/common/interfaces/resource.interface.ts
@@ -20,7 +20,7 @@ export interface Resource {
     id: string;
     name: string;
   };
-  dataType?: string;
+  dataType?: UriData;
   dataTypeProperty?: string;
   defaultValue?: string;
   domain?: UriData;

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -125,7 +125,7 @@ export default function CommonViewContent({
                 <UriInfo uri={data.path} lang={displayLang} />
               </BasicBlock>
               <BasicBlock title={t('data-type')}>
-                {data.dataType ?? t('not-defined')}
+                {data.dataType?.curie ?? t('not-defined')}
               </BasicBlock>
               <Separator />
               <div>

--- a/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
@@ -33,8 +33,8 @@ export default function RangeAndDomain({
     }
 
     return dataTypesResult.map((result) => ({
-      labelText: result,
-      uniqueItemId: result,
+      labelText: result.curie ?? result.uri,
+      uniqueItemId: result.uri,
     }));
   }, [dataTypesResult, isDataTypesSuccess]);
 
@@ -133,9 +133,12 @@ export default function RangeAndDomain({
             if (!applicationProfile && data.range != undefined) {
               return value.uniqueItemId == data.range.uri;
             } else if (applicationProfile && data.dataType) {
-              return value.uniqueItemId == data.dataType.id;
+              return value.uniqueItemId == data.dataType.uri;
             } else {
-              return value.uniqueItemId == 'rdfs:Literal';
+              return (
+                value.uniqueItemId ==
+                'http://www.w3.org/2000/01/rdf-schema#Literal'
+              );
             }
           })}
           clearButtonLabel={t('clear-selection')}
@@ -144,7 +147,7 @@ export default function RangeAndDomain({
             handleUpdate({
               ...data,
               ...(applicationProfile
-                ? { dataType: { id: e, label: e } }
+                ? { dataType: { uri: e, curie: e, label: { en: e } } }
                 : { range: { uri: e, curie: e, label: { en: e } } }),
             })
           }
@@ -201,7 +204,7 @@ export default function RangeAndDomain({
           />
         }
         handleRemoval={() => handleDomainOrRangeRemoval('range')}
-        items={data.range && typeof data.range !== 'string' ? [data.range] : []}
+        items={data.range ? [data.range] : []}
         label={`${t('target-class')} (rdfs:range)`}
         optionalText={t('optional')}
       />

--- a/datamodel-ui/src/modules/resource/utils.ts
+++ b/datamodel-ui/src/modules/resource/utils.ts
@@ -25,24 +25,11 @@ export function resourceToResourceFormType(data: Resource): ResourceFormType {
           status: 'DRAFT',
         }))
       : [],
-    dataType: data.dataType
-      ? { id: data.dataType, label: data.dataType }
-      : undefined,
+    dataType: data.dataType,
     domain: data.domain,
     equivalentResource: data.equivalentResource,
     path: data.path,
-    range: data.range
-      ? {
-          uri: data.range.uri,
-          curie: data.range.curie,
-          label: {
-            en:
-              data.type == ResourceType.ASSOCIATION
-                ? data.range.curie ?? ''
-                : data.range.uri,
-          },
-        }
-      : undefined,
+    range: data.range,
     subResourceOf: data.subResourceOf,
   };
 }


### PR DESCRIPTION
Store full URI for attribute's data type (e.g. http://www.w3.org/2001/XMLSchema#integer instead of xsd:integer)