### PR TITLE
YTI-3624: remove automatic label inheritance

### DIFF
--- a/datamodel-ui/src/common/components/resource/resource.slice.tsx
+++ b/datamodel-ui/src/common/components/resource/resource.slice.tsx
@@ -155,52 +155,34 @@ export const resourceApi = createApi({
 
 function resourceInitialData(
   type: ResourceType,
-  languages?: string[],
   initialReferenceResource?: UriData,
   applicationProfile?: boolean
 ): ResourceFormType {
-  let retValue = {} as ResourceFormType;
-
   if (applicationProfile) {
-    retValue =
+    const initialData =
       type === ResourceType.ASSOCIATION
-        ? {
-            ...initialAppAssociation,
-            path: initialReferenceResource,
-          }
-        : {
-            ...initialAppAttribute,
-            path: initialReferenceResource,
-          };
+        ? initialAppAssociation
+        : initialAppAttribute;
+    return {
+      ...initialData,
+      path: initialReferenceResource,
+    };
   } else {
-    retValue =
-      type === ResourceType.ASSOCIATION
-        ? {
-            ...initialAssociation,
-            label: initialReferenceResource?.label ?? {},
-            subResourceOf: [
-              initialReferenceResource ?? DEFAULT_ASSOCIATION_SUBPROPERTY,
-            ],
-          }
-        : {
-            ...initialAttribute,
-            label: initialReferenceResource?.label ?? {},
-            subResourceOf: [
-              initialReferenceResource ?? DEFAULT_ATTRIBUTE_SUBPROPERTY,
-            ],
-          };
-  }
-
-  if (languages) {
-    retValue = {
-      ...retValue,
-      label: Object.fromEntries(
-        languages.map((lang) => [lang, retValue.label[lang] ?? ''])
-      ),
+    if (type === ResourceType.ASSOCIATION) {
+      return {
+        ...initialAssociation,
+        subResourceOf: [
+          initialReferenceResource ?? DEFAULT_ASSOCIATION_SUBPROPERTY,
+        ],
+      };
+    }
+    return {
+      ...initialAttribute,
+      subResourceOf: [
+        initialReferenceResource ?? DEFAULT_ATTRIBUTE_SUBPROPERTY,
+      ],
     };
   }
-
-  return retValue;
 }
 
 export const resourceSlice = createSlice({
@@ -229,19 +211,13 @@ export function setResource(data: ResourceFormType): AppThunk {
 
 export function initializeResource(
   type: ResourceType,
-  langs: string[],
   initialReferenceResource?: UriData,
   applicationProfile?: boolean
 ): AppThunk {
   return (dispatch) =>
     dispatch(
       resourceSlice.actions.setResource(
-        resourceInitialData(
-          type,
-          langs,
-          initialReferenceResource,
-          applicationProfile
-        )
+        resourceInitialData(type, initialReferenceResource, applicationProfile)
       )
     );
 }

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -108,7 +108,7 @@ export default function ClassInfo({
         applicationProfile: applicationProfile ?? false,
       });
     } else {
-      dispatch(initializeResource(value.type, languages, value.uriData, true));
+      dispatch(initializeResource(value.type, value.uriData, true));
       dispatch(setAddResourceRestrictionToClass(true));
     }
   };

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -147,12 +147,7 @@ export default function ClassView({
 
     dispatch(
       setClass(
-        internalClassToClassForm(
-          value,
-          languages,
-          applicationProfile,
-          targetIsAppProfile
-        )
+        internalClassToClassForm(value, applicationProfile, targetIsAppProfile)
       )
     );
 
@@ -177,7 +172,6 @@ export default function ClassView({
       setClass(
         internalClassToClassForm(
           data.value,
-          languages,
           applicationProfile,
           data.targetIsAppProfile,
           data.associations,

--- a/datamodel-ui/src/modules/class-view/utils.ts
+++ b/datamodel-ui/src/modules/class-view/utils.ts
@@ -11,22 +11,17 @@ export const DEFAULT_SUBCLASS_OF = {
 
 export function internalClassToClassForm(
   data: InternalClass,
-  languages: string[],
   applicationProfile?: boolean,
   targetIsAppProfile?: boolean,
   associations?: SimpleResource[],
   attributes?: SimpleResource[]
 ): ClassFormType {
-  const label = languages.reduce(
-    (acc, lang) => ({ ...acc, [lang]: data.label[lang] }),
-    {}
-  );
   const obj = {
     editorialNote: '',
     equivalentClass: [],
     identifier: applicationProfile ? data.identifier : '',
     uri: data.id,
-    label: label,
+    label: {},
     inheritedAttributes: [],
     note: {},
     subClassOf: [],

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -105,7 +105,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
       });
     } else {
       dispatch(setSelected(id, 'classes'));
-      dispatch(initializeResource(value.type, ['fi'], value.uriData, true));
+      dispatch(initializeResource(value.type, value.uriData, true));
       dispatch(setAddResourceRestrictionToClass(true));
     }
   };

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -188,7 +188,7 @@ export default function ResourceView({
   };
 
   const handleFollowUp = (value?: UriData) => {
-    dispatch(initializeResource(type, languages, value, applicationProfile));
+    dispatch(initializeResource(type, value, applicationProfile));
 
     setView(
       type === ResourceType.ASSOCIATION ? 'associations' : 'attributes',


### PR DESCRIPTION
Changelog:
- Remove automatically setting label from parent resources
- We can also remove setting empty language data for labels as its not needed for payload
- refactored resourceInitialData to return value instead of assigning a value and returning it