### PR TITLE
YTI-3647: add actions to library nodes in graph

### DIFF
--- a/datamodel-ui/src/common/components/model/model.slice.tsx
+++ b/datamodel-ui/src/common/components/model/model.slice.tsx
@@ -195,6 +195,7 @@ const initialState = {
   displayLang: 'fi',
   addResourceRestrictionToClass: false,
   updateVisualization: false,
+  updateClassData: false,
   tools: {
     fullScreen: false,
     resetPosition: false,
@@ -319,6 +320,12 @@ export const modelSlice = createSlice({
         updateVisualization: action.payload,
       };
     },
+    setUpdateClassData(state, action) {
+      return {
+        ...state,
+        updateClassData: action.payload,
+      };
+    },
     setTools(state, action) {
       if (
         action.payload.key === 'showByName' ||
@@ -393,7 +400,7 @@ export function selectViews() {
 }
 
 export function selectClassView() {
-  return (state: AppState) => state.model.view.classes;
+  return (state: AppState): ViewListItem => state.model.view.classes;
 }
 
 export function selectResourceView(type: 'associations' | 'attributes') {
@@ -484,7 +491,8 @@ export function setAddResourceRestrictionToClass(value: boolean): AppThunk {
 }
 
 export function selectAddResourceRestrictionToClass() {
-  return (state: AppState) => state.model.addResourceRestrictionToClass;
+  return (state: AppState): boolean =>
+    state.model.addResourceRestrictionToClass;
 }
 
 export function setUpdateVisualization(value: boolean): AppThunk {
@@ -493,5 +501,13 @@ export function setUpdateVisualization(value: boolean): AppThunk {
 }
 
 export function selectUpdateVisualization() {
-  return (state: AppState) => state.model.updateVisualization;
+  return (state: AppState): boolean => state.model.updateVisualization;
+}
+
+export function setUpdateClassData(value: boolean): AppThunk {
+  return (dispatch) => dispatch(modelSlice.actions.setUpdateClassData(value));
+}
+
+export function selectUpdateClassData() {
+  return (state: AppState): boolean => state.model.updateClassData;
 }

--- a/datamodel-ui/src/common/interfaces/graph.interface.ts
+++ b/datamodel-ui/src/common/interfaces/graph.interface.ts
@@ -4,10 +4,12 @@ export interface ClassNodeDataType {
   applicationProfile?: boolean;
   identifier: string;
   label: { [key: string]: string };
+  uri: string;
   modelId: string;
   resources: {
     identifier: string;
     label?: { [key: string]: string };
+    uri: string;
     type: ResourceType.ASSOCIATION | ResourceType.ATTRIBUTE;
     codeLists?: string[];
     dataType?: string | null;
@@ -21,6 +23,7 @@ export interface ClassNodeDataType {
 export interface AttributeNodeType {
   identifier: string;
   label: { [key: string]: string };
+  uri: string;
   modelId: string;
   dataType?: string;
   refetch?: () => void;

--- a/datamodel-ui/src/common/interfaces/visualization.interface.ts
+++ b/datamodel-ui/src/common/interfaces/visualization.interface.ts
@@ -1,6 +1,7 @@
 export interface VisualizationType {
   identifier: string;
   label: { [key: string]: string };
+  uri: string;
   references: VisualizationReferenceType[];
   position: {
     x: number;
@@ -9,6 +10,7 @@ export interface VisualizationType {
   attributes?: {
     identifier: string;
     label: { [key: string]: string };
+    uri: string;
     dataType?: string;
     minCount?: number;
     maxCount?: number;
@@ -23,6 +25,7 @@ export interface VisualizationType {
 export interface VisualizationReferenceType {
   identifier: string;
   label?: { [key: string]: string };
+  uri: string;
   referenceTarget: string;
   referenceType: ReferenceType;
   minCount?: number;

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -31,7 +31,9 @@ import { useSelector } from 'react-redux';
 import {
   selectAddResourceRestrictionToClass,
   selectDisplayLang,
+  selectUpdateClassData,
   setAddResourceRestrictionToClass,
+  setUpdateClassData,
   setUpdateVisualization,
 } from '@app/common/components/model/model.slice';
 import { ADMIN_EMAIL } from '@app/common/utils/get-value';
@@ -84,12 +86,20 @@ export default function ClassInfo({
   const [showTooltip, setShowTooltip] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showRenameModal, setShowRenameModal] = useState(false);
+  const updateClassData = useSelector(selectUpdateClassData());
   const dispatch = useStoreDispatch();
   const renderResourceForm = useSelector(selectAddResourceRestrictionToClass());
 
   const displayLang = useSelector(selectDisplayLang());
   const [addReference, addReferenceResult] = useAddPropertyReferenceMutation();
   const { ref: toolTipRef } = useGetAwayListener(showTooltip, setShowTooltip);
+
+  useEffect(() => {
+    if (updateClassData) {
+      handleRefetch();
+      dispatch(setUpdateClassData(false));
+    }
+  }, [dispatch, handleRefetch, updateClassData]);
 
   const handleFollowUp = (value: {
     uriData: UriData;

--- a/datamodel-ui/src/modules/graph/index.tsx
+++ b/datamodel-ui/src/modules/graph/index.tsx
@@ -288,7 +288,7 @@ const GraphContent = ({
         modelId,
         deleteNodeById,
         applicationProfile,
-        applicationProfile ? refetchNodes : undefined,
+        refetchNodes,
         organizationIds
       )
     );

--- a/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
+++ b/datamodel-ui/src/modules/graph/nodes/node.styles.tsx
@@ -47,7 +47,7 @@ export const ClassNodeDiv = styled.div<{
       flex-grow: 1;
     }
 
-    height: ${(props) => (props.$appProfile ? '37px' : '27px')};
+    padding: ${(props) => props.theme.suomifi.spacing.xxs};
   }
 
   .react-flow__handle {

--- a/datamodel-ui/src/modules/graph/utils/create-attribute-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-attribute-node/index.ts
@@ -14,6 +14,7 @@ export default function createAttributeNode(
       identifier: node.identifier,
       modelId: modelId,
       label: node.label,
+      uri: node.uri,
       dataType: node.dataType,
       ...(refetch ? { refetch: refetch } : {}),
     },

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/create-class-node.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/create-class-node.test.ts
@@ -9,6 +9,7 @@ describe('create-class-node', () => {
           fi: 'label-1-fi',
           en: 'label-1-en',
         },
+        uri: 'uri-1',
         references: [],
         position: {
           x: 0,
@@ -48,6 +49,7 @@ describe('create-class-node', () => {
         label: {
           fi: 'label-1-fi',
         },
+        uri: 'uri-1',
         references: [],
         position: {
           x: 0,
@@ -56,18 +58,21 @@ describe('create-class-node', () => {
         attributes: [
           {
             identifier: 'attr-1',
+            uri: 'uri-attr-1',
             label: {
               fi: 'attr-1-fi',
             },
           },
           {
             identifier: 'attr-2',
+            uri: 'uri-attr-2',
             label: {
               fi: 'attr-2-fi',
             },
           },
           {
             identifier: 'attr-3',
+            uri: 'uri-attr-3',
             label: {
               fi: 'attr-3-fi',
             },
@@ -76,6 +81,7 @@ describe('create-class-node', () => {
         associations: [
           {
             identifier: 'assoc-1',
+            uri: 'uri-assoc-1',
             label: {
               fi: 'assoc-1-fi',
             },
@@ -84,6 +90,7 @@ describe('create-class-node', () => {
           },
           {
             identifier: 'assoc-2',
+            uri: 'uri-assoc-2',
             label: {
               fi: 'assoc-2-fi',
             },
@@ -92,6 +99,7 @@ describe('create-class-node', () => {
           },
           {
             identifier: 'assoc-3',
+            uri: 'uri-assoc-3',
             label: {
               fi: 'assoc-3-fi',
             },

--- a/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/create-class-node/index.ts
@@ -20,6 +20,7 @@ export default function createClassNode(
       ...(applicationProfile !== undefined
         ? { applicationProfile: applicationProfile }
         : {}),
+      uri: node.uri,
       resources: [
         ...(node.attributes ?? []).map((a) => ({
           ...a,

--- a/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
+++ b/datamodel-ui/src/modules/graph/utils/generate-positions-payload/generate-positions-payload.test.ts
@@ -17,6 +17,7 @@ describe('generate-positions-payload', () => {
           data: {
             identifier: 'node-1',
             label: {},
+            uri: 'uri-1',
             modelId: 'model-1',
             resources: [],
           },
@@ -29,6 +30,7 @@ describe('generate-positions-payload', () => {
           id: 'node-2',
           data: {
             identifier: 'node-2',
+            uri: 'uri-2',
             label: {},
             modelId: 'model-1',
             resources: [],
@@ -42,6 +44,7 @@ describe('generate-positions-payload', () => {
           id: 'node-3',
           data: {
             identifier: 'node-3',
+            uri: 'uri-3',
             label: {},
             modelId: 'model-1',
             resources: [],

--- a/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
+++ b/datamodel-ui/src/modules/graph/utils/visualization-test-data/index.ts
@@ -5,6 +5,7 @@ export const libraryData = {
     {
       identifier: 'address',
       label: { fi: 'Osoite' },
+      uri: 'uri-address',
       position: { x: 813, y: -93 },
       type: 'CLASS',
       references: [],
@@ -129,6 +130,7 @@ export const profileData = {
       label: {
         fi: 'Osoite',
       },
+      uri: 'uri-address',
       position: {
         x: 698,
         y: 66,


### PR DESCRIPTION
Changelog: 
- added typing to some slice selectors (should all of them be typed
  - this seemed to help  with typing when using the selector
- Added actions buttons to library graph nodes
- Simplified the button generation on code side
- Added uris to visualization for added filtering support.