### PR TITLE
YTI-4374 - Fix Swedish placeholder text for vocabulary search input

### DIFF
--- a/terminology-ui/public/locales/sv/common.json
+++ b/terminology-ui/public/locales/sv/common.json
@@ -206,7 +206,7 @@
   "vocabulary-filter-filter-by-keyword": "Sök med ett ord",
   "vocabulary-filter-items": "stycken",
   "vocabulary-filter-show-only": "Visa endast",
-  "vocabulary-filter-visual-placeholder": "Till exempel dagvård, studering…",
+  "vocabulary-filter-visual-placeholder": "Till exempel dagvård, studiestöd…",
   "vocabulary-info-collection": "Begreppsurval",
   "vocabulary-info-concept": "Begrepp",
   "vocabulary-info-copied-from": "Kopierad från ordlistan",


### PR DESCRIPTION
This PR fixes a non-existent Swedish word in the vocabulary search field placeholder text by replacing it with an actual relevant word. This was requested by a translator of an organization using the service.