### PR TITLE
Matomo functionalities added

### DIFF
--- a/datamodel-ui/next.config.js
+++ b/datamodel-ui/next.config.js
@@ -22,14 +22,15 @@ module.exports = () => {
     transpilePackages: ['common-ui'],
     async headers() {
       const isProd = process.env.NODE_ENV === 'production';
+      const matomoUrl = process.env.MATOMO_URL ?? '';
 
       const ProductionContentSecurityPolicy = [
         "base-uri 'self';",
         "default-src 'self';",
         "font-src 'self';",
         "img-src 'self' data:;",
-        "script-src 'self' 'unsafe-inline';",
-        "connect-src 'self';",
+        `script-src 'self' 'unsafe-inline' ${matomoUrl};`,
+        `connect-src 'self' ${matomoUrl};`,
         "style-src 'self' 'unsafe-inline' data:;",
         "frame-src 'self';",
       ];
@@ -39,8 +40,8 @@ module.exports = () => {
         "default-src 'self';",
         "font-src 'self';",
         "img-src 'self' 'unsafe-eval' 'unsafe-inline' data:;",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval';",
-        "connect-src 'self';",
+        `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${matomoUrl};`,
+        `connect-src 'self' ${matomoUrl};`,
         "style-src 'self' 'unsafe-inline' data:;",
         "frame-src 'self';",
       ];

--- a/datamodel-ui/src/common/components/layout/index.tsx
+++ b/datamodel-ui/src/common/components/layout/index.tsx
@@ -1,11 +1,14 @@
 import { FakeableUser } from 'yti-common-ui/interfaces/fakeable-user.interface';
 import { User } from 'yti-common-ui/interfaces/user.interface';
 import { default as CommonLayout } from 'yti-common-ui/layout/layout';
-
+import Matomo from 'yti-common-ui/matomo';
 interface LayoutProps {
   user?: User | null;
   fakeableUsers?: FakeableUser[] | null;
   feedbackSubject?: string;
+  fullScreenElements?: React.ReactNode;
+  headerHidden?: boolean;
+  langPickerHidden?: boolean;
   children: React.ReactNode;
 }
 
@@ -13,6 +16,9 @@ export default function Layout({
   user,
   fakeableUsers,
   feedbackSubject,
+  fullScreenElements,
+  headerHidden,
+  langPickerHidden,
   children,
 }: LayoutProps): React.ReactElement {
   return (
@@ -20,6 +26,10 @@ export default function Layout({
       user={user ?? undefined}
       fakeableUsers={fakeableUsers ?? []}
       feedbackSubject={feedbackSubject}
+      matomo={<Matomo />}
+      fullScreenElements={fullScreenElements}
+      headerHidden={headerHidden}
+      langPickerHidden={langPickerHidden}
     >
       {children}
     </CommonLayout>

--- a/datamodel-ui/src/common/utils/create-getserversideprops.ts
+++ b/datamodel-ui/src/common/utils/create-getserversideprops.ts
@@ -123,6 +123,9 @@ export function createCommonGetServerSideProps<
                 /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
               )
             ),
+            isMatomoEnabled: process.env.MATOMO_ENABLED === 'true',
+            matomoUrl: process.env.MATOMO_URL ?? null,
+            matomoSiteId: process.env.MATOMO_SITE_ID ?? null,
             user: user ?? null,
             fakeableUsers:
               !fakeableUsers || isEqual(fakeableUsers, {})

--- a/datamodel-ui/src/pages/404.tsx
+++ b/datamodel-ui/src/pages/404.tsx
@@ -5,11 +5,12 @@ import {
   initialCommonContextState,
 } from 'yti-common-ui/common-context-provider';
 import PageHead from 'yti-common-ui/page-head';
+import Matomo from 'yti-common-ui/matomo';
 
 export default function Custom404() {
   return (
     <CommonContextProvider value={initialCommonContextState}>
-      <ErrorLayout>
+      <ErrorLayout matomo={<Matomo />}>
         <PageHead
           baseUrl="https://tietomallit.suomi.fi"
           title="Error"

--- a/datamodel-ui/src/pages/500.tsx
+++ b/datamodel-ui/src/pages/500.tsx
@@ -5,11 +5,12 @@ import {
   initialCommonContextState,
 } from 'yti-common-ui/common-context-provider';
 import PageHead from 'yti-common-ui/page-head';
+import Matomo from 'yti-common-ui/matomo';
 
 export default function Custom500() {
   return (
     <CommonContextProvider value={initialCommonContextState}>
-      <ErrorLayout>
+      <ErrorLayout matomo={<Matomo />}>
         <PageHead
           baseUrl="https://tietomallit.suomi.fi"
           title="Error"

--- a/datamodel-ui/src/pages/model/[...slug].tsx
+++ b/datamodel-ui/src/pages/model/[...slug].tsx
@@ -2,7 +2,6 @@ import {
   CommonContextProvider,
   CommonContextState,
 } from 'yti-common-ui/common-context-provider';
-import Layout from 'yti-common-ui/layout/layout';
 import { SSRConfig } from 'next-i18next';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
 import PageHead from 'yti-common-ui/page-head';
@@ -50,16 +49,20 @@ import { compareLocales } from '@app/common/utils/compare-locals';
 import { useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
 import { wrapper } from '@app/store';
+import { getLanguageVersion } from '@app/common/utils/get-language-version';
+import Layout from '@app/common/components/layout';
 
 interface IndexPageProps extends CommonContextState {
   _netI18Next: SSRConfig;
   modelId: string;
+  title?: string;
+  description?: string;
 }
 
 export default function ModelPage(props: IndexPageProps) {
   wrapper.useHydration(props);
 
-  const { query } = useRouter();
+  const { query, asPath } = useRouter();
   const version = getSlugAsString(query.ver);
   const { data } = useGetModelQuery({
     modelId: props.modelId,
@@ -76,7 +79,12 @@ export default function ModelPage(props: IndexPageProps) {
         headerHidden={fullScreen}
         langPickerHidden={true}
       >
-        <PageHead baseUrl="https://tietomallit.suomi.fi" />
+        <PageHead
+          baseUrl="https://tietomallit.suomi.fi"
+          title={props.title ?? ''}
+          description={props.description ?? ''}
+          path={asPath}
+        />
 
         <Model modelId={props.modelId} fullScreen={fullScreen} />
       </Layout>
@@ -241,9 +249,20 @@ export const getServerSideProps = createCommonGetServerSideProps(
       store.dispatch(setDisplayLang(query.lang as string));
     }
 
+    const title = getLanguageVersion({
+      data: model.label,
+      lang: locale ?? 'fi',
+    });
+    const description = getLanguageVersion({
+      data: model.description,
+      lang: locale ?? 'fi',
+    });
+
     return {
       props: {
         modelId: modelId,
+        title: title,
+        description: description,
       },
     };
   }


### PR DESCRIPTION
Changes in this PR:
- Necessary Matomo configurations added
- `<Matomo />` components added and/or enabled
- `<Head />` parameters added
- Data model/[...slug] page changed to use internal `<Layout />` component instead of from `common-ui`