### PR TITLE
handle non-200 response in getModelAsFile

### DIFF
--- a/datamodel-ui/src/pages/api/getModelAsFile.ts
+++ b/datamodel-ui/src/pages/api/getModelAsFile.ts
@@ -84,10 +84,13 @@ export default async function getModelAsFile(
       headers: headers,
       responseType: 'stream',
       decompress: false,
+      validateStatus: () => true,
     }
   );
 
-  if (isRaw === 'true') {
+  if (status !== 200) {
+    // do nothing for 404 or errors, just pass through
+  } else if (isRaw === 'true') {
     res.setHeader('Content-Type', 'text/plain; charset=UTF-8');
   } else {
     res.setHeader('Content-Type', mimeType);
@@ -96,6 +99,7 @@ export default async function getModelAsFile(
       `attachment; filename="${encodeURIComponent(filename)}"`
     );
   }
+
   res.status(status);
   response.pipe(res);
 }


### PR DESCRIPTION
the API may return 404 if the user has no access to a draft version of a model, and in that case we should forward the 404 to the browser as well instead of throwing a more dramatic error.