### PR TITLE
YTI-3699 - Search filter selects out of sync with url state

### DIFF
--- a/common-ui/components/filter/language-filter.tsx
+++ b/common-ui/components/filter/language-filter.tsx
@@ -24,12 +24,13 @@ export default function LanguageFilter({
         labelText={labelText}
         visualPlaceholder={t('choose-language')}
         itemAdditionHelpText={''}
-        defaultSelectedItem={languages.find(
-          (lang) => lang.uniqueItemId === urlState.lang
-        )}
-        onItemSelect={(lang) =>
+        selectedItem={
+          languages.find((lang) => lang.uniqueItemId === urlState.lang) ??
+          undefined
+        }
+        onItemSelectionChange={(selectedItem) =>
           patchUrlState({
-            lang: lang ? lang : '',
+            lang: selectedItem?.uniqueItemId ?? undefined,
             page: initialUrlState.page,
           })
         }

--- a/common-ui/components/filter/organization-filter.tsx
+++ b/common-ui/components/filter/organization-filter.tsx
@@ -34,13 +34,18 @@ export default function OrganizationFilter({
         ariaOptionsAvailableText={
           'terminology-search-filter-organizations-available'
         }
-        onItemSelect={(uniqueItemId) =>
+        itemAdditionHelpText=""
+        selectedItem={
+          organizations.find(
+            (org) => org.uniqueItemId === urlState.organization
+          ) ?? undefined
+        }
+        onItemSelectionChange={(selectedItem) =>
           patchUrlState({
-            organization: uniqueItemId ?? undefined,
+            organization: selectedItem?.uniqueItemId ?? undefined,
             page: initialUrlState.page,
           })
         }
-        itemAdditionHelpText=""
         id="filter-organization-selector"
       />
     </DropdownWrapper>


### PR DESCRIPTION
This PR fixes an issue where the main search filter select components, namely organization and language, did not reflect the correct state after a filter was cleared using the chips on the top of the search results. 

Changes:
- Made main search filter selects controlled, always reflecting the url state