### PR TITLE
YTI-3484 fix default sh:node selection

### DIFF
--- a/datamodel-ui/src/modules/class-restriction-modal/index.tsx
+++ b/datamodel-ui/src/modules/class-restriction-modal/index.tsx
@@ -21,7 +21,7 @@ import LargeModal from '@app/common/components/large-modal';
 
 interface ClassRestrictionModalProps {
   visible: boolean;
-  selectedNodeShape: InternalClassInfo;
+  selectedTargetClass: InternalClassInfo;
   hide: () => void;
   handleFollowUp: (
     createNew?: boolean,
@@ -31,14 +31,16 @@ interface ClassRestrictionModalProps {
 
 export default function ClassRestrictionModal({
   visible,
-  selectedNodeShape,
+  selectedTargetClass,
   hide,
   handleFollowUp,
 }: ClassRestrictionModalProps) {
   const { t, i18n } = useTranslation('admin');
   const [keyword, setKeyword] = useState('');
-  const [selected, setSelected] = useState(selectedNodeShape.id);
-  const { data, isSuccess } = useGetNodeShapesQuery(selectedNodeShape.id);
+  const [selectedClassOrNodeShape, setTargetClassOrNodeShape] = useState(
+    selectedTargetClass.id
+  );
+  const { data, isSuccess } = useGetNodeShapesQuery(selectedTargetClass.id);
   const nodeShapes: ResultType[] = useMemo(() => {
     if (!data) {
       return [];
@@ -52,18 +54,18 @@ export default function ClassRestrictionModal({
   };
 
   const handleClick = (id: string | string[]) => {
-    if (selected !== id) {
-      setSelected(Array.isArray(id) ? id[0] : id);
+    if (selectedClassOrNodeShape !== id) {
+      setTargetClassOrNodeShape(Array.isArray(id) ? id[0] : id);
       return;
     }
-    setSelected('');
+    setTargetClassOrNodeShape('');
   };
 
   useEffect(() => {
     if (isSuccess && data.length < 1) {
       handleFollowUp(true);
     }
-  }, [isSuccess, handleFollowUp, data, selected]);
+  }, [isSuccess, handleFollowUp, data, selectedClassOrNodeShape]);
 
   return (
     <LargeModal
@@ -90,10 +92,10 @@ export default function ClassRestrictionModal({
           <div>
             <ResourceList
               handleClick={(value) => handleClick(value)}
-              selected={selected}
+              selected={selectedClassOrNodeShape}
               items={[
                 mapInternalClassInfoToResultType(
-                  selectedNodeShape,
+                  selectedTargetClass,
                   i18n.language
                 ),
               ]}
@@ -132,7 +134,7 @@ export default function ClassRestrictionModal({
                     )
               }
               primaryColumnName={t('class-name')}
-              selected={selected}
+              selected={selectedClassOrNodeShape}
               id="available-class-restrictions"
             />
           </div>
@@ -142,12 +144,14 @@ export default function ClassRestrictionModal({
       <ModalFooter>
         <Button
           disabled={
-            !selected || selected === '' || selected === selectedNodeShape.id
+            !selectedClassOrNodeShape ||
+            selectedClassOrNodeShape === '' ||
+            selectedClassOrNodeShape === selectedTargetClass.id
           }
           onClick={() =>
             handleFollowUp(
               false,
-              data?.find((d) => d.id === selected)
+              data?.find((d) => d.id === selectedClassOrNodeShape)
             )
           }
           id="select-class-restriction-button"
@@ -155,7 +159,7 @@ export default function ClassRestrictionModal({
           {t('select-class-restriction')}
         </Button>
         <Button
-          disabled={selected !== selectedNodeShape.id}
+          disabled={selectedClassOrNodeShape !== selectedTargetClass.id}
           variant="secondary"
           onClick={() => handleFollowUp(true)}
           id="create-new-class-restriction-button"

--- a/datamodel-ui/src/modules/class-view/application-profile-flow.tsx
+++ b/datamodel-ui/src/modules/class-view/application-profile-flow.tsx
@@ -10,12 +10,12 @@ import { SimpleResource } from '@app/common/interfaces/simple-resource.interface
 
 export default function ApplicationProfileFlow({
   visible,
-  selectedNodeShape,
+  selectedTargetClass,
   handleFollowUp,
 }: {
   visible: boolean;
-  selectedNodeShape: {
-    nodeShape: InternalClassInfo;
+  selectedTargetClass: {
+    targetClass: InternalClassInfo;
     isAppProfile?: boolean;
   };
   handleFollowUp: (data?: {
@@ -30,10 +30,10 @@ export default function ApplicationProfileFlow({
   const [resourcePickerVisible, setResourcePickerVisible] = useState(false);
 
   useEffect(() => {
-    if (!selectedNodeShape.isAppProfile) {
+    if (!selectedTargetClass.isAppProfile) {
       setRestrictionVisible(visible);
     }
-  }, [visible, selectedNodeShape]);
+  }, [visible, selectedTargetClass]);
 
   const handleClassRestrictionClose = () => {
     setRestrictionVisible(false);
@@ -41,7 +41,7 @@ export default function ApplicationProfileFlow({
 
   const handleClassRestrictionFollowUp = (
     createNew?: boolean,
-    classRestriction?: InternalClass
+    existingNodeShape?: InternalClass
   ) => {
     setRestrictionVisible(false);
 
@@ -53,9 +53,8 @@ export default function ApplicationProfileFlow({
     setRestrictionVisible(false);
     setResourcePickerVisible(false);
     handleFollowUp({
-      value: selectedNodeShape.nodeShape,
+      value: existingNodeShape,
       targetIsAppProfile: true,
-      targetClass: classRestriction,
     });
   };
 
@@ -72,7 +71,7 @@ export default function ApplicationProfileFlow({
     }
 
     handleFollowUp({
-      value: selectedNodeShape.nodeShape,
+      value: selectedTargetClass.targetClass,
       associations: value.associations,
       attributes: value.attributes,
     });
@@ -84,7 +83,7 @@ export default function ApplicationProfileFlow({
         <ClassRestrictionModal
           hide={() => handleClassRestrictionClose()}
           visible={restrictionVisible}
-          selectedNodeShape={selectedNodeShape.nodeShape}
+          selectedTargetClass={selectedTargetClass.targetClass}
           handleFollowUp={(createNew, classRestriction) =>
             handleClassRestrictionFollowUp(createNew, classRestriction)
           }
@@ -96,9 +95,9 @@ export default function ApplicationProfileFlow({
           visible={resourcePickerVisible}
           selectedNodeShape={{
             modelId:
-              getPrefixFromURI(selectedNodeShape.nodeShape.namespace) ?? '',
-            classId: selectedNodeShape.nodeShape.identifier ?? '',
-            isAppProfile: selectedNodeShape.isAppProfile ?? false,
+              getPrefixFromURI(selectedTargetClass.targetClass.namespace) ?? '',
+            classId: selectedTargetClass.targetClass.identifier ?? '',
+            isAppProfile: selectedTargetClass.isAppProfile ?? false,
           }}
           handleFollowUp={(value?: {
             associations: SimpleResource[];

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -76,9 +76,9 @@ export default function ClassView({
   const [isEdit, setIsEdit] = useState(false);
   const [showAppProfileModal, setShowAppProfileModal] = useState(false);
   const [basedOnNodeShape, setBasedOnNodeShape] = useState(false);
-  const [selectedNodeShape, setSelectedNodeShape] = useState<
+  const [selectedTargetClass, setSelectedTargetClass] = useState<
     | {
-        nodeShape: InternalClassInfo;
+        targetClass: InternalClassInfo;
         isAppProfile?: boolean;
       }
     | undefined
@@ -124,9 +124,9 @@ export default function ClassView({
 
     if (applicationProfile && value && !targetIsAppProfile) {
       setShowAppProfileModal(true);
-      setSelectedNodeShape({
-        nodeShape: value,
-        isAppProfile: targetIsAppProfile ?? false,
+      setSelectedTargetClass({
+        targetClass: value,
+        isAppProfile: false,
       });
       return;
     }
@@ -167,7 +167,7 @@ export default function ClassView({
     attributes?: SimpleResource[];
   }) => {
     setShowAppProfileModal(false);
-    setSelectedNodeShape(undefined);
+    setSelectedTargetClass(undefined);
 
     if (!data || !data.value) {
       return;
@@ -265,10 +265,10 @@ export default function ClassView({
                   handleFollowUp={handleFollowUpAction}
                   applicationProfile={applicationProfile}
                 />
-                {selectedNodeShape && (
+                {selectedTargetClass && (
                   <ApplicationProfileFlow
                     visible={showAppProfileModal}
-                    selectedNodeShape={selectedNodeShape}
+                    selectedTargetClass={selectedTargetClass}
                     handleFollowUp={handleAppProfileFollowUpAction}
                   />
                 )}


### PR DESCRIPTION
- Use more desrcriptive names 
- Rename nodeShape -> targetClass, because default selection is used as sh:targetClass value