### PR TITLE
add support for additional matomo trackers

### DIFF
--- a/common-ui/components/common-context-provider/index.tsx
+++ b/common-ui/components/common-context-provider/index.tsx
@@ -6,7 +6,7 @@ import { User } from '../../interfaces/user.interface';
 export interface CommonContextState {
   isSSRMobile: boolean;
   isMatomoEnabled: boolean;
-  matomoUrl: string | null;
+  matomoUrl: string | string[] | null;
   matomoSiteId: string | null;
   user: User | null;
   fakeableUsers: FakeableUser[] | null;

--- a/common-ui/components/matomo/index.tsx
+++ b/common-ui/components/matomo/index.tsx
@@ -24,7 +24,7 @@ function matomo(...args: string[]): void {
 }
 
 export interface MatomoProps {
-  url: string;
+  url: string | string[];
   siteId: string;
 }
 
@@ -33,12 +33,22 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
   const [previousPath, setPreviousPath] = useState(router.asPath.split('?')[0]);
 
   useEffect(() => {
+    const mainUrl = (Array.isArray(url)) ? url[0] : url;
+    const additionalUrls = (Array.isArray(url) && url.length > 1) ? url.slice(1) : [];
+
     matomo('disableCookies');
     matomo('trackPageView');
     matomo('enableLinkTracking');
-    matomo('setTrackerUrl', `${url}/matomo.php`);
+    matomo('setTrackerUrl', `${mainUrl}/matomo.php`);
     matomo('setSiteId', siteId);
     matomo('enableJSErrorTracking');
+
+    // also send to these servers
+    // https://developer.matomo.org/guides/tracking-javascript-guide#multiple-matomo-trackers
+    additionalUrls.forEach((additionalUrl) => {
+      matomo('addTracker', `${additionalUrl}/matomo.php`, siteId);
+    });
+
   }, [siteId, url]);
 
   useEffect(() => {
@@ -75,7 +85,7 @@ export function MatomoTracking({ url, siteId }: MatomoProps) {
       router.events.off('routeChangeComplete', onRouteChangeComplete);
   }, [router.events, previousPath]);
 
-  return <Script src={`${url}/matomo.js`} />;
+  return <Script src={`${(Array.isArray(url)) ? url[0] : url}/matomo.js`} />;
 }
 
 const WithEnv = () => {

--- a/datamodel-ui/src/common/utils/create-getserversideprops.ts
+++ b/datamodel-ui/src/common/utils/create-getserversideprops.ts
@@ -127,7 +127,13 @@ export function createCommonGetServerSideProps<
             )
           ),
           isMatomoEnabled: process.env.MATOMO_ENABLED === 'true',
-          matomoUrl: process.env.MATOMO_URL ?? null,
+          matomoUrl:
+            process.env.MATOMO_URL === undefined ||
+            process.env.MATOMO_URL === ''
+              ? null
+              : process.env.MATOMO_URL.split(' ').length > 1
+              ? process.env.MATOMO_URL.split(' ')
+              : process.env.MATOMO_URL,
           matomoSiteId: process.env.MATOMO_SITE_ID ?? null,
           user: user ?? null,
           fakeableUsers:

--- a/terminology-ui/src/common/utils/create-getserversideprops.ts
+++ b/terminology-ui/src/common/utils/create-getserversideprops.ts
@@ -123,7 +123,13 @@ export function createCommonGetServerSideProps<
             )
           ),
           isMatomoEnabled: process.env.MATOMO_ENABLED === 'true',
-          matomoUrl: process.env.MATOMO_URL ?? null,
+          matomoUrl:
+            process.env.MATOMO_URL === undefined ||
+            process.env.MATOMO_URL === ''
+              ? null
+              : process.env.MATOMO_URL.split(' ').length > 1
+              ? process.env.MATOMO_URL.split(' ')
+              : process.env.MATOMO_URL,
           matomoSiteId: process.env.MATOMO_SITE_ID ?? null,
           user: user ?? null,
           fakeableUsers:


### PR DESCRIPTION
During migration to new matomo host, this will allow sending data to two matomo hosts simultaneously.