### PR TITLE
Yti 3602 404 page

### DIFF
--- a/datamodel-ui/public/locales/en/common.json
+++ b/datamodel-ui/public/locales/en/common.json
@@ -7,6 +7,7 @@
   "actions": "Actions",
   "add-email-subscription": "Add email subscription",
   "allowed-values": "Allowed values",
+  "an-error-occured-while-fetching-resource": "An error occured while fetching resource.",
   "association": "Association",
   "association-count-title_one": "{{count}} Association",
   "association-count-title_other": "{{count}} Associations",
@@ -286,5 +287,6 @@
   "vocabulary-info-sv": "",
   "vocabulary-results-more": "",
   "working-version": "Working version",
-  "yes": "Yes"
+  "yes": "Yes",
+  "you-can-try-to-reload-the-page-or-the-resource-does-not-exist": "You can try to reload the page or the resource does not exist."
 }

--- a/datamodel-ui/public/locales/fi/common.json
+++ b/datamodel-ui/public/locales/fi/common.json
@@ -7,6 +7,7 @@
   "actions": "Toiminnot",
   "add-email-subscription": "Tilaa sähköposti-ilmoitukset",
   "allowed-values": "Sallitut arvot",
+  "an-error-occured-while-fetching-resource": "Resurssin tietojen haussa ilmeni ongelma.",
   "association": "Assosiaatio",
   "association-count-title_one": "{{count}} Assosiaatio",
   "association-count-title_other": "{{count}} Assosiaatiota",
@@ -286,5 +287,6 @@
   "vocabulary-info-sv": "",
   "vocabulary-results-more": "",
   "working-version": "Työversio",
-  "yes": "Kyllä"
+  "yes": "Kyllä",
+  "you-can-try-to-reload-the-page-or-the-resource-does-not-exist": "Voit yrittää ladata sivun uudestaan tai resurssia ei ole olemassa."
 }

--- a/datamodel-ui/public/locales/sv/common.json
+++ b/datamodel-ui/public/locales/sv/common.json
@@ -7,6 +7,7 @@
   "actions": "",
   "add-email-subscription": "",
   "allowed-values": "",
+  "an-error-occured-while-fetching-resource": "",
   "association": "",
   "association-count-title_one": "",
   "association-count-title_other": "",
@@ -286,5 +287,6 @@
   "vocabulary-info-sv": "",
   "vocabulary-results-more": "",
   "working-version": "",
-  "yes": ""
+  "yes": "",
+  "you-can-try-to-reload-the-page-or-the-resource-does-not-exist": ""
 }

--- a/datamodel-ui/src/common/components/model-drawer/index.tsx
+++ b/datamodel-ui/src/common/components/model-drawer/index.tsx
@@ -45,9 +45,7 @@ export default function Drawer({ views }: SideNavigationProps) {
   const router = useRouter();
   const currentView = useSelector(selectCurrentViewName());
   const [activeView, setActiveView] = useState<ViewType | undefined>(
-    isSmall
-      ? views.find((v) => v.id === 'graph')
-      : views.find((v) => v.id === 'info')
+    views.find((v) => v.id === currentView)
   );
   const { setView } = useSetView();
 

--- a/datamodel-ui/src/common/components/resource-error/index.tsx
+++ b/datamodel-ui/src/common/components/resource-error/index.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
+import { Button, IconArrowLeft, InlineAlert } from 'suomifi-ui-components';
+import DrawerContent from 'yti-common-ui/drawer/drawer-content-wrapper';
+import StaticHeader from 'yti-common-ui/drawer/static-header';
+
+interface ResourceErrorProps {
+  handleReturn?: () => void;
+  noHeader?: boolean;
+}
+
+export default function ResourceError({
+  handleReturn,
+  noHeader = false,
+}: ResourceErrorProps) {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const ref = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  const handleReturnFallback = () => {
+    const modelId = router.query.slug?.[0];
+    const resourceType = router.query.slug?.[1];
+
+    if (!modelId) {
+      router.push('/');
+      return;
+    }
+
+    if (!resourceType) {
+      router.push(`/model/${modelId}/info`);
+    }
+
+    switch (resourceType) {
+      case 'class':
+        router.push(`/model/${modelId}/classes`);
+        break;
+      case 'association':
+        router.push(`/model/${modelId}/associations`);
+        break;
+      default:
+        router.push(`/model/${modelId}/attributes`);
+        break;
+    }
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      setHeaderHeight(ref.current.clientHeight);
+    }
+  }, [ref]);
+
+  if (noHeader) {
+    return RenderError();
+  }
+
+  return (
+    <>
+      <StaticHeader ref={ref}>
+        <div>
+          <Button
+            variant="secondaryNoBorder"
+            icon={<IconArrowLeft />}
+            onClick={() =>
+              handleReturn ? handleReturn() : handleReturnFallback()
+            }
+            style={{ textTransform: 'uppercase' }}
+          >
+            {t('back')}
+          </Button>
+        </div>
+      </StaticHeader>
+      <DrawerContent height={headerHeight}>{RenderError()}</DrawerContent>
+    </>
+  );
+}
+
+function RenderError() {
+  const { t } = useTranslation('common');
+
+  return (
+    <InlineAlert status="error">
+      {t('an-error-occured-while-fetching-resource')}
+      <br />
+      {t('you-can-try-to-reload-the-page-or-the-resource-does-not-exist')}
+    </InlineAlert>
+  );
+}

--- a/datamodel-ui/src/common/components/uri-info/index.tsx
+++ b/datamodel-ui/src/common/components/uri-info/index.tsx
@@ -11,7 +11,11 @@ interface UriInfoProps {
 }
 
 export function getEnvParam(uri?: string) {
-  if (!uri || uri.indexOf('uri.suomi.fi') === -1) {
+  if (
+    !uri ||
+    uri.indexOf('uri.suomi.fi') === -1 ||
+    typeof window === 'undefined'
+  ) {
     return '';
   }
 

--- a/datamodel-ui/src/common/utils/create-getserversideprops.ts
+++ b/datamodel-ui/src/common/utils/create-getserversideprops.ts
@@ -110,7 +110,7 @@ export function createCommonGetServerSideProps<
 
         return {
           ...results,
-          redirect: redirectProp,
+          ...(redirectProp && { redirect: redirectProp }),
           props: {
             ...resultsProps,
             ...(await serverSideTranslations(locale ?? 'fi', [

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -42,6 +42,7 @@ import ClassInfo from './class-info';
 import useSetView from '@app/common/utils/hooks/use-set-view';
 import useSetPage from '@app/common/utils/hooks/use-set-page';
 import { SimpleResource } from '@app/common/interfaces/simple-resource.interface';
+import ResourceError from '@app/common/components/resource-error';
 
 interface ClassViewProps {
   modelId: string;
@@ -97,6 +98,7 @@ export default function ClassView({
   const {
     data: classData,
     isSuccess,
+    isError: classIsError,
     refetch: refetchData,
   } = useGetClassQuery(
     {
@@ -342,6 +344,10 @@ export default function ClassView({
   function renderClass() {
     if (!view.info) {
       return <></>;
+    }
+
+    if (classIsError) {
+      return <ResourceError handleReturn={handleReturn} />;
     }
 
     return (

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -33,6 +33,7 @@ import { UriData } from '@app/common/interfaces/uri.interface';
 import { useUpdateClassResrictionTargetMutation } from '@app/common/components/class/class.slice';
 import getApiError from '@app/common/utils/get-api-errors';
 import { useEffect, useState } from 'react';
+import ResourceError from '@app/common/components/resource-error';
 
 interface ResourceInfoProps {
   data: SimpleResource;
@@ -62,7 +63,11 @@ export default function ResourceInfo({
   const dispatch = useStoreDispatch();
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const { data: resourceData, isSuccess } = useGetResourceQuery(
+  const {
+    data: resourceData,
+    isSuccess,
+    isError,
+  } = useGetResourceQuery(
     {
       modelId: data.modelId,
       resourceIdentifier: data.identifier,
@@ -215,6 +220,7 @@ export default function ResourceInfo({
         </InlineAlert>
       )}
       <ExpanderContent>
+        {isError && <ResourceError noHeader={true} />}
         {isSuccess && (
           <CommonViewContent
             data={resourceData}

--- a/datamodel-ui/src/modules/model-form/link-block.tsx
+++ b/datamodel-ui/src/modules/model-form/link-block.tsx
@@ -1,5 +1,4 @@
 import { ModelFormType } from '@app/common/interfaces/model-form.interface';
-import { Link } from '@app/common/interfaces/model.interface';
 import { useTranslation } from 'next-i18next';
 import styled from 'styled-components';
 import {

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -43,6 +43,7 @@ import useSetPage from '@app/common/utils/hooks/use-set-page';
 import { useReactFlow } from 'reactflow';
 import getConnectedElements from '../graph/utils/get-connected-elements';
 import { UriData } from '@app/common/interfaces/uri.interface';
+import ResourceError from '@app/common/components/resource-error';
 
 interface ResourceViewProps {
   modelId: string;
@@ -93,7 +94,11 @@ export default function ResourceView({
     fromVersion: version,
   });
 
-  const { data: resourceData, refetch: refetchResource } = useGetResourceQuery(
+  const {
+    data: resourceData,
+    refetch: refetchResource,
+    isError: resourceIsError,
+  } = useGetResourceQuery(
     {
       modelId: globalSelected.modelId ?? modelId,
       resourceIdentifier: globalSelected.id ?? '',
@@ -326,9 +331,14 @@ export default function ResourceView({
   }
 
   function renderInfo() {
-    if (!view.info || !resourceData) {
+    if (!view.info) {
       return <></>;
     }
+
+    if (resourceIsError) {
+      return <ResourceError handleReturn={handleReturn} />;
+    }
+
     return (
       <ResourceInfo
         data={resourceData}

--- a/datamodel-ui/src/pages/404.tsx
+++ b/datamodel-ui/src/pages/404.tsx
@@ -1,0 +1,24 @@
+import Error from 'yti-common-ui/error/error';
+import ErrorLayout from 'yti-common-ui/layout/error-layout';
+import {
+  CommonContextProvider,
+  initialCommonContextState,
+} from 'yti-common-ui/common-context-provider';
+import PageHead from 'yti-common-ui/page-head';
+
+export default function Custom404() {
+  return (
+    <CommonContextProvider value={initialCommonContextState}>
+      <ErrorLayout>
+        <PageHead
+          baseUrl="https://tietomallit.suomi.fi"
+          title="Error"
+          siteTitle="Yhteentoimivuusalusta"
+          description="An error occured"
+        />
+
+        <Error />
+      </ErrorLayout>
+    </CommonContextProvider>
+  );
+}

--- a/datamodel-ui/src/pages/500.tsx
+++ b/datamodel-ui/src/pages/500.tsx
@@ -1,0 +1,24 @@
+import Error from 'yti-common-ui/error/error';
+import ErrorLayout from 'yti-common-ui/layout/error-layout';
+import {
+  CommonContextProvider,
+  initialCommonContextState,
+} from 'yti-common-ui/common-context-provider';
+import PageHead from 'yti-common-ui/page-head';
+
+export default function Custom500() {
+  return (
+    <CommonContextProvider value={initialCommonContextState}>
+      <ErrorLayout>
+        <PageHead
+          baseUrl="https://tietomallit.suomi.fi"
+          title="Error"
+          siteTitle="Yhteentoimivuusalusta"
+          description="An error occured"
+        />
+
+        <Error errorCode={500} />
+      </ErrorLayout>
+    </CommonContextProvider>
+  );
+}


### PR DESCRIPTION
Changes in this PR:
- Added `/404` and `/500` pages
- New component added for resources that can't be downloaded
- Fixed SSR - now supports version info and initial view is retrieved from Redux
- Fixed minor bug with `getEnvParam()` when `window` isn't defined