### PR TITLE
show error message if adding attribute/association to a class fails

### DIFF
--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -12,6 +12,7 @@ import {
   IconOptionsVertical,
   Text,
   Tooltip,
+  InlineAlert,
 } from 'suomifi-ui-components';
 import { BasicBlock } from 'yti-common-ui/block';
 import DrawerContent from 'yti-common-ui/drawer/drawer-content-wrapper';
@@ -43,6 +44,7 @@ import UriList from '@app/common/components/uri-list';
 import UriInfo from '@app/common/components/uri-info';
 import { UriData } from '@app/common/interfaces/uri.interface';
 import { RenameModal } from '../rename-modal';
+import getApiError from '@app/common/utils/get-api-errors';
 
 interface ClassInfoProps {
   data?: ClassType;
@@ -301,6 +303,13 @@ export default function ClassInfo({
 
       {data && (
         <DrawerContent height={headerHeight}>
+          {addReferenceResult.error ? (
+            <InlineAlert status="error">
+              {getApiError(addReferenceResult.error)[0]}
+            </InlineAlert>
+          ) : (
+            <></>
+          )}
           <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
             <Text variant="bold">
               {getLanguageVersion({


### PR DESCRIPTION
Added a simple `InlineAlert` if the result of the action resulted in an error.

![image](https://github.com/VRK-YTI/yti-terminology-ui/assets/25614946/967c0d0d-815c-4a9b-b51b-f42f4ac09361)
