### PR TITLE
YTI-4293 - Hide domain/range association options from models that don't use them.

### DIFF
--- a/datamodel-ui/src/common/interfaces/model.interface.ts
+++ b/datamodel-ui/src/common/interfaces/model.interface.ts
@@ -33,6 +33,7 @@ export interface ModelType {
   };
   version?: string;
   versionIri?: string;
+  hasAssociationsWithDomainOrRange: boolean;
 }
 
 export interface InternalNamespace {

--- a/datamodel-ui/src/modules/class-view/class-info.tsx
+++ b/datamodel-ui/src/modules/class-view/class-info.tsx
@@ -72,6 +72,7 @@ interface ClassInfoProps {
   handleShowClass: (classId: string) => void;
   disableEdit?: boolean;
   organizationIds?: string[];
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ClassInfo({
@@ -85,6 +86,7 @@ export default function ClassInfo({
   handleShowClass,
   disableEdit,
   organizationIds,
+  hasAssociationsWithDomainOrRange,
 }: ClassInfoProps) {
   const { t, i18n } = useTranslation('common');
   const hasPermission = HasPermission({
@@ -501,6 +503,9 @@ export default function ClassInfo({
                       applicationProfile={applicationProfile}
                       disableEdit={disableEdit}
                       targetInClassRestriction={assoc.range}
+                      hasAssociationsWithDomainOrRange={
+                        hasAssociationsWithDomainOrRange
+                      }
                     />
                   ))}
               </ExpanderGroup>

--- a/datamodel-ui/src/modules/class-view/index.tsx
+++ b/datamodel-ui/src/modules/class-view/index.tsx
@@ -53,6 +53,7 @@ interface ClassViewProps {
   terminologies: string[];
   applicationProfile?: boolean;
   organizationIds?: string[];
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ClassView({
@@ -62,6 +63,7 @@ export default function ClassView({
   terminologies,
   applicationProfile,
   organizationIds,
+  hasAssociationsWithDomainOrRange,
 }: ClassViewProps) {
   const { t, i18n } = useTranslation('common');
   const ref = useRef<HTMLDivElement>(null);
@@ -365,6 +367,7 @@ export default function ClassView({
         disableEdit={version ? true : false}
         handleShowClass={handleShowClass}
         organizationIds={organizationIds}
+        hasAssociationsWithDomainOrRange={hasAssociationsWithDomainOrRange}
       />
     );
   }

--- a/datamodel-ui/src/modules/class-view/resource-info.tsx
+++ b/datamodel-ui/src/modules/class-view/resource-info.tsx
@@ -58,6 +58,7 @@ interface ResourceInfoProps {
   disableEdit?: boolean;
   targetInClassRestriction?: UriData;
   disableAssocTarget?: boolean;
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ResourceInfo({
@@ -71,6 +72,7 @@ export default function ResourceInfo({
   disableEdit,
   targetInClassRestriction,
   disableAssocTarget,
+  hasAssociationsWithDomainOrRange,
 }: ResourceInfoProps) {
   const { t, i18n } = useTranslation('common');
   const displayLang = useSelector(selectDisplayLang());
@@ -270,6 +272,7 @@ export default function ResourceInfo({
             disableEdit={disableEdit}
             handleRemoveCodeList={handleShowRemoveCodeListModal}
             organizationIds={resourceData.contributor?.map((c) => c.id)}
+            modelUsesDomainRange={hasAssociationsWithDomainOrRange}
           />
         )}
         {!data.modelId && (

--- a/datamodel-ui/src/modules/common-view-content/index.tsx
+++ b/datamodel-ui/src/modules/common-view-content/index.tsx
@@ -24,10 +24,7 @@ import ConceptView from '../concept-view';
 import SanitizedTextContent from 'yti-common-ui/sanitized-text-content';
 import HasPermission from '@app/common/utils/has-permission';
 import { useSelector } from 'react-redux';
-import {
-  selectCurrentViewName,
-  selectDisplayLang,
-} from '@app/common/components/model/model.slice';
+import { selectDisplayLang } from '@app/common/components/model/model.slice';
 import { ADMIN_EMAIL } from '@app/common/utils/get-value';
 import { useGetAllCodesQuery } from '@app/common/components/code/code.slice';
 import UriList from '@app/common/components/uri-list';
@@ -56,6 +53,7 @@ export default function CommonViewContent({
   simpleResourceCodeLists,
   disableEdit,
   handleRemoveCodeList,
+  modelUsesDomainRange,
 }: {
   modelId: string;
   inUse?: boolean;
@@ -70,6 +68,7 @@ export default function CommonViewContent({
   simpleResourceCodeLists?: string[];
   disableEdit?: boolean;
   handleRemoveCodeList?: (value: string) => void;
+  modelUsesDomainRange?: boolean;
 }) {
   const { t, i18n } = useTranslation('common');
   const hasPermission = HasPermission({
@@ -85,8 +84,6 @@ export default function CommonViewContent({
     }
   );
   const router = useRouter();
-  const currentView = useSelector(selectCurrentViewName());
-  const isClassesView = currentView === 'classes';
   const [showReferences, setShowReferences] = useState(false);
 
   function getCodeListLabel(uri: string) {
@@ -457,7 +454,7 @@ export default function CommonViewContent({
           </>
         )}
 
-        {!isClassesView && data.type === ResourceType.ASSOCIATION && (
+        {modelUsesDomainRange && data.type === ResourceType.ASSOCIATION && (
           <>
             <BasicBlock
               title={t('associations-source', { ns: 'admin' })}

--- a/datamodel-ui/src/modules/model/index.tsx
+++ b/datamodel-ui/src/modules/model/index.tsx
@@ -141,6 +141,9 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
             applicationProfile={modelInfo?.graphType === 'PROFILE'}
             terminologies={modelInfo?.terminologies.map((t) => t.uri) ?? []}
             organizationIds={organizationIds}
+            hasAssociationsWithDomainOrRange={
+              modelInfo?.hasAssociationsWithDomainOrRange ?? false
+            }
           />
         ),
       },
@@ -183,6 +186,9 @@ export default function Model({ modelId, fullScreen }: ModelProps) {
             applicationProfile={modelInfo?.graphType === 'PROFILE'}
             terminologies={modelInfo?.terminologies.map((t) => t.uri) ?? []}
             organizationIds={organizationIds}
+            hasAssociationsWithDomainOrRange={
+              modelInfo?.hasAssociationsWithDomainOrRange ?? false
+            }
           />
         ),
       },

--- a/datamodel-ui/src/modules/resource/index.tsx
+++ b/datamodel-ui/src/modules/resource/index.tsx
@@ -55,6 +55,7 @@ interface ResourceViewProps {
   terminologies: string[];
   applicationProfile?: boolean;
   organizationIds?: string[];
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ResourceView({
@@ -65,6 +66,7 @@ export default function ResourceView({
   terminologies,
   applicationProfile,
   organizationIds,
+  hasAssociationsWithDomainOrRange,
 }: ResourceViewProps) {
   const { t, i18n } = useTranslation('common');
   const dispatch = useStoreDispatch();
@@ -355,6 +357,7 @@ export default function ResourceView({
         }
         disableEdit={version ? true : false}
         organizationIds={organizationIds}
+        hasAssociationsWithDomainOrRange={hasAssociationsWithDomainOrRange}
       />
     );
   }
@@ -373,6 +376,7 @@ export default function ResourceView({
         currentModelId={modelId}
         isEdit={view.edit}
         handleReturn={view.edit ? handleFormReturn : handleReturn}
+        hasAssociationsWithDomainOrRange={hasAssociationsWithDomainOrRange}
       />
     );
   }

--- a/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/components/range-and-domain.tsx
@@ -18,11 +18,13 @@ export default function RangeAndDomain({
   data,
   modelId,
   handleUpdate,
+  modelUsesDomainRange,
 }: {
   applicationProfile?: boolean;
   data: ResourceFormType;
   modelId: string;
   handleUpdate: (value: ResourceFormType) => void;
+  modelUsesDomainRange?: boolean;
 }) {
   const { t } = useTranslation('admin');
   const { data: dataTypesResult, isSuccess: isDataTypesSuccess } =
@@ -96,7 +98,7 @@ export default function RangeAndDomain({
     });
   };
 
-  if (applicationProfile && data.type === ResourceType.ASSOCIATION) {
+  if (data.type === ResourceType.ASSOCIATION && !modelUsesDomainRange) {
     return <></>;
   }
 

--- a/datamodel-ui/src/modules/resource/resource-form/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-form/index.tsx
@@ -75,6 +75,7 @@ interface ResourceFormProps {
   applicationProfile?: boolean;
   handleReturn: () => void;
   handleFollowUp?: (identifier: string, type: ResourceType) => void;
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ResourceForm({
@@ -86,6 +87,7 @@ export default function ResourceForm({
   applicationProfile,
   handleReturn,
   handleFollowUp,
+  hasAssociationsWithDomainOrRange,
 }: ResourceFormProps) {
   const { t } = useTranslation('admin');
   const { enableConfirmation, disableConfirmation } =
@@ -555,6 +557,7 @@ export default function ResourceForm({
             modelId={modelId}
             data={data}
             handleUpdate={handleUpdate}
+            modelUsesDomainRange={hasAssociationsWithDomainOrRange}
           />
 
           {!applicationProfile && (

--- a/datamodel-ui/src/modules/resource/resource-info/index.tsx
+++ b/datamodel-ui/src/modules/resource/resource-info/index.tsx
@@ -50,6 +50,7 @@ interface CommonViewProps {
   currentModelId?: string;
   disableEdit?: boolean;
   organizationIds?: string[];
+  hasAssociationsWithDomainOrRange?: boolean;
 }
 
 export default function ResourceInfo({
@@ -65,6 +66,7 @@ export default function ResourceInfo({
   currentModelId,
   disableEdit,
   organizationIds,
+  hasAssociationsWithDomainOrRange,
 }: CommonViewProps) {
   const { t, i18n } = useTranslation('common');
   const displayLang = useSelector(selectDisplayLang());
@@ -286,6 +288,7 @@ export default function ResourceInfo({
               data={data}
               inUse={inUse}
               organizationIds={organizationIds}
+              modelUsesDomainRange={hasAssociationsWithDomainOrRange}
             />
           </>
         )}


### PR DESCRIPTION
This PR utilizes the newly added flag on backend to only render domain/range association options if the model already uses them.