### PR TITLE
Fixed a bug with resource edit view shown as blank

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -352,7 +352,7 @@ export function selectSelected() {
 export function setSelected(
   id: string,
   type: keyof typeof initialView,
-  modelId?: string
+  modelId: string
 ): AppThunk {
   return (dispatch) =>
     dispatch(modelSlice.actions.setSelected({ id, type, modelId }));

--- a/datamodel-ui/src/common/components/multi-column-search/index.tsx
+++ b/datamodel-ui/src/common/components/multi-column-search/index.tsx
@@ -137,7 +137,7 @@ export default function MultiColumnSearch({
 
   const handleSearchChange = (
     key: keyof InternalResourcesSearchParams,
-    value: typeof searchParams[keyof InternalResourcesSearchParams]
+    value: (typeof searchParams)[keyof InternalResourcesSearchParams]
   ) => {
     if (key === 'groups' && isEqual(value, ['-1'])) {
       setSearchParams({ ...searchParams, [key]: [] });

--- a/datamodel-ui/src/common/utils/get-value.ts
+++ b/datamodel-ui/src/common/utils/get-value.ts
@@ -186,8 +186,8 @@ export function getUri(data?: ModelType): string {
   return `http://uri.suomi.fi/datamodel/ns/${data?.prefix}`;
 }
 
-export function getPrefixFromURI(namespace: string) {
-  return namespace.split('/').filter(Boolean).pop()?.replace('#', '');
+export function getPrefixFromURI(namespace: string): string {
+  return namespace.split('/').filter(Boolean).pop()?.replace('#', '') ?? '';
 }
 
 export function getTerminology(

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -201,11 +201,11 @@ export default function ClassView({
 
   const handleFollowUp = (classId: string) => {
     setView('classes', 'info', classId);
-    dispatch(setSelected(classId, 'classes'));
+    dispatch(setSelected(classId, 'classes', modelId));
   };
 
   const handleActive = (classId: string) => {
-    dispatch(setSelected(classId, 'classes'));
+    dispatch(setSelected(classId, 'classes', modelId));
     dispatch(resetHovered());
   };
 

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -206,7 +206,7 @@ const GraphContent = ({
   const onEdgeClick = useCallback(
     (e, edge) => {
       if (edge.data.identifier && globalSelected.id !== edge.data.identifier) {
-        dispatch(setSelected(edge.data.identifier, 'associations'));
+        dispatch(setSelected(edge.data.identifier, 'associations', modelId));
         return;
       }
 
@@ -219,7 +219,7 @@ const GraphContent = ({
       );
       setHasChanges(true);
     },
-    [dispatch, globalSelected.id, splitEdge]
+    [dispatch, globalSelected.id, modelId, splitEdge]
   );
 
   const onNodeMouseEnter = useCallback(

--- a/datamodel-ui/src/modules/graph/nodes/attribute-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/attribute-node.tsx
@@ -33,7 +33,7 @@ export default function AttributeNode({ id, data }: AttributeNodeProps) {
 
   const handleResourceClick = (id: string) => {
     setView('attributes', 'info', id);
-    dispatch(setSelected(id, 'attributes'));
+    dispatch(setSelected(id, 'attributes', data.modelId));
   };
 
   const label = tools.showById

--- a/datamodel-ui/src/modules/graph/nodes/class-node.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/class-node.tsx
@@ -70,7 +70,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
 
   const handleTitleClick = () => {
     if (globalSelected.id !== id) {
-      dispatch(setSelected(id, 'classes'));
+      dispatch(setSelected(id, 'classes', data.modelId));
     }
   };
 
@@ -104,7 +104,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
         applicationProfile: true,
       });
     } else {
-      dispatch(setSelected(id, 'classes'));
+      dispatch(setSelected(id, 'classes', data.modelId));
       dispatch(initializeResource(value.type, value.uriData, true));
       dispatch(setAddResourceRestrictionToClass(true));
     }
@@ -117,7 +117,7 @@ export default function ClassNode({ id, data, selected }: ClassNodeProps) {
     const resourceType =
       type === ResourceType.ASSOCIATION ? 'associations' : 'attributes';
     setView(resourceType, 'info', id);
-    dispatch(setSelected(id, resourceType));
+    dispatch(setSelected(id, resourceType, data.modelId));
   };
 
   const handleResourceHover = (

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -298,7 +298,10 @@ export default function ResourceForm({
       dispatch(
         setSelected(
           data.identifier,
-          data.type === ResourceType.ASSOCIATION ? 'associations' : 'attributes'
+          data.type === ResourceType.ASSOCIATION
+            ? 'associations'
+            : 'attributes',
+          modelId
         )
       );
       setView(


### PR DESCRIPTION
Changes in this PR:
- Added `modelId` to all `setSelected()`. Edit views of resources selected were in an incorrect state if `modelId` wasn't found