### PR TITLE
Incorrect language labels replaced with language codes

### DIFF
--- a/common-ui/components/search-results/result-card.tsx
+++ b/common-ui/components/search-results/result-card.tsx
@@ -23,6 +23,7 @@ interface ResultCardProps {
   icon?: ReactNode;
   noChip?: boolean;
   noDescriptionText: string;
+  noVersion?: boolean;
   partOfText?: string;
   partOf?: string[];
   identifier?: string;
@@ -41,6 +42,7 @@ export default function ResultCard({
   noChip = false,
   noDescriptionText,
   partOf,
+  noVersion,
   version,
   identifier,
   partOfText,
@@ -79,7 +81,9 @@ export default function ResultCard({
             <span style={{ textTransform: 'uppercase' }}>{identifier}</span>
           </>
         )}
-        {version ? (
+        {noVersion ? (
+          <></>
+        ) : version ? (
           <>
             <span aria-hidden={true}>&middot;</span>
             <span style={{ textTransform: 'uppercase' }}>{`${t(

--- a/common-ui/components/search-results/search-results.tsx
+++ b/common-ui/components/search-results/search-results.tsx
@@ -37,6 +37,7 @@ interface SearchResultsProps {
   partOfText?: string;
   noDescriptionText: string;
   noChip?: boolean;
+  noVersion?: boolean;
   tagsTitle: string;
   tagsHiddenTitle: string;
   withDefaultStatuses?: string[];
@@ -72,6 +73,7 @@ export default function SearchResults({
   partOfText,
   noDescriptionText,
   noChip,
+  noVersion,
   tagsTitle,
   tagsHiddenTitle,
   withDefaultStatuses,
@@ -111,6 +113,7 @@ export default function SearchResults({
               partOfText={partOfText}
               noDescriptionText={noDescriptionText}
               noChip={noChip}
+              noVersion={noVersion}
               extra={
                 extra &&
                 ('expander' in extra

--- a/terminology-ui/src/modules/edit-vocabulary/generate-initial-data.test.ts
+++ b/terminology-ui/src/modules/edit-vocabulary/generate-initial-data.test.ts
@@ -1,20 +1,16 @@
 import { VocabularyInfoDTO } from '@app/common/interfaces/vocabulary.interface';
 import generateInitialData from './generate-initial-data';
 
-const mockTranslations = () => {
-  return 'mock label text';
-};
-
 describe('generate-initial-data', () => {
   it('should generate initial data from input', () => {
-    const returned = generateInitialData('fi', mockTranslations, dataSmall);
+    const returned = generateInitialData('fi', dataSmall);
 
     const expected = {
       contact: 'yhteentoimivuus@dvv.fi',
       languages: [
         {
           description: 'kuvaus',
-          labelText: 'mock label text',
+          labelText: 'fi',
           selected: true,
           title: 'testi2',
           uniqueItemId: 'fi',
@@ -46,27 +42,27 @@ describe('generate-initial-data', () => {
   });
 
   it('should generate data from large input', () => {
-    const returned = generateInitialData('fi', mockTranslations, dataLarge);
+    const returned = generateInitialData('fi', dataLarge);
     const expected = {
       contact: 'yhteentoimivuus@dvv.fi',
       languages: [
         {
           description: 'kuvaus',
-          labelText: 'mock label text',
+          labelText: 'fi',
           selected: true,
           title: 'testi2',
           uniqueItemId: 'fi',
         },
         {
           description: 'description',
-          labelText: 'mock label text',
+          labelText: 'en',
           selected: true,
           title: 'test2',
           uniqueItemId: 'en',
         },
         {
           description: '',
-          labelText: 'mock label text',
+          labelText: 'sv',
           selected: true,
           title: 'test2',
           uniqueItemId: 'sv',

--- a/terminology-ui/src/modules/edit-vocabulary/generate-initial-data.ts
+++ b/terminology-ui/src/modules/edit-vocabulary/generate-initial-data.ts
@@ -1,12 +1,10 @@
 import { getPropertyValue } from '@app/common/components/property-value/get-property-value';
 import { NewTerminologyInfo } from '@app/common/interfaces/new-terminology-info';
 import { VocabularyInfoDTO } from '@app/common/interfaces/vocabulary.interface';
-import { TFunction } from 'next-i18next';
 import { LanguageBlockType } from 'yti-common-ui/form/language-selector';
 
 export default function generateInitialData(
   lang: string,
-  t: TFunction,
   data?: VocabularyInfoDTO
 ): NewTerminologyInfo | undefined {
   if (!data) {
@@ -21,9 +19,7 @@ export default function generateInitialData(
       const title =
         data.properties.prefLabel?.find((p) => p.lang === l.value)?.value ?? '';
 
-      const labelText = ['fi', 'sv', 'en'].includes(l.value)
-        ? `${t(`language-label-text-${l.value}`)}`
-        : l.value;
+      const labelText = l.value;
 
       return {
         title,

--- a/terminology-ui/src/modules/edit-vocabulary/index.tsx
+++ b/terminology-ui/src/modules/edit-vocabulary/index.tsx
@@ -55,7 +55,7 @@ export default function EditVocabulary({ terminologyId }: EditVocabularyProps) {
     id: terminologyId,
   });
   const user = useSelector(selectLogin());
-  const [data, setData] = useState(generateInitialData(i18n.language, t, info));
+  const [data, setData] = useState(generateInitialData(i18n.language, info));
   const [isValid, setIsValid] = useState(true);
   const [userPosted, setUserPosted] = useState(false);
   const [isCreating, setIsCreating] = useState(false);

--- a/terminology-ui/src/modules/terminology-search/index.tsx
+++ b/terminology-ui/src/modules/terminology-search/index.tsx
@@ -263,6 +263,7 @@ export default function TerminologySearch() {
                     'terminology-search-results-information-domains'
                   )}
                   noDescriptionText={t('vocabulary-results-no-description')}
+                  noVersion
                   tagsTitle={t('terminology-search-terminologies', {
                     count: data?.totalHitCount ?? 0,
                   })}

--- a/terminology-ui/src/modules/vocabulary/index.tsx
+++ b/terminology-ui/src/modules/vocabulary/index.tsx
@@ -307,6 +307,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
                       domains={[]}
                       organizations={[]}
                       noChip
+                      noVersion
                     />
                     <Pagination
                       maxPages={Math.ceil(conceptsData.totalHitCount / 50)}
@@ -423,6 +424,7 @@ export default function Vocabulary({ id }: VocabularyProps) {
             data={filteredCollections}
             domains={[]}
             organizations={[]}
+            noVersion
             extra={{
               other: {
                 title: t('vocabulary-filter-concepts'),


### PR DESCRIPTION
Changes in this PR:
- Translated languages replaced with language codes gotten from backend
- Fixed small visual bug with search result cards where too many middots were visible