### PR TITLE
YTI-4388 - Add placeholder text for empty collection

### DIFF
--- a/terminology-ui/public/locales/en/collection.json
+++ b/terminology-ui/public/locales/en/collection.json
@@ -24,6 +24,7 @@
   "field-definition": "Definition",
   "field-identifier": "Identifier",
   "field-member": "Concepts in the collection",
+  "no-collection-members": "No concepts have been added to the collection",
   "field-name": "Name",
   "heading": "Collection",
   "last-modified": "Last modified",

--- a/terminology-ui/public/locales/fi/collection.json
+++ b/terminology-ui/public/locales/fi/collection.json
@@ -24,6 +24,7 @@
   "field-definition": "Kuvaus",
   "field-identifier": "Tunnus",
   "field-member": "Valikoimaan kuuluvat käsitteet",
+  "no-collection-members": "Käsitekokoelmaan ei ole lisätty käsitteitä",
   "field-name": "Nimi",
   "heading": "Käsitekokoelma",
   "last-modified": "Viimeksi muokattu",

--- a/terminology-ui/public/locales/sv/collection.json
+++ b/terminology-ui/public/locales/sv/collection.json
@@ -24,6 +24,7 @@
   "field-definition": "Definition",
   "field-identifier": "Identifierare",
   "field-member": "Begrepp, som hör till urvalet",
+  "no-collection-members": "Inga begrepp har lagts till i begreppsurvalet",
   "field-name": "Namn",
   "heading": "Begreppsurval",
   "last-modified": "Redigerad",

--- a/terminology-ui/src/modules/collection/index.tsx
+++ b/terminology-ui/src/modules/collection/index.tsx
@@ -193,24 +193,32 @@ export default function Collection({
           )}
 
           <BasicBlock title={<h2>{t('field-member')}</h2>}>
-            <List>
-              {collection?.members?.map((concept) => (
-                <li key={concept.identifier}>
-                  <Link
-                    href={`/terminology/${terminology?.prefix}/concept/${concept.identifier}`}
-                    passHref
-                    legacyBehavior
-                  >
-                    <SuomiLink href="">
-                      {getLanguageVersion({
-                        data: concept.label,
-                        lang: i18n.language,
-                      })}
-                    </SuomiLink>
-                  </Link>
-                </li>
-              ))}
-            </List>
+            {!!collection && collection?.members?.length > 0 ? (
+              <List>
+                {collection?.members?.map((concept) => (
+                  <li key={concept.identifier}>
+                    <Link
+                      href={`/terminology/${terminology?.prefix}/concept/${concept.identifier}`}
+                      passHref
+                      legacyBehavior
+                    >
+                      <SuomiLink href="">
+                        {getLanguageVersion({
+                          data: concept.label,
+                          lang: i18n.language,
+                        })}
+                      </SuomiLink>
+                    </Link>
+                  </li>
+                ))}
+              </List>
+            ) : (
+              <Paragraph>
+                <Text smallScreen>
+                  <i>{t('no-collection-members')}</i>
+                </Text>
+              </Paragraph>
+            )}
           </BasicBlock>
 
           <Separator />


### PR DESCRIPTION
This PR adds a placeholder text when a collection has no added terms. This prevents a situation where there's a redundant heading with no content in the section.