### PR TITLE
YTI-4349 Change max length for description

### DIFF
--- a/common-ui/components/form/language-selector.tsx
+++ b/common-ui/components/form/language-selector.tsx
@@ -157,7 +157,7 @@ export default function LanguageSelector(
             }
             defaultValue={item.description}
             id={`description-input-${item.uniqueItemId}`}
-            maxLength={TEXT_INPUT_MAX}
+            maxLength={TEXT_AREA_MAX}
           />
         </LanguageBlock>
       ))}


### PR DESCRIPTION
Allow 5000 characters in datamodel's and terminology's description