### PR TITLE
YTI-3571 use iri.suomi.fi identifier

### DIFF
--- a/common-ui/components/form/prefix.tsx
+++ b/common-ui/components/form/prefix.tsx
@@ -49,7 +49,8 @@ export default function Prefix({
   maxLength,
   minLength,
 }: PrefixProps) {
-  const URI = 'http://uri.suomi.fi';
+  const URI =
+    typeInUri === 'model' ? 'https://iri.suomi.fi' : 'http://uri.suomi.fi';
   const [initalPrefix] = useState(prefix);
   const [inputType, setInputType] = useState<'manual' | 'automatic'>(
     noAuto ? 'manual' : 'automatic'

--- a/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
+++ b/datamodel-ui/src/common/components/search-internal-resources/search-internal-resources.slice.ts
@@ -8,6 +8,7 @@ import {
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import { Type } from '@app/common/interfaces/type.interface';
 import { inUseStatusList } from '@app/common/utils/status-list';
+import { SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 
 export interface InternalResourcesSearchParams {
   query: string;
@@ -70,7 +71,7 @@ function createUrl(obj: InternalResourcesSearchParams): string {
 
   if (obj.limitToDataModel) {
     baseQuery = baseQuery.concat(
-      `&limitToDataModel=http://uri.suomi.fi/datamodel/ns/${obj.limitToDataModel}`
+      `&limitToDataModel=${SUOMI_FI_NAMESPACE}${obj.limitToDataModel}/`
     );
   }
 
@@ -97,7 +98,7 @@ function createUrl(obj: InternalResourcesSearchParams): string {
   if (obj.includeDraftFrom) {
     baseQuery = baseQuery.concat(
       `&includeDraftFrom=${obj.includeDraftFrom
-        .map((modelId) => `http://uri.suomi.fi/datamodel/ns/${modelId}`)
+        .map((modelId) => `${SUOMI_FI_NAMESPACE}${modelId}/`)
         .join(',')}`
     );
   }

--- a/datamodel-ui/src/common/interfaces/model.interface.ts
+++ b/datamodel-ui/src/common/interfaces/model.interface.ts
@@ -2,6 +2,7 @@ import { Status } from './status.interface';
 
 export interface ModelType {
   type: 'LIBRARY' | 'PROFILE';
+  uri: string;
   prefix: string;
   status: Status;
   label: { [key: string]: string };

--- a/datamodel-ui/src/common/utils/get-value.ts
+++ b/datamodel-ui/src/common/utils/get-value.ts
@@ -26,6 +26,7 @@ function getLangObject(data: { [key: string]: string }) {
   });
 }
 
+export const SUOMI_FI_NAMESPACE = 'https://iri.suomi.fi/model/';
 export const ADMIN_EMAIL = 'yhteentoimivuus@dvv.fi';
 
 export function getTitle(data?: ModelType, lang?: string): string {
@@ -180,10 +181,6 @@ export function getIsPartOfWithId(
 
 export function getLanguages(data?: ModelType): string[] {
   return data?.languages ?? [];
-}
-
-export function getUri(data?: ModelType): string {
-  return `http://uri.suomi.fi/datamodel/ns/${data?.prefix}`;
 }
 
 export function getPrefixFromURI(namespace: string): string {

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -36,7 +36,7 @@ import {
   setUpdateClassData,
   setUpdateVisualization,
 } from '@app/common/components/model/model.slice';
-import { ADMIN_EMAIL } from '@app/common/utils/get-value';
+import { ADMIN_EMAIL, SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 import { ResourceType } from '@app/common/interfaces/resource-type.interface';
 import ResourceModal from './resource-modal';
 import { useAddPropertyReferenceMutation } from '@app/common/components/class/class.slice';
@@ -213,7 +213,7 @@ export default function ClassInfo({
           dispatch(setAddResourceRestrictionToClass(false));
           handleFollowUp({
             uriData: {
-              uri: `http://uri.suomi.fi/datamodel/ns/${modelId}/${identifier}`,
+              uri: `${SUOMI_FI_NAMESPACE}${modelId}/${identifier}`,
               curie: `${modelId}:${identifier}`,
               label: {},
             },

--- a/datamodel-ui/src/modules/model-form/generate-payload.tsx
+++ b/datamodel-ui/src/modules/model-form/generate-payload.tsx
@@ -1,12 +1,10 @@
 import { ModelFormType } from '@app/common/interfaces/model-form.interface';
 import { NewModel } from '@app/common/interfaces/new-model.interface';
-import { ADMIN_EMAIL } from '@app/common/utils/get-value';
+import { ADMIN_EMAIL, SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 
 export default function generatePayload(data: ModelFormType): NewModel {
-  const SUOMI_FI_NAMESPACE = 'http://uri.suomi.fi/datamodel/ns/';
-
   return {
-    id: `${SUOMI_FI_NAMESPACE}${data.prefix}`,
+    id: `${SUOMI_FI_NAMESPACE}${data.prefix}/`,
     description: data.languages
       .filter((l) => l.description !== '')
       .reduce(

--- a/datamodel-ui/src/modules/model-form/index.tsx
+++ b/datamodel-ui/src/modules/model-form/index.tsx
@@ -34,6 +34,7 @@ import { compareLocales } from '@app/common/utils/compare-locals';
 import { translateStatus } from '@app/common/utils/translation-helpers';
 import { useSelector } from 'react-redux';
 import { selectLogin } from '@app/common/components/login/login.slice';
+import { SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 
 interface ModelFormProps {
   formData: ModelFormType;
@@ -284,9 +285,7 @@ export default function ModelForm({
           </div>
           <div>
             <Label>{t('namespace')}</Label>
-            <Text
-              smallScreen
-            >{`http://uri.suomi.fi/datamodel/ns/${formData.prefix}`}</Text>
+            <Text smallScreen>{`${SUOMI_FI_NAMESPACE}${formData.prefix}`}</Text>
           </div>
           {oldVersion &&
             (initialStatus.current === 'SUGGESTED' ||
@@ -334,7 +333,7 @@ export default function ModelForm({
             })
           }
           inUseMutation={useGetModelExistsMutation}
-          typeInUri={'datamodel/ns'}
+          typeInUri={'model'}
           error={errorInPrefix()}
           translations={{
             automatic: t('create-prefix-automatically'),

--- a/datamodel-ui/src/modules/model/model-info-view.tsx
+++ b/datamodel-ui/src/modules/model/model-info-view.tsx
@@ -19,7 +19,6 @@ import {
   ADMIN_EMAIL,
   getIsPartOfWithId,
   getOrganizationsWithId,
-  getUri,
 } from '@app/common/utils/get-value';
 import { LinksWrapper, TooltipWrapper } from './model.styles';
 import { translateLanguage } from '@app/common/utils/translation-helpers';
@@ -262,11 +261,11 @@ export default function ModelInfoView({
         </BasicBlock>
         <BasicBlock title={t('prefix')}>{modelInfo.prefix}</BasicBlock>
         <BasicBlock title={t('model-uri')}>
-          {getUri(modelInfo)}
+          {modelInfo.uri}
           <Button
             icon={<IconCopy />}
             variant="secondary"
-            onClick={() => navigator.clipboard.writeText(getUri(modelInfo))}
+            onClick={() => navigator.clipboard.writeText(modelInfo.uri)}
             style={{ width: 'max-content' }}
             id="copy-uri-button"
           >

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -44,6 +44,7 @@ import { useReactFlow } from 'reactflow';
 import getConnectedElements from '../graph/utils/get-connected-elements';
 import { UriData } from '@app/common/interfaces/uri.interface';
 import ResourceError from '@app/common/components/resource-error';
+import { SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 
 interface ResourceViewProps {
   modelId: string;
@@ -115,7 +116,7 @@ export default function ResourceView({
   const { data: inUse, refetch: refetchInUse } = useGetResourceActiveQuery(
     {
       prefix: modelId,
-      uri: `http://uri.suomi.fi/datamodel/ns/${globalSelected.modelId}/${globalSelected.id}`,
+      uri: `${SUOMI_FI_NAMESPACE}${globalSelected.modelId}/${globalSelected.id}`,
       version: version,
     },
     {

--- a/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
@@ -125,9 +125,10 @@ export default function RangeAndDomain({
             label={`${t('target-attribute')} (owl:DatatypeProperty)`}
           />
         )}
-
         <SingleSelect
-          labelText={`${t('range')} (rdfs:datatype)`}
+          labelText={`${t('range')} ${
+            applicationProfile ? '(sh:datatype)' : '(rdfs:range)'
+          }`}
           itemAdditionHelpText=""
           ariaOptionsAvailableText={t('available-ranges') as string}
           defaultSelectedItem={attributeRanges.find(

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -61,6 +61,7 @@ import {
   DEFAULT_ATTRIBUTE_SUBPROPERTY,
 } from '@app/common/components/resource/utils';
 import PropertyToggle from './components/property-toggle';
+import { SUOMI_FI_NAMESPACE } from '@app/common/utils/get-value';
 
 interface ResourceFormProps {
   modelId: string;
@@ -116,7 +117,7 @@ export default function ResourceForm({
   const { data: inUseResult, isSuccess: isActiveSuccess } =
     useGetResourceActiveQuery({
       prefix: currentModelId,
-      uri: `http://uri.suomi.fi/datamodel/ns/${modelId}/${data.identifier}`,
+      uri: `${SUOMI_FI_NAMESPACE}${modelId}/${data.identifier}`,
     });
 
   useEffect(() => {
@@ -163,7 +164,7 @@ export default function ResourceForm({
     if (inUseResult !== inUse) {
       togglePropertyShape({
         modelId: currentModelId,
-        uri: `http://uri.suomi.fi/datamodel/ns/${modelId}/${data.identifier}`,
+        uri: `${SUOMI_FI_NAMESPACE}${modelId}/${data.identifier}`,
       });
     }
   };


### PR DESCRIPTION
- Created constant for namespace prefix `https://iri.suomi.fi`
- Minor fix for displaying range's / datatype's label text (show sh:datatype for application profile, rdfs:range for library)