### PR TITLE
YTI-3593: fix resource modals on application profile graph

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -200,6 +200,7 @@ const initialState = {
   hasChanges: false,
   displayWarning: false,
   displayLang: 'fi',
+  addResourceRestrictionToClass: false,
   tools: {
     fullScreen: false,
     resetPosition: false,
@@ -318,6 +319,12 @@ export const modelSlice = createSlice({
       return {
         ...state,
         displayLang: action.payload,
+      };
+    },
+    setAddResourceRestrictionToClass(state, action) {
+      return {
+        ...state,
+        addResourceRestrictionToClass: action.payload,
       };
     },
     setTools(state, action) {
@@ -477,4 +484,13 @@ export function setResetPosition(value: boolean): AppThunk {
 
 export function selectResetPosition() {
   return (state: AppState) => state.model.tools.resetPosition;
+}
+
+export function setAddResourceRestrictionToClass(value: boolean): AppThunk {
+  return (dispatch) =>
+    dispatch(modelSlice.actions.setAddResourceRestrictionToClass(value));
+}
+
+export function selectAddResourceRestrictionToClass() {
+  return (state: AppState) => state.model.addResourceRestrictionToClass;
 }

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -27,7 +27,11 @@ import { useGetAwayListener } from '@app/common/utils/hooks/use-get-away-listene
 import HasPermission from '@app/common/utils/has-permission';
 import DeleteModal from '../delete-modal';
 import { useSelector } from 'react-redux';
-import { selectDisplayLang } from '@app/common/components/model/model.slice';
+import {
+  selectAddResourceRestrictionToClass,
+  selectDisplayLang,
+  setAddResourceRestrictionToClass,
+} from '@app/common/components/model/model.slice';
 import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import ResourceModal from './resource-modal';
@@ -78,8 +82,8 @@ export default function ClassInfo({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showRenameModal, setShowRenameModal] = useState(false);
   const dispatch = useStoreDispatch();
+  const renderResourceForm = useSelector(selectAddResourceRestrictionToClass());
 
-  const [renderResourceForm, setRenderResourceForm] = useState(false);
   const displayLang = useSelector(selectDisplayLang());
   const [addReference, addReferenceResult] = useAddPropertyReferenceMutation();
   const { ref: toolTipRef } = useGetAwayListener(showTooltip, setShowTooltip);
@@ -102,7 +106,7 @@ export default function ClassInfo({
       });
     } else {
       dispatch(initializeResource(value.type, languages, value.uriData, true));
-      setRenderResourceForm(true);
+      dispatch(setAddResourceRestrictionToClass(true));
     }
   };
 
@@ -190,9 +194,9 @@ export default function ClassInfo({
         modelId={modelId}
         languages={languages}
         terminologies={terminologies}
-        handleReturn={() => setRenderResourceForm(false)}
+        handleReturn={() => dispatch(setAddResourceRestrictionToClass(false))}
         handleFollowUp={(identifier, type) => {
-          setRenderResourceForm(false);
+          dispatch(setAddResourceRestrictionToClass(false));
           handleFollowUp({
             uriData: {
               uri: `http://uri.suomi.fi/datamodel/ns/${modelId}/${identifier}`,

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -7,6 +7,7 @@ import {
   selectHovered,
   selectModelTools,
   selectSelected,
+  setAddResourceRestrictionToClass,
   setHighlighted,
   setHovered,
   setSelected,
@@ -40,6 +41,7 @@ import getConnectedElements from '../utils/get-connected-elements';
 import { UriData } from '@app/common/interfaces/uri.interface';
 import { ClassNodeDataType } from '@app/common/interfaces/graph.interface';
 import useSetView from '@app/common/utils/hooks/use-set-view';
+import { initializeResource } from '@app/common/components/resource/resource.slice';
 
 interface ClassNodeProps {
   id: string;
@@ -94,12 +96,18 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
       return;
     }
 
-    addReference({
-      prefix: data.modelId,
-      identifier: data.identifier,
-      uri: value.uriData.uri,
-      applicationProfile: true,
-    });
+    if (value.mode === 'select') {
+      addReference({
+        prefix: data.modelId,
+        identifier: data.identifier,
+        uri: value.uriData.uri,
+        applicationProfile: true,
+      });
+    } else {
+      dispatch(setSelected(id, 'classes'));
+      dispatch(initializeResource(value.type, ['fi'], value.uriData, true));
+      dispatch(setAddResourceRestrictionToClass(true));
+    }
   };
 
   const handleResourceClick = (
@@ -180,21 +188,23 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
                 open={showTooltip}
               >
                 <ResourceModal
-                  modelId={'profile1'}
+                  modelId={data.modelId}
                   type={ResourceType.ATTRIBUTE}
                   handleFollowUp={handleMenuFollowUp}
-                  limitSearchTo={'PROFILE'}
+                  limitSearchTo={'LIBRARY'}
+                  applicationProfile={data.applicationProfile}
+                  limitToSelect={!data.applicationProfile}
                   buttonIcon
-                  limitToSelect
                 />
 
                 <ResourceModal
-                  modelId={'profile1'}
+                  modelId={data.modelId}
                   type={ResourceType.ASSOCIATION}
                   handleFollowUp={handleMenuFollowUp}
-                  limitSearchTo={'PROFILE'}
+                  limitSearchTo={'LIBRARY'}
+                  applicationProfile={data.applicationProfile}
+                  limitToSelect={!data.applicationProfile}
                   buttonIcon
-                  limitToSelect
                 />
               </Tooltip>
             </TooltipWrapper>


### PR DESCRIPTION
Changelog:
- Change class restriction nodes actions button to now do the same as in the class info buttons

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/19401683/ba8e62f9-a6fc-4674-bcf6-9741a814b0f5)
