### PR TITLE
YTI-4373 Improve term addition form validation

### DIFF
--- a/common-ui/components/form/prefix.tsx
+++ b/common-ui/components/form/prefix.tsx
@@ -3,6 +3,7 @@ import { Label, Paragraph, Text } from 'suomifi-ui-components';
 import { TEXT_INPUT_MAX } from '../../utils/constants';
 import { PrefixContainer, TextInput } from './prefix.styles';
 import { UseMutation } from '@reduxjs/toolkit/dist/query/react/buildHooks';
+import { isValidIdentifier } from '../../utils/validation-utils';
 
 interface PrefixProps {
   prefix: string;
@@ -46,9 +47,7 @@ export default function Prefix({
   const [validatePrefix, inUse] = inUseMutation();
 
   const handleTextInput = (e: string) => {
-    const regex = new RegExp('^[a-z][a-z0-9-_]+$');
-
-    if (e.match(regex) && e.length >= minLength && e.length <= maxLength) {
+    if (isValidIdentifier(e)) {
       setPrefixInternal(e);
       setPrefixValid(true);
       setPrefix(e, true);

--- a/common-ui/utils/validation-utils.ts
+++ b/common-ui/utils/validation-utils.ts
@@ -1,0 +1,8 @@
+// Validator function for prefixes/identifiers. Based on the PREFIX_REGEX in ValidationConstants in common-backend
+export const isValidIdentifier = (id: string | null | undefined): boolean => {
+  if (!id) {
+    return false;
+  }
+  const re = /^[a-z][a-z0-9_-]{1,31}$/;
+  return re.test(id);
+};

--- a/terminology-ui/public/locales/en/admin.json
+++ b/terminology-ui/public/locales/en/admin.json
@@ -126,7 +126,7 @@
     "diagramsUri": "One or more diagram's url is not in valid form",
     "editorialNote": "At least one editorial note is missing a descriptive text",
     "example": "At least one example is missing a descriptive text",
-    "identifier": "Concept's identifier is undefined",
+    "identifier": "Concept's identifier is undefined or does not match the required format",
     "language": "Term's language is undefined",
     "note": "At least one note is missing a descriptive text",
     "prefLabel": "Term's name is undefined",

--- a/terminology-ui/public/locales/en/admin.json
+++ b/terminology-ui/public/locales/en/admin.json
@@ -329,7 +329,7 @@
   "term-name-label": "Term name",
   "term-name-placeholder": "Give term name",
   "term-new-type": "New type of term",
-  "term-prefix-input-hint-text": "Unique prefix for Data Model that can not be changed afterwards. Prefix must start with a lowercase letter and be 2-32 characters long. Valid characters are a-z, 0-9, \"_\" and \"-\".",
+  "term-prefix-input-hint-text": "Unique prefix for term that can not be changed afterwards. Prefix must start with a lowercase letter and be 2-32 characters long. Valid characters are a-z, 0-9, \"_\" and \"-\".",
   "term-scope-hint-text": "Scope or domain where term is in use.",
   "term-scope-label": "Scope",
   "term-scope-placeholder": "Give scope",

--- a/terminology-ui/public/locales/en/admin.json
+++ b/terminology-ui/public/locales/en/admin.json
@@ -329,6 +329,7 @@
   "term-name-label": "Term name",
   "term-name-placeholder": "Give term name",
   "term-new-type": "New type of term",
+  "term-prefix-input-hint-text": "Unique prefix for Data Model that can not be changed afterwards. Prefix must start with a lowercase letter and be 2-32 characters long. Valid characters are a-z, 0-9, \"_\" and \"-\".",
   "term-scope-hint-text": "Scope or domain where term is in use.",
   "term-scope-label": "Scope",
   "term-scope-placeholder": "Give scope",

--- a/terminology-ui/public/locales/en/common.json
+++ b/terminology-ui/public/locales/en/common.json
@@ -9,6 +9,8 @@
   "cancel": "",
   "card-organizations": "organizations",
   "change-language-selected-language": "Change langugage, selected language: {{selectedLanguage}}",
+  "character-counter-remaining": "characters remaining",
+  "character-counter-over-limit": "characters too many",
   "choose-language": "Choose a language",
   "clear-language-filter": "Clear language filter",
   "close": "Close",

--- a/terminology-ui/public/locales/fi/admin.json
+++ b/terminology-ui/public/locales/fi/admin.json
@@ -126,7 +126,7 @@
     "diagramsUri": "Yhdellä tai useammalla käsitekaaviolla on virheellinen verkko-osoite",
     "editorialNote": "Vähintään yhdeltä ylläpitäjän muistiipanolta puuttuu selite",
     "example": "Vähintään yhdeltä käyttöesimerkiltä puuttuu selite",
-    "identifier": "Käsitteen tunnusta ei ole määritetty",
+    "identifier": "Käsitteen tunnusta ei ole määritetty tai se ei ole vaatimusten mukainen",
     "language": "Termin kieltä ei ole määritetty",
     "note": "Vähintään yhdeltä huomautukselta puuttuu selite",
     "prefLabel": "Termin nimeä ei ole määritetty",

--- a/terminology-ui/public/locales/fi/admin.json
+++ b/terminology-ui/public/locales/fi/admin.json
@@ -329,7 +329,7 @@
   "term-name-label": "Termin nimi",
   "term-name-placeholder": "Kirjoita termin nimi",
   "term-new-type": "Termin uusi tyyppi",
-  "term-prefix-input-hint-text": "Tietomallin yksilöivä tunnus, jota ei voi muuttaa tietomallin luonnin jälkeen. Tunnuksen tulee alkaa pienellä kirjaimella ja sen pitää olla 2-32 merkkiä pitkä. Sallitut merkit ovat a-z, 0-9, \"_\" ja \"-\".",
+  "term-prefix-input-hint-text": "Termin yksilöivä tunnus, jota ei voi muuttaa termin luonnin jälkeen. Tunnuksen tulee alkaa pienellä kirjaimella ja sen pitää olla 2-32 merkkiä pitkä. Sallitut merkit ovat a-z, 0-9, \"_\" ja \"-\".",
   "term-scope-hint-text": "Ala, jossa termi on käytössä.",
   "term-scope-label": "Käyttöala",
   "term-scope-placeholder": "Kirjoita alan nimi",

--- a/terminology-ui/public/locales/fi/admin.json
+++ b/terminology-ui/public/locales/fi/admin.json
@@ -329,6 +329,7 @@
   "term-name-label": "Termin nimi",
   "term-name-placeholder": "Kirjoita termin nimi",
   "term-new-type": "Termin uusi tyyppi",
+  "term-prefix-input-hint-text": "Tietomallin yksilöivä tunnus, jota ei voi muuttaa tietomallin luonnin jälkeen. Tunnuksen tulee alkaa pienellä kirjaimella ja sen pitää olla 2-32 merkkiä pitkä. Sallitut merkit ovat a-z, 0-9, \"_\" ja \"-\".",
   "term-scope-hint-text": "Ala, jossa termi on käytössä.",
   "term-scope-label": "Käyttöala",
   "term-scope-placeholder": "Kirjoita alan nimi",

--- a/terminology-ui/public/locales/fi/common.json
+++ b/terminology-ui/public/locales/fi/common.json
@@ -9,6 +9,8 @@
   "cancel": "",
   "card-organizations": "sisällöntuottajaa",
   "change-language-selected-language": "Vaihda kieli, valittu kieli: {{selectedLanguage}}",
+  "character-counter-remaining": "merkkiä jäljellä",
+  "character-counter-over-limit": "merkkiä liikaa",
   "choose-language": "Valitse kieli",
   "clear-language-filter": "Tyhjennä kielivalinta",
   "close": "Sulje",

--- a/terminology-ui/public/locales/sv/admin.json
+++ b/terminology-ui/public/locales/sv/admin.json
@@ -329,6 +329,7 @@
   "term-name-label": "Termens namn",
   "term-name-placeholder": "Ange termens namn",
   "term-new-type": "Termens nya typ",
+  "term-prefix-input-hint-text": "Unikt prefix som inte kan ändras i efterhand. Prefixet måste börja med en liten bokstav och vara 2-32 tecken långt. Tillåtna tecken är a-z, 0-9, \"_\" och \"-\".",
   "term-scope-hint-text": "Användningsområde, som termen används på.",
   "term-scope-label": "Användningsområde",
   "term-scope-placeholder": "Ange ett användningsområde",

--- a/terminology-ui/public/locales/sv/admin.json
+++ b/terminology-ui/public/locales/sv/admin.json
@@ -126,7 +126,7 @@
     "diagramsUri": "Ett eller flera begreppsdiagram har en felaktig webbadress",
     "editorialNote": "Beskrivning  fattas åtminstone från en administratörens anmärkning",
     "example": "Beskrivning fattas åtminstone från ett användningsexempel",
-    "identifier": "Begreppets identifierare har inte definierats",
+    "identifier": "Begreppets identifierare har inte definierats eller är i ett felaktigt format",
     "language": "Termens språk har inte definierats",
     "note": "Beskrivning fattas åtminstone från en anmärkning",
     "prefLabel": "Termens namn har inte definierats",

--- a/terminology-ui/public/locales/sv/common.json
+++ b/terminology-ui/public/locales/sv/common.json
@@ -9,6 +9,8 @@
   "cancel": "",
   "card-organizations": "innehållsproducenter",
   "change-language-selected-language": "",
+  "character-counter-remaining": "tecken kvar",
+  "character-counter-over-limit": "för många tecken",
   "choose-language": "Välj språk",
   "clear-language-filter": "Töm språkvalet",
   "close": "Stäng",

--- a/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.styles.tsx
+++ b/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.styles.tsx
@@ -39,6 +39,12 @@ export const SubjectTextInput = styled(TextInput)`
   margin-top: ${(props) => props.theme.suomifi.spacing.m};
 `;
 
+export const IdentifierTextInput = styled(TextInput)`
+  & .fi-text-input_input-element-container {
+    max-width: 290px;
+  }
+`;
+
 export const WideTextarea = styled(Textarea)`
   width: 438px;
 `;

--- a/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.tsx
+++ b/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.tsx
@@ -14,7 +14,11 @@ import { useState } from 'react';
 import { BasicInfo, ListType } from '../new-concept.types';
 import ListBlock from '../list-block';
 import { translateLanguage } from '@app/common/utils/translation-helpers';
-import { TEXT_AREA_MAX, TEXT_INPUT_MAX } from 'yti-common-ui/utils/constants';
+import {
+  MODEL_PREFIX_MAX,
+  TEXT_AREA_MAX,
+  TEXT_INPUT_MAX,
+} from 'yti-common-ui/utils/constants';
 import { FormError } from '../validate-form';
 import StatusPicker from './status-picker';
 import { TextInput } from 'suomifi-ui-components';
@@ -45,7 +49,7 @@ export default function ConceptBasicInformation({
 }: ConceptBasicInformationProps) {
   const { t } = useTranslation('admin');
   const [basicInfo, setBasicInfo] = useState<BasicInfo>(initialValues);
-  const [conceptExists, exitst] = useConceptExistsMutation();
+  const [conceptExists, exists] = useConceptExistsMutation();
 
   const handleBasicInfoUpdate = ({ key, lang, value }: BasicInfoUpdate) => {
     if (key === 'definition' && lang && typeof value === 'string') {
@@ -74,14 +78,22 @@ export default function ConceptBasicInformation({
         labelText={t('concept-identifier')}
         disabled={isEdit}
         defaultValue={basicInfo.identifier}
+        maxLength={MODEL_PREFIX_MAX}
+        characterLimit={MODEL_PREFIX_MAX}
+        ariaCharactersRemainingText={(amount) =>
+          `${amount} ${t('character-counter-remaining')}`
+        }
+        ariaCharactersExceededText={(amount) =>
+          `${amount} ${t('character-counter-over-limit')}`
+        }
         onBlur={() =>
           conceptExists({
             terminologyId,
             conceptId: basicInfo.identifier,
           })
         }
-        status={exitst.data ? 'error' : 'default'}
-        statusText={exitst.data ? t('prefix-taken') : ''}
+        status={exists.data ? 'error' : 'default'}
+        statusText={exists.data ? t('prefix-taken') : ''}
         onChange={(e) =>
           handleBasicInfoUpdate({
             key: 'identifier',
@@ -180,6 +192,13 @@ export default function ConceptBasicInformation({
         }
         defaultValue={basicInfo.definition[lang] ?? ''}
         maxLength={TEXT_AREA_MAX}
+        characterLimit={TEXT_AREA_MAX}
+        ariaCharactersRemainingText={(amount) =>
+          `${amount} ${t('character-counter-remaining')}`
+        }
+        ariaCharactersExceededText={(amount) =>
+          `${amount} ${t('character-counter-over-limit')}`
+        }
         className="definition-input"
       />
     );
@@ -199,6 +218,13 @@ export default function ConceptBasicInformation({
         }
         defaultValue={basicInfo.subject}
         maxLength={TEXT_INPUT_MAX}
+        characterLimit={TEXT_INPUT_MAX}
+        ariaCharactersRemainingText={(amount) =>
+          `${amount} ${t('character-counter-remaining')}`
+        }
+        ariaCharactersExceededText={(amount) =>
+          `${amount} ${t('character-counter-over-limit')}`
+        }
         id="subject-input"
       />
     );

--- a/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.tsx
+++ b/terminology-ui/src/modules/edit-concept/basic-information/concept-basic-information.tsx
@@ -4,6 +4,7 @@ import {
   WiderTextarea,
   H2Sm,
   SubjectTextInput,
+  IdentifierTextInput,
 } from './concept-basic-information.styles';
 import ConceptDiagramsAndSources from './concept-diagrams-and-sources';
 import OtherInformation from './other-information';
@@ -74,18 +75,13 @@ export default function ConceptBasicInformation({
       <Separator isLarge />
       <H2Sm variant="h2">{t('concept-basic-information')}</H2Sm>
 
-      <TextInput
+      <IdentifierTextInput
         labelText={t('concept-identifier')}
         disabled={isEdit}
+        fullWidth
         defaultValue={basicInfo.identifier}
         maxLength={MODEL_PREFIX_MAX}
-        characterLimit={MODEL_PREFIX_MAX}
-        ariaCharactersRemainingText={(amount) =>
-          `${amount} ${t('character-counter-remaining')}`
-        }
-        ariaCharactersExceededText={(amount) =>
-          `${amount} ${t('character-counter-over-limit')}`
-        }
+        hintText={t('term-prefix-input-hint-text')}
         onBlur={() =>
           conceptExists({
             terminologyId,

--- a/terminology-ui/src/modules/edit-concept/validate-form.tsx
+++ b/terminology-ui/src/modules/edit-concept/validate-form.tsx
@@ -46,7 +46,12 @@ export default function validateForm(data: EditConceptType): FormError {
     identifier: false,
   };
 
-  if (!data.basicInformation.identifier) {
+  // Id identifier is missing or of wrong length
+  if (
+    !data.basicInformation.identifier ||
+    data.basicInformation.identifier.length < 2 ||
+    data.basicInformation.identifier.length > 32
+  ) {
     errors.identifier = true;
   }
 

--- a/terminology-ui/src/modules/edit-concept/validate-form.tsx
+++ b/terminology-ui/src/modules/edit-concept/validate-form.tsx
@@ -1,3 +1,4 @@
+import { isValidIdentifier } from 'yti-common-ui/utils/validation-utils';
 import { EditConceptType } from './new-concept.types';
 
 export interface FormError {
@@ -47,11 +48,7 @@ export default function validateForm(data: EditConceptType): FormError {
   };
 
   // Id identifier is missing or of wrong length
-  if (
-    !data.basicInformation.identifier ||
-    data.basicInformation.identifier.length < 2 ||
-    data.basicInformation.identifier.length > 32
-  ) {
+  if (!isValidIdentifier(data.basicInformation.identifier)) {
     errors.identifier = true;
   }
 


### PR DESCRIPTION
This PR improves the frontend validation on the term addition form in order to minimize backend errors, which currently lack proper handling on the front end and can cause the user to get stuck.

It also adds character counters to the form to give users a bit more feedback on the maximum content length of different fields.