### PR TITLE
YTI-4317 encode filename

### DIFF
--- a/datamodel-ui/src/pages/api/getModelAsFile.ts
+++ b/datamodel-ui/src/pages/api/getModelAsFile.ts
@@ -85,7 +85,7 @@ export default withIronSessionApiRoute(
       res.setHeader('Content-Type', mimeType);
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${filename}"`
+        `attachment; filename="${encodeURIComponent(filename)}"`
       );
     }
     res.status(status);

--- a/terminology-ui/src/pages/api/getTerminologyAsFile.ts
+++ b/terminology-ui/src/pages/api/getTerminologyAsFile.ts
@@ -67,7 +67,10 @@ export default withIronSessionApiRoute(
     );
 
     res.setHeader('Content-Type', mimeType);
-    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${encodeURIComponent(filename)}"`
+    );
 
     res.status(status);
     response.pipe(res);


### PR DESCRIPTION
Add url encode for filename in content-disposition header. Invalid characters will cause an error `TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]`