### PR TITLE
YTI-3610: current model as draft in all datamodels filter

### DIFF
--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -127,6 +127,7 @@ export default function MultiColumnSearch({
         ...searchParams,
         ['limitToDataModel']: '',
         ['fromAddedNamespaces']: false,
+        ['includeDraftFrom']: [modelId],
         pageFrom: 0,
       });
     }
@@ -136,7 +137,7 @@ export default function MultiColumnSearch({
 
   const handleSearchChange = (
     key: keyof InternalResourcesSearchParams,
-    value: (typeof searchParams)[keyof InternalResourcesSearchParams]
+    value: typeof searchParams[keyof InternalResourcesSearchParams]
   ) => {
     if (key === 'groups' && isEqual(value, ['-1'])) {
       setSearchParams({ ...searchParams, [key]: [] });

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -22,6 +22,7 @@ export interface InternalResourcesSearchParams {
   limitToModelType?: Type;
   extend?: boolean;
   fromVersion?: string;
+  includeDraftFrom?: string[];
 }
 
 export function initialSearchData(
@@ -91,6 +92,14 @@ function createUrl(obj: InternalResourcesSearchParams): string {
 
   if (obj.fromVersion) {
     baseQuery = baseQuery.concat(`&fromVersion=${obj.fromVersion}`);
+  }
+
+  if (obj.includeDraftFrom) {
+    baseQuery = baseQuery.concat(
+      `&includeDraftFrom=${obj.includeDraftFrom
+        .map((modelId) => `http://uri.suomi.fi/datamodel/ns/${modelId}`)
+        .join(',')}`
+    );
   }
 
   return baseQuery;


### PR DESCRIPTION
Changelog:
- Add current model as includeDraftFrom when having the All datamodels filter